### PR TITLE
Format code during build itself + fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 target/
 *.iml
+*DS_Store
+TestFile

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <immutables.value.version>2.9.2</immutables.value.version>
     <httpclient.version>4.5.14</httpclient.version>
     <commons-io.version>2.13.0</commons-io.version>
-    <databricks-sdk.version>0.7.0</databricks-sdk.version>
+    <databricks-sdk.version>0.8.0</databricks-sdk.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
   </properties>
   <dependencies>
@@ -51,6 +51,11 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
       <version>${arrow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.diffplug.spotless</groupId>
+      <artifactId>spotless-maven-plugin</artifactId>
+      <version>2.39.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -132,7 +137,10 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
           <configuration>
-            <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+            <argLine>
+              --add-opens=java.base/java.nio=ALL-UNNAMED
+              -Dnet.bytebuddy.experimental=true
+            </argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -159,6 +167,29 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.39.0</version>
+          <executions>
+            <execution>
+              <id>format</id>
+              <goals>
+                <goal>apply</goal>
+              </goals>
+              <phase>compile</phase>
+            </execution>
+          </executions>
+          <configuration>
+            <sourceDirectory>src/</sourceDirectory>
+            <targetDirectory>src/</targetDirectory>
+            <java>
+              <googleJavaFormat>
+                <version>1.18.1</version>
+              </googleJavaFormat>
+            </java>
+          </configuration>
         </plugin>
       </plugins>
     </build>

--- a/src/main/java/com/databricks/jdbc/client/DatabricksClient.java
+++ b/src/main/java/com/databricks/jdbc/client/DatabricksClient.java
@@ -6,18 +6,16 @@ import com.databricks.jdbc.core.IDatabricksStatement;
 import com.databricks.jdbc.core.ImmutableSessionInfo;
 import com.databricks.jdbc.core.ImmutableSqlParameter;
 import com.databricks.sdk.service.sql.ExternalLink;
-
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
 
-/**
- * Interface for Databricks client which abstracts the integration with Databricks server.
- */
+/** Interface for Databricks client which abstracts the integration with Databricks server. */
 public interface DatabricksClient {
 
   /**
    * Creates a new session for given warehouse-Id.
+   *
    * @param warehouseId for which a session should be created
    * @return created session
    */
@@ -25,6 +23,7 @@ public interface DatabricksClient {
 
   /**
    * Deletes a session for given session-Id
+   *
    * @param sessionId for which the session should be deleted
    * @param warehouseId underlying warehouse-Id
    */
@@ -32,6 +31,7 @@ public interface DatabricksClient {
 
   /**
    * Executes a statement in Databricks server
+   *
    * @param statement SQL statement that needs to be executed
    * @param warehouseId warehouse-Id which should be used for statement execution
    * @param parameters SQL parameters for the statement
@@ -41,12 +41,17 @@ public interface DatabricksClient {
    * @return response for statement execution
    */
   DatabricksResultSet executeStatement(
-      String sql, String warehouseId, Map<Integer, ImmutableSqlParameter> parameters,
-      StatementType statementType, IDatabricksSession session, IDatabricksStatement parentStatement)
+      String sql,
+      String warehouseId,
+      Map<Integer, ImmutableSqlParameter> parameters,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatement parentStatement)
       throws SQLException;
 
   /**
    * Closes a statement in Databricks server
+   *
    * @param statementId statement which should be closed
    * @return response for statement execution
    */
@@ -54,6 +59,7 @@ public interface DatabricksClient {
 
   /**
    * Fetches the chunk details for given chunk index and statement-Id.
+   *
    * @param statementId statement-Id for which chunk should be fetched
    * @param chunkIndex chunkIndex for which chunk should be fetched
    */

--- a/src/main/java/com/databricks/jdbc/client/DatabricksHttpException.java
+++ b/src/main/java/com/databricks/jdbc/client/DatabricksHttpException.java
@@ -1,8 +1,6 @@
 package com.databricks.jdbc.client;
 
-/**
- * Exception class to handle http errors while downloading chunk data from external links.
- */
+/** Exception class to handle http errors while downloading chunk data from external links. */
 public class DatabricksHttpException extends Exception {
 
   private final Throwable cause;

--- a/src/main/java/com/databricks/jdbc/client/IDatabricksHttpClient.java
+++ b/src/main/java/com/databricks/jdbc/client/IDatabricksHttpClient.java
@@ -1,17 +1,13 @@
 package com.databricks.jdbc.client;
 
-import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
-/**
- * Http client interface for executing http requests.
- */
+/** Http client interface for executing http requests. */
 public interface IDatabricksHttpClient {
 
   /**
-   * Executes the given http request and returns the response
-   * TODO: add error handling
+   * Executes the given http request and returns the response TODO: add error handling
    *
    * @param request underlying http request
    * @return http response

--- a/src/main/java/com/databricks/jdbc/client/http/DatabricksHttpClient.java
+++ b/src/main/java/com/databricks/jdbc/client/http/DatabricksHttpClient.java
@@ -2,10 +2,13 @@ package com.databricks.jdbc.client.http;
 
 import com.databricks.jdbc.client.DatabricksHttpException;
 import com.databricks.jdbc.client.IDatabricksHttpClient;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
-import org.apache.http.client.BackoffManager;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -16,14 +19,7 @@ import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
-/**
- * Http client implementation to be used for executing http requests.
- */
+/** Http client implementation to be used for executing http requests. */
 public class DatabricksHttpClient implements IDatabricksHttpClient {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksHttpClient.class);
@@ -69,6 +65,7 @@ public class DatabricksHttpClient implements IDatabricksHttpClient {
     retryableCodes.add(502); // bad gateway (should this be retried?)
     retryableCodes.add(503); // service unavailable
     retryableCodes.add(504); // gateway timeout
+    return retryableCodes;
   }
 
   private CloseableHttpClient makeClosableHttpClient() {
@@ -77,29 +74,35 @@ public class DatabricksHttpClient implements IDatabricksHttpClient {
         // TODO: set appropriate user agent
         .setUserAgent("jdbc/databricks")
         .setDefaultRequestConfig(makeRequestConfig())
-        .setRetryHandler((exception, executionCount, context) -> {
-          if (executionCount > DEFAULT_RETRY_COUNT
-              || !isRetryAllowed(((HttpClientContext) context).getRequest().getRequestLine().getMethod())) {
-            return false;
-          }
-          long nextBackOffDelay = MIN_BACKOFF_INTERVAL * (long) Math.pow(DEFAULT_BACKOFF_FACTOR, executionCount - 1);
-          long delay = Math.min(MAX_RETRY_INTERVAL, nextBackOffDelay);
-          try {
-            Thread.sleep(delay);
-          } catch (InterruptedException e) {
-            // Do nothing
-          }
-          return true;
-        })
-        .addInterceptorFirst(new HttpResponseInterceptor() {
-          // Handling 500 and 503 explicitly for retry
-          @Override
-          public void process(HttpResponse httpResponse, HttpContext httpContext) throws HttpException, IOException {
-            if (isErrorCodeRetryable(httpResponse.getStatusLine().getStatusCode())) {
-              throw new IOException("Retry http request");
-            }
-          }
-        })
+        .setRetryHandler(
+            (exception, executionCount, context) -> {
+              if (executionCount > DEFAULT_RETRY_COUNT
+                  || !isRetryAllowed(
+                      ((HttpClientContext) context).getRequest().getRequestLine().getMethod())) {
+                return false;
+              }
+              long nextBackOffDelay =
+                  MIN_BACKOFF_INTERVAL
+                      * (long) Math.pow(DEFAULT_BACKOFF_FACTOR, executionCount - 1);
+              long delay = Math.min(MAX_RETRY_INTERVAL, nextBackOffDelay);
+              try {
+                Thread.sleep(delay);
+              } catch (InterruptedException e) {
+                // Do nothing
+              }
+              return true;
+            })
+        .addInterceptorFirst(
+            new HttpResponseInterceptor() {
+              // Handling 500 and 503 explicitly for retry
+              @Override
+              public void process(HttpResponse httpResponse, HttpContext httpContext)
+                  throws HttpException, IOException {
+                if (isErrorCodeRetryable(httpResponse.getStatusLine().getStatusCode())) {
+                  throw new IOException("Retry http request");
+                }
+              }
+            })
         .build();
   }
 
@@ -123,8 +126,10 @@ public class DatabricksHttpClient implements IDatabricksHttpClient {
     try {
       return httpClient.execute(request);
     } catch (IOException e) {
-      String errorMsg = String.format("Caught error while executing http request: [%s]",
-          RequestSanitizer.sanitizeRequest(request));
+      String errorMsg =
+          String.format(
+              "Caught error while executing http request: [%s]",
+              RequestSanitizer.sanitizeRequest(request));
       LOGGER.atError().setCause(e).log(errorMsg);
       throw new DatabricksHttpException(errorMsg, e);
     }

--- a/src/main/java/com/databricks/jdbc/client/impl/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/DatabricksSdkClient.java
@@ -2,11 +2,11 @@ package com.databricks.jdbc.client.impl;
 
 import com.databricks.jdbc.client.DatabricksClient;
 import com.databricks.jdbc.client.StatementType;
+import com.databricks.jdbc.client.sqlexec.*;
 import com.databricks.jdbc.client.sqlexec.CloseStatementRequest;
 import com.databricks.jdbc.client.sqlexec.CreateSessionRequest;
 import com.databricks.jdbc.client.sqlexec.DeleteSessionRequest;
 import com.databricks.jdbc.client.sqlexec.Session;
-import com.databricks.jdbc.client.sqlexec.*;
 import com.databricks.jdbc.core.DatabricksResultSet;
 import com.databricks.jdbc.core.DatabricksSQLException;
 import com.databricks.jdbc.core.IDatabricksSession;
@@ -18,19 +18,16 @@ import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.service.sql.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Implementation of DatabricksClient interface using Databricks Java SDK.
- */
+/** Implementation of DatabricksClient interface using Databricks Java SDK. */
 public class DatabricksSdkClient implements DatabricksClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksSdkClient.class);
   private static final String ASYNC_TIMEOUT_VALUE = "0s";
@@ -44,35 +41,40 @@ public class DatabricksSdkClient implements DatabricksClient {
   public DatabricksSdkClient(IDatabricksConnectionContext connectionContext) {
     this.connectionContext = connectionContext;
     // Handle more auth types
-    this.databricksConfig = new DatabricksConfig()
-        .setHost(connectionContext.getHostUrl())
-        .setToken(connectionContext.getToken());
+    this.databricksConfig =
+        new DatabricksConfig()
+            .setHost(connectionContext.getHostUrl())
+            .setToken(connectionContext.getToken());
 
     this.workspaceClient = new WorkspaceClient(databricksConfig);
   }
 
-  public DatabricksSdkClient(IDatabricksConnectionContext connectionContext,
-                             StatementExecutionService statementExecutionService, ApiClient apiClient) {
+  public DatabricksSdkClient(
+      IDatabricksConnectionContext connectionContext,
+      StatementExecutionService statementExecutionService,
+      ApiClient apiClient) {
     this.connectionContext = connectionContext;
     // Handle more auth types
-    this.databricksConfig = new DatabricksConfig()
-        .setHost(connectionContext.getHostUrl())
-        .setToken(connectionContext.getToken());
+    this.databricksConfig =
+        new DatabricksConfig()
+            .setHost(connectionContext.getHostUrl())
+            .setToken(connectionContext.getToken());
 
-    this.workspaceClient = new WorkspaceClient(true /* mock */, apiClient)
-        .withStatementExecutionImpl(statementExecutionService);
+    this.workspaceClient =
+        new WorkspaceClient(true /* mock */, apiClient)
+            .withStatementExecutionImpl(statementExecutionService);
   }
 
   @Override
   public ImmutableSessionInfo createSession(String warehouseId) {
     LOGGER.debug("public Session createSession(String warehouseId = {})", warehouseId);
-    CreateSessionRequest request = new CreateSessionRequest()
-        .setWarehouseId(warehouseId);
+    CreateSessionRequest request = new CreateSessionRequest().setWarehouseId(warehouseId);
     String path = "/api/2.0/sql/statements/sessions";
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    Session session = (Session) workspaceClient.apiClient().POST(path, request, Session.class, headers);
+    Session session =
+        (Session) workspaceClient.apiClient().POST(path, request, Session.class, headers);
     return ImmutableSessionInfo.builder()
         .warehouseId(session.getWarehouseId())
         .sessionId(session.getSessionId())
@@ -82,7 +84,8 @@ public class DatabricksSdkClient implements DatabricksClient {
   @Override
   public void deleteSession(String sessionId, String warehouseId) {
     LOGGER.debug("public void deleteSession(String sessionId = {})", sessionId);
-    DeleteSessionRequest request = new DeleteSessionRequest().setSessionId(sessionId).setWarehouseId(warehouseId);
+    DeleteSessionRequest request =
+        new DeleteSessionRequest().setSessionId(sessionId).setWarehouseId(warehouseId);
     String path = String.format("/api/2.0/sql/statements/sessions/%s", request.getSessionId());
     Map<String, String> headers = new HashMap<>();
     workspaceClient.apiClient().DELETE(path, request, Void.class, headers);
@@ -90,30 +93,45 @@ public class DatabricksSdkClient implements DatabricksClient {
 
   @Override
   public DatabricksResultSet executeStatement(
-      String sql, String warehouseId, Map<Integer, ImmutableSqlParameter> parameters,
-      StatementType statementType, IDatabricksSession session, IDatabricksStatement parentStatement) throws SQLException {
-    LOGGER.debug("public DatabricksResultSet executeStatement(String sql = {}, String warehouseId = {}, Map<Integer, ImmutableSqlParameter> parameters, StatementType statementType = {}, IDatabricksSession session)", sql, warehouseId, statementType);
+      String sql,
+      String warehouseId,
+      Map<Integer, ImmutableSqlParameter> parameters,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatement parentStatement)
+      throws SQLException {
+    LOGGER.debug(
+        "public DatabricksResultSet executeStatement(String sql = {}, String warehouseId = {}, Map<Integer, ImmutableSqlParameter> parameters, StatementType statementType = {}, IDatabricksSession session)",
+        sql,
+        warehouseId,
+        statementType);
     Format format = useCloudFetchForResult(statementType) ? Format.ARROW_STREAM : Format.JSON_ARRAY;
-    Disposition disposition = useCloudFetchForResult(statementType) ? Disposition.EXTERNAL_LINKS : Disposition.INLINE;
+    Disposition disposition =
+        useCloudFetchForResult(statementType) ? Disposition.EXTERNAL_LINKS : Disposition.INLINE;
     ExecuteStatementRequestWithSession request =
-        (ExecuteStatementRequestWithSession) new ExecuteStatementRequestWithSession()
-            .setSessionId(session.getSessionId())
-            .setStatement(sql)
-            .setWarehouseId(warehouseId)
-            .setDisposition(disposition)
-            .setFormat(format)
-            .setWaitTimeout(SYNC_TIMEOUT_VALUE)
-            .setOnWaitTimeout(TimeoutAction.CONTINUE)
-            .setParameters(parameters.values().stream().map(
-                param -> new PositionalStatementParameterListItem()
-                    .setOrdinal(param.cardinal())
-                    .setType(param.type())
-                    .setValue(param.value().toString()))
-                .collect(Collectors.toList()));
+        (ExecuteStatementRequestWithSession)
+            new ExecuteStatementRequestWithSession()
+                .setSessionId(session.getSessionId())
+                .setStatement(sql)
+                .setWarehouseId(warehouseId)
+                .setDisposition(disposition)
+                .setFormat(format)
+                .setWaitTimeout(SYNC_TIMEOUT_VALUE)
+                .setOnWaitTimeout(TimeoutAction.CONTINUE)
+                .setParameters(
+                    parameters.values().stream()
+                        .map(
+                            param ->
+                                new PositionalStatementParameterListItem()
+                                    .setOrdinal(param.cardinal())
+                                    .setType(param.type())
+                                    .setValue(param.value().toString()))
+                        .collect(Collectors.toList()));
 
     long pollCount = 0;
     long executionStartTime = Instant.now().toEpochMilli();
-    ExecuteStatementResponse response = workspaceClient.statementExecution().executeStatement(request);
+    ExecuteStatementResponse response =
+        workspaceClient.statementExecution().executeStatement(request);
     String statementId = response.getStatementId();
     StatementState responseState = response.getStatus().getState();
 
@@ -129,18 +147,26 @@ public class DatabricksSdkClient implements DatabricksClient {
           throw new DatabricksSQLException("Statement execution fetch interrupted");
         }
       }
-      response = wrapGetStatementResponse(workspaceClient.statementExecution().getStatement(statementId));
+      response =
+          wrapGetStatementResponse(workspaceClient.statementExecution().getStatement(statementId));
       responseState = response.getStatus().getState();
       pollCount++;
     }
     long executionEndTime = Instant.now().toEpochMilli();
-    LOGGER.atDebug().log("Executed sql [%s] with status [%s], total time taken [%d] and pollCount [%d]",
+    LOGGER.atDebug().log(
+        "Executed sql [%s] with status [%s], total time taken [%d] and pollCount [%d]",
         sql, responseState, (executionEndTime - executionStartTime), pollCount);
     if (responseState != StatementState.SUCCEEDED) {
       handleFailedExecution(responseState, statementId, sql);
     }
-    return new DatabricksResultSet(response.getStatus(), statementId, response.getResult(),
-          response.getManifest(), statementType, session, parentStatement);
+    return new DatabricksResultSet(
+        response.getStatus(),
+        statementId,
+        response.getResult(),
+        response.getManifest(),
+        statementType,
+        session,
+        parentStatement);
   }
 
   private boolean useCloudFetchForResult(StatementType statementType) {
@@ -158,28 +184,40 @@ public class DatabricksSdkClient implements DatabricksClient {
 
   @Override
   public Collection<ExternalLink> getResultChunks(String statementId, long chunkIndex) {
-    LOGGER.debug("public Optional<ExternalLink> getResultChunk(String statementId = {}, long chunkIndex = {})", statementId, chunkIndex);
-    return workspaceClient.statementExecution().getStatementResultChunkN(statementId, chunkIndex).getExternalLinks();
+    LOGGER.debug(
+        "public Optional<ExternalLink> getResultChunk(String statementId = {}, long chunkIndex = {})",
+        statementId,
+        chunkIndex);
+    return workspaceClient
+        .statementExecution()
+        .getStatementResultChunkN(statementId, chunkIndex)
+        .getExternalLinks();
   }
 
-  /**
-   * Handles a failed execution and throws appropriate exception
-   */
-  private void handleFailedExecution(StatementState statementState, String statementId, String statement) throws SQLException {
-    LOGGER.debug("private void handleFailedExecution(StatementState statementState = {}, String statementId = {}, String statement = {})", statementState, statementId, statement);
+  /** Handles a failed execution and throws appropriate exception */
+  private void handleFailedExecution(
+      StatementState statementState, String statementId, String statement) throws SQLException {
+    LOGGER.debug(
+        "private void handleFailedExecution(StatementState statementState = {}, String statementId = {}, String statement = {})",
+        statementState,
+        statementId,
+        statement);
     switch (statementState) {
       case FAILED:
       case CLOSED:
       case CANCELED:
         // TODO: Handle differently for failed, closed and cancelled with proper error codes
-        throw new DatabricksSQLException("Statement execution failed " + statementId + " -> " + statement);
+        throw new DatabricksSQLException(
+            "Statement execution failed " + statementId + " -> " + statement);
       default:
         throw new IllegalStateException("Invalid state for error");
     }
   }
 
-  private ExecuteStatementResponse wrapGetStatementResponse(GetStatementResponse getStatementResponse) {
-    return new ExecuteStatementResponse().setStatementId(getStatementResponse.getStatementId())
+  private ExecuteStatementResponse wrapGetStatementResponse(
+      GetStatementResponse getStatementResponse) {
+    return new ExecuteStatementResponse()
+        .setStatementId(getStatementResponse.getStatementId())
         .setStatus(getStatementResponse.getStatus())
         .setManifest(getStatementResponse.getManifest())
         .setResult(getStatementResponse.getResult());

--- a/src/main/java/com/databricks/jdbc/client/sqlexec/CloseStatementRequest.java
+++ b/src/main/java/com/databricks/jdbc/client/sqlexec/CloseStatementRequest.java
@@ -1,14 +1,12 @@
 package com.databricks.jdbc.client.sqlexec;
 
 import com.databricks.sdk.support.ToStringer;
-
 import java.util.Objects;
 
 public class CloseStatementRequest {
   private String statementId;
 
-  public CloseStatementRequest() {
-  }
+  public CloseStatementRequest() {}
 
   public CloseStatementRequest setStatementId(String statementId) {
     this.statementId = statementId;
@@ -23,7 +21,7 @@ public class CloseStatementRequest {
     if (this == o) {
       return true;
     } else if (o != null && this.getClass() == o.getClass()) {
-      CloseStatementRequest that = (CloseStatementRequest)o;
+      CloseStatementRequest that = (CloseStatementRequest) o;
       return Objects.equals(this.statementId, that.statementId);
     } else {
       return false;
@@ -31,10 +29,12 @@ public class CloseStatementRequest {
   }
 
   public int hashCode() {
-    return Objects.hash(new Object[]{this.statementId});
+    return Objects.hash(new Object[] {this.statementId});
   }
 
   public String toString() {
-    return (new ToStringer(CloseStatementRequest.class)).add("statementId", this.statementId).toString();
+    return (new ToStringer(CloseStatementRequest.class))
+        .add("statementId", this.statementId)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/client/sqlexec/CreateSessionRequest.java
+++ b/src/main/java/com/databricks/jdbc/client/sqlexec/CreateSessionRequest.java
@@ -35,8 +35,6 @@ public class CreateSessionRequest {
 
   @Override
   public String toString() {
-    return new ToStringer(CreateSessionRequest.class)
-        .add("warehouseId", warehouseId)
-        .toString();
+    return new ToStringer(CreateSessionRequest.class).add("warehouseId", warehouseId).toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/client/sqlexec/DeleteSessionRequest.java
+++ b/src/main/java/com/databricks/jdbc/client/sqlexec/DeleteSessionRequest.java
@@ -2,18 +2,17 @@ package com.databricks.jdbc.client.sqlexec;
 
 import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class DeleteSessionRequest {
 
   @JsonProperty("session_id")
   private String sessionId;
+
   @JsonProperty("warehouse_id")
   private String warehouseId;
 
-  public DeleteSessionRequest() {
-  }
+  public DeleteSessionRequest() {}
 
   public DeleteSessionRequest setSessionId(String sessionId) {
     this.sessionId = sessionId;
@@ -37,7 +36,7 @@ public class DeleteSessionRequest {
     if (this == o) {
       return true;
     } else if (o != null && this.getClass() == o.getClass()) {
-      DeleteSessionRequest that = (DeleteSessionRequest)o;
+      DeleteSessionRequest that = (DeleteSessionRequest) o;
       return Objects.equals(this.sessionId, that.sessionId)
           && Objects.equals(this.warehouseId, that.warehouseId);
     } else {

--- a/src/main/java/com/databricks/jdbc/client/sqlexec/ExecuteStatementRequestWithSession.java
+++ b/src/main/java/com/databricks/jdbc/client/sqlexec/ExecuteStatementRequestWithSession.java
@@ -3,7 +3,6 @@ package com.databricks.jdbc.client.sqlexec;
 import com.databricks.sdk.service.sql.ExecuteStatementRequest;
 import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class ExecuteStatementRequestWithSession extends ExecuteStatementRequest {
@@ -23,16 +22,15 @@ public class ExecuteStatementRequestWithSession extends ExecuteStatementRequest 
 
   public boolean equals(Object o) {
     if (o != null && o.getClass() == getClass()) {
-      return super.equals(o) && Objects.equals(this.sessionId, ((ExecuteStatementRequestWithSession) o).sessionId);
+      return super.equals(o)
+          && Objects.equals(this.sessionId, ((ExecuteStatementRequestWithSession) o).sessionId);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        super.hashCode(),
-        sessionId);
+    return Objects.hash(super.hashCode(), sessionId);
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/client/sqlexec/PositionalStatementParameterListItem.java
+++ b/src/main/java/com/databricks/jdbc/client/sqlexec/PositionalStatementParameterListItem.java
@@ -1,10 +1,8 @@
 package com.databricks.jdbc.client.sqlexec;
 
-import com.databricks.sdk.service.sql.ExecuteStatementRequest;
 import com.databricks.sdk.service.sql.StatementParameterListItem;
 import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class PositionalStatementParameterListItem extends StatementParameterListItem {
@@ -24,16 +22,15 @@ public class PositionalStatementParameterListItem extends StatementParameterList
 
   public boolean equals(Object o) {
     if (o != null && o.getClass() == getClass()) {
-      return super.equals(o) && Objects.equals(this.ordinal, ((PositionalStatementParameterListItem) o).ordinal);
+      return super.equals(o)
+          && Objects.equals(this.ordinal, ((PositionalStatementParameterListItem) o).ordinal);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        super.hashCode(),
-        ordinal);
+    return Objects.hash(super.hashCode(), ordinal);
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/core/ArrowStreamResult.java
+++ b/src/main/java/com/databricks/jdbc/core/ArrowStreamResult.java
@@ -1,12 +1,9 @@
 package com.databricks.jdbc.core;
 
 import com.databricks.jdbc.client.IDatabricksHttpClient;
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.arrow.vector.ValueVector;
-import org.apache.arrow.vector.types.Types;
 import com.databricks.sdk.service.sql.*;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,19 +22,32 @@ class ArrowStreamResult implements IExecutionResult {
 
   List<ColumnInfo> columnInfos;
 
-  ArrowStreamResult(ResultManifest resultManifest, ResultData resultData, String statementId,
-                    IDatabricksSession session) {
-    this(resultManifest, new ChunkDownloader(statementId, resultManifest, resultData, session), session);
+  ArrowStreamResult(
+      ResultManifest resultManifest,
+      ResultData resultData,
+      String statementId,
+      IDatabricksSession session) {
+    this(
+        resultManifest,
+        new ChunkDownloader(statementId, resultManifest, resultData, session),
+        session);
   }
 
   @VisibleForTesting
-  ArrowStreamResult(ResultManifest resultManifest, ResultData resultData, String statementId,
-                    IDatabricksSession session, IDatabricksHttpClient httpClient) {
-    this(resultManifest, new ChunkDownloader(statementId, resultManifest, resultData, session, httpClient), session);
+  ArrowStreamResult(
+      ResultManifest resultManifest,
+      ResultData resultData,
+      String statementId,
+      IDatabricksSession session,
+      IDatabricksHttpClient httpClient) {
+    this(
+        resultManifest,
+        new ChunkDownloader(statementId, resultManifest, resultData, session, httpClient),
+        session);
   }
 
-  private ArrowStreamResult(ResultManifest resultManifest, ChunkDownloader chunkDownloader,
-                            IDatabricksSession session) {
+  private ArrowStreamResult(
+      ResultManifest resultManifest, ChunkDownloader chunkDownloader, IDatabricksSession session) {
     this.rowOffsetToChunkMap = getRowOffsetMap(resultManifest);
     this.session = session;
     this.chunkDownloader = chunkDownloader;
@@ -47,7 +57,9 @@ class ArrowStreamResult implements IExecutionResult {
     this.chunkIterator = null;
   }
 
-  public ChunkDownloader getChunkDownloader() {return this.chunkDownloader;}
+  public ChunkDownloader getChunkDownloader() {
+    return this.chunkDownloader;
+  }
 
   private static ImmutableMap<Long, ChunkInfo> getRowOffsetMap(ResultManifest resultManifest) {
     ImmutableMap.Builder<Long, ChunkInfo> rowOffsetMapBuilder = ImmutableMap.builder();
@@ -56,7 +68,7 @@ class ArrowStreamResult implements IExecutionResult {
     }
     return rowOffsetMapBuilder.build();
   }
-  
+
   @Override
   public Object getObject(int columnIndex) throws SQLException {
     // we have two types:
@@ -91,8 +103,9 @@ class ArrowStreamResult implements IExecutionResult {
 
   @Override
   public boolean hasNext() {
-    return !isClosed() && ((chunkIterator != null && chunkIterator.hasNextRow())
-        || chunkDownloader.hasNextChunk());
+    return !isClosed()
+        && ((chunkIterator != null && chunkIterator.hasNextRow())
+            || chunkDownloader.hasNextChunk());
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/core/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/ArrowToJavaObjectConverter.java
@@ -1,107 +1,106 @@
 package com.databricks.jdbc.core;
 
-import org.apache.arrow.vector.types.Types;
 import com.databricks.sdk.service.sql.ColumnInfoTypeName;
-
 import java.math.BigDecimal;
 import java.sql.Date;
-import com.databricks.jdbc.core.DatabricksSQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 
 public class ArrowToJavaObjectConverter {
-    // TODO (Madhav): Check Arrow to JSON conversion
-    public static Object convert(Object object, ColumnInfoTypeName requiredType) throws DatabricksSQLException {
-        switch (requiredType) {
-            case BYTE:
-                return convertToByte(object);
-            case SHORT:
-                return convertToShort(object);
-            case INT:
-                return convertToInteger(object);
-            case LONG:
-                return convertToLong(object);
-            case FLOAT:
-                return convertToFloat(object);
-            case DOUBLE:
-                return convertToDouble(object);
-            case DECIMAL:
-                return convertToBigDecimal(object);
-            case BINARY:
-                return convertToByteArray(object);
-            case BOOLEAN:
-                return convertToBoolean(object);
-            case CHAR:
-                return convertToChar(object);
-            case STRING:
-            // Struct and Array are present in Arrow data in the VARCHAR ValueVector format
-            case STRUCT:
-            case ARRAY:
-                return convertToString(object);
-            case DATE:
-                return convertToDate(object);
-            case TIMESTAMP:
-                return convertToTimestamp(object);
-            case NULL:
-                return null;
-            default:
-                throw new DatabricksSQLException("Unsupported type");
-        }
+  // TODO (Madhav): Check Arrow to JSON conversion
+  public static Object convert(Object object, ColumnInfoTypeName requiredType)
+      throws DatabricksSQLException {
+    switch (requiredType) {
+      case BYTE:
+        return convertToByte(object);
+      case SHORT:
+        return convertToShort(object);
+      case INT:
+        return convertToInteger(object);
+      case LONG:
+        return convertToLong(object);
+      case FLOAT:
+        return convertToFloat(object);
+      case DOUBLE:
+        return convertToDouble(object);
+      case DECIMAL:
+        return convertToBigDecimal(object);
+      case BINARY:
+        return convertToByteArray(object);
+      case BOOLEAN:
+        return convertToBoolean(object);
+      case CHAR:
+        return convertToChar(object);
+      case STRING:
+        // Struct and Array are present in Arrow data in the VARCHAR ValueVector format
+      case STRUCT:
+      case ARRAY:
+        return convertToString(object);
+      case DATE:
+        return convertToDate(object);
+      case TIMESTAMP:
+        return convertToTimestamp(object);
+      case NULL:
+        return null;
+      default:
+        throw new DatabricksSQLException("Unsupported type");
     }
+  }
 
-    private static Object convertToTimestamp(Object object) throws DatabricksSQLException {
+  private static Object convertToTimestamp(Object object) throws DatabricksSQLException {
 
-        Instant instant = Instant.ofEpochMilli(object instanceof Integer ? (int) object : (long) object);
-        return Timestamp.from(instant);
-    }
+    Instant instant =
+        Instant.ofEpochMilli(object instanceof Integer ? (int) object : (long) object);
+    return Timestamp.from(instant);
+  }
 
-    private static Date convertToDate(Object object) throws DatabricksSQLException {
-        LocalDate localDate = LocalDate.ofEpochDay((int) object);
-        return Date.valueOf(localDate);
-    }
+  private static Date convertToDate(Object object) throws DatabricksSQLException {
+    LocalDate localDate = LocalDate.ofEpochDay((int) object);
+    return Date.valueOf(localDate);
+  }
 
-    private static char convertToChar(Object object) throws DatabricksSQLException {
-        return (object.toString()).charAt(0);
-    }
+  private static char convertToChar(Object object) throws DatabricksSQLException {
+    return (object.toString()).charAt(0);
+  }
 
-    private static String convertToString(Object object) throws DatabricksSQLException {
-        return object.toString();
-    }
+  private static String convertToString(Object object) throws DatabricksSQLException {
+    return object.toString();
+  }
 
-    private static boolean convertToBoolean(Object object) throws DatabricksSQLException {
-        return (boolean) object;
-    }
+  private static boolean convertToBoolean(Object object) throws DatabricksSQLException {
+    return (boolean) object;
+  }
 
-    private static byte[] convertToByteArray(Object object) throws DatabricksSQLException {
-        return (byte[]) object;
-    }
+  private static byte[] convertToByteArray(Object object) throws DatabricksSQLException {
+    return (byte[]) object;
+  }
 
-    private static byte convertToByte(Object object) throws DatabricksSQLException {
-        return (byte) object;
-    }
+  private static byte convertToByte(Object object) throws DatabricksSQLException {
+    return (byte) object;
+  }
 
-    private static short convertToShort(Object object) throws DatabricksSQLException {
-        return (short) object;
-    }
+  private static short convertToShort(Object object) throws DatabricksSQLException {
+    return (short) object;
+  }
 
-    private static BigDecimal convertToBigDecimal(Object object) throws DatabricksSQLException {
-        return (BigDecimal) object;
-    }
+  private static BigDecimal convertToBigDecimal(Object object) throws DatabricksSQLException {
+    return (BigDecimal) object;
+  }
 
-    private static double convertToDouble(Object object) throws DatabricksSQLException {
-        return (double) object;
-    }
+  private static double convertToDouble(Object object) throws DatabricksSQLException {
+    return (double) object;
+  }
 
-    private static float convertToFloat(Object object) throws DatabricksSQLException {
-        return (float) object;
-    }
+  private static float convertToFloat(Object object) throws DatabricksSQLException {
+    return (float) object;
+  }
 
-    private static int convertToInteger(Object object) throws DatabricksSQLException {
-        return (int) object;
-    }
+  private static int convertToInteger(Object object) throws DatabricksSQLException {
+    return (int) object;
+  }
 
-    private static long convertToLong(Object object) throws DatabricksSQLException {
-        return (long) object;
-    }
+  private static long convertToLong(Object object) throws DatabricksSQLException {
+    return (long) object;
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/DatabricksColumn.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksColumn.java
@@ -5,23 +5,18 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface DatabricksColumn {
 
-  /**
-   * Name of the column in result set
-   */
+  /** Name of the column in result set */
   String columnName();
 
-  /**
-   * Type of the column in result set
-   */
+  /** Type of the column in result set */
   int columnType();
 
-  /**
-   * Full data type spec, SQL/catalogString text
-   */
+  /** Full data type spec, SQL/catalogString text */
   String columnTypeText();
 
   /**
-   * Precision is the maximum number of significant digits that can be stored in a column. For string, it's 255.
+   * Precision is the maximum number of significant digits that can be stored in a column. For
+   * string, it's 255.
    */
   int typePrecision();
 }

--- a/src/main/java/com/databricks/jdbc/core/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksConnection.java
@@ -3,19 +3,16 @@ package com.databricks.jdbc.core;
 import com.databricks.jdbc.client.DatabricksClient;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.*;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Implementation for Databricks specific connection.
- */
+/** Implementation for Databricks specific connection. */
 public class DatabricksConnection implements IDatabricksConnection, Connection {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksConnection.class);
@@ -24,6 +21,7 @@ public class DatabricksConnection implements IDatabricksConnection, Connection {
 
   /**
    * Creates an instance of Databricks connection for given connection context.
+   *
    * @param connectionContext underlying connection context
    */
   public DatabricksConnection(IDatabricksConnectionContext connectionContext) {
@@ -32,7 +30,8 @@ public class DatabricksConnection implements IDatabricksConnection, Connection {
   }
 
   @VisibleForTesting
-  DatabricksConnection(IDatabricksConnectionContext connectionContext, DatabricksClient databricksClient) {
+  DatabricksConnection(
+      IDatabricksConnectionContext connectionContext, DatabricksClient databricksClient) {
     this.session = new DatabricksSession(connectionContext, databricksClient);
     this.session.open();
   }
@@ -169,20 +168,34 @@ public class DatabricksConnection implements IDatabricksConnection, Connection {
   }
 
   @Override
-  public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
-    LOGGER.debug("public Statement createStatement(int resultSetType = {}, int resultSetConcurrency = {})", resultSetType, resultSetConcurrency);
+  public Statement createStatement(int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    LOGGER.debug(
+        "public Statement createStatement(int resultSetType = {}, int resultSetConcurrency = {})",
+        resultSetType,
+        resultSetConcurrency);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-    LOGGER.debug("public PreparedStatement prepareStatement(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {})", sql, resultSetType, resultSetConcurrency);
+  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    LOGGER.debug(
+        "public PreparedStatement prepareStatement(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {})",
+        sql,
+        resultSetType,
+        resultSetConcurrency);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-    LOGGER.debug("public CallableStatement prepareCall(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {})", sql, resultSetType, resultSetConcurrency);
+  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+      throws SQLException {
+    LOGGER.debug(
+        "public CallableStatement prepareCall(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {})",
+        sql,
+        resultSetType,
+        resultSetConcurrency);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -235,38 +248,66 @@ public class DatabricksConnection implements IDatabricksConnection, Connection {
   }
 
   @Override
-  public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-    LOGGER.debug("public Statement createStatement(int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})", resultSetType, resultSetConcurrency, resultSetHoldability);
+  public Statement createStatement(
+      int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+    LOGGER.debug(
+        "public Statement createStatement(int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})",
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-    LOGGER.debug("public PreparedStatement prepareStatement(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})", sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+  public PreparedStatement prepareStatement(
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    LOGGER.debug(
+        "public PreparedStatement prepareStatement(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})",
+        sql,
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-    LOGGER.debug("public CallableStatement prepareCall(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})", sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+  public CallableStatement prepareCall(
+      String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+      throws SQLException {
+    LOGGER.debug(
+        "public CallableStatement prepareCall(String sql = {}, int resultSetType = {}, int resultSetConcurrency = {}, int resultSetHoldability = {})",
+        sql,
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
-    LOGGER.debug("public PreparedStatement prepareStatement(String sql = {}, int autoGeneratedKeys = {})", sql, autoGeneratedKeys);
+    LOGGER.debug(
+        "public PreparedStatement prepareStatement(String sql = {}, int autoGeneratedKeys = {})",
+        sql,
+        autoGeneratedKeys);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
-    LOGGER.debug("public PreparedStatement prepareStatement(String sql = {}, int[] columnIndexes = {})", sql, columnIndexes);
+    LOGGER.debug(
+        "public PreparedStatement prepareStatement(String sql = {}, int[] columnIndexes = {})",
+        sql,
+        columnIndexes);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
-    LOGGER.debug("public PreparedStatement prepareStatement(String sql = {}, String[] columnNames = {})", sql, columnNames);
+    LOGGER.debug(
+        "public PreparedStatement prepareStatement(String sql = {}, String[] columnNames = {})",
+        sql,
+        columnNames);
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/src/main/java/com/databricks/jdbc/core/DatabricksDatabaseMetaData.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksDatabaseMetaData.java
@@ -5,15 +5,14 @@ import com.databricks.jdbc.driver.DatabricksJdbcConstants;
 import com.databricks.jdbc.util.WildcardUtil;
 import com.databricks.sdk.service.sql.StatementState;
 import com.databricks.sdk.service.sql.StatementStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public static final String DRIVER_NAME = "DatabricksJDBC";
@@ -25,13 +24,16 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public static final int JDBC_MINOR_VERSION = 0;
   public static final int JDBC_PATCH_VERSION = 0;
   public static final Integer MAX_NAME_LENGTH = 128;
-  public static final String NUMERIC_FUNCTIONS = "ABS,ACOS,ASIN,ATAN,ATAN2,CEILING,COS,COT,DEGREES,EXP,FLOOR,LOG,LOG10,MOD,PI,POWER,RADIANS,RAND,ROUND,SIGN,SIN,SQRT,TAN,TRUNCATE";
-  public static final String STRING_FUNCTIONS = "ASCII,CHAR,CHAR_LENGTH,CHARACTER_LENGTH,CONCAT,INSERT,LCASE,LEFT,LENGTH,LOCATE,LOCATE2,LTRIM,OCTET_LENGTH,POSITION,REPEAT,REPLACE,RIGHT,RTRIM,SOUNDEX,SPACE,SUBSTRING,UCASE";
+  public static final String NUMERIC_FUNCTIONS =
+      "ABS,ACOS,ASIN,ATAN,ATAN2,CEILING,COS,COT,DEGREES,EXP,FLOOR,LOG,LOG10,MOD,PI,POWER,RADIANS,RAND,ROUND,SIGN,SIN,SQRT,TAN,TRUNCATE";
+  public static final String STRING_FUNCTIONS =
+      "ASCII,CHAR,CHAR_LENGTH,CHARACTER_LENGTH,CONCAT,INSERT,LCASE,LEFT,LENGTH,LOCATE,LOCATE2,LTRIM,OCTET_LENGTH,POSITION,REPEAT,REPLACE,RIGHT,RTRIM,SOUNDEX,SPACE,SUBSTRING,UCASE";
   public static final String SYSTEM_FUNCTIONS = "DATABASE,IFNULL,USER";
-  public static final String TIME_DATE_FUNCTIONS = "CURDATE,CURRENT_DATE,CURRENT_TIME,CURRENT_TIMESTAMP,CURTIME,DAYNAME,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR,HOUR,MINUTE,MONTH,MONTHNAME,NOW,QUARTER,SECOND,TIMESTAMPADD,TIMESTAMPDIFF,WEEK,YEAR";
+  public static final String TIME_DATE_FUNCTIONS =
+      "CURDATE,CURRENT_DATE,CURRENT_TIME,CURRENT_TIMESTAMP,CURTIME,DAYNAME,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR,HOUR,MINUTE,MONTH,MONTHNAME,NOW,QUARTER,SECOND,TIMESTAMPADD,TIMESTAMPDIFF,WEEK,YEAR";
   private final IDatabricksConnection connection;
   private final IDatabricksSession session;
-  private final static Logger LOGGER = LoggerFactory.getLogger(DatabricksDatabaseMetaData.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksDatabaseMetaData.class);
 
   public DatabricksDatabaseMetaData(IDatabricksConnection connection) {
     this.connection = connection;
@@ -111,9 +113,11 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public String getDatabaseProductVersion() throws SQLException {
     LOGGER.debug("public String getDatabaseProductVersion()");
     throwExceptionIfConnectionIsClosed();
-    return DATABASE_MAJOR_VERSION + DatabricksJdbcConstants.FULL_STOP
-            + DATABASE_MINOR_VERSION + DatabricksJdbcConstants.FULL_STOP
-            + DATABASE_PATCH_VERSION;
+    return DATABASE_MAJOR_VERSION
+        + DatabricksJdbcConstants.FULL_STOP
+        + DATABASE_MINOR_VERSION
+        + DatabricksJdbcConstants.FULL_STOP
+        + DATABASE_PATCH_VERSION;
   }
 
   @Override
@@ -127,9 +131,11 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public String getDriverVersion() throws SQLException {
     LOGGER.debug("public String getDriverVersion()");
     throwExceptionIfConnectionIsClosed();
-    return JDBC_MAJOR_VERSION + DatabricksJdbcConstants.FULL_STOP
-            + JDBC_MINOR_VERSION + DatabricksJdbcConstants.FULL_STOP
-            + JDBC_PATCH_VERSION;
+    return JDBC_MAJOR_VERSION
+        + DatabricksJdbcConstants.FULL_STOP
+        + JDBC_MINOR_VERSION
+        + DatabricksJdbcConstants.FULL_STOP
+        + JDBC_PATCH_VERSION;
   }
 
   @Override
@@ -304,7 +310,8 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public boolean supportsConvert(int fromType, int toType) throws SQLException {
-    LOGGER.debug("public boolean supportsConvert(int fromType = {}, int toType = {})", fromType, toType);
+    LOGGER.debug(
+        "public boolean supportsConvert(int fromType = {}, int toType = {})", fromType, toType);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -863,37 +870,76 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getProcedures(String catalog = {}, String schemaPattern = {}, String procedureNamePattern = {})", catalog, schemaPattern, procedureNamePattern);
+  public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getProcedures(String catalog = {}, String schemaPattern = {}, String procedureNamePattern = {})",
+        catalog,
+        schemaPattern,
+        procedureNamePattern);
     // TODO: check once, simba returns empty result set as well
     throwExceptionIfConnectionIsClosed();
     return new DatabricksResultSet(
-            new StatementStatus().setState(StatementState.SUCCEEDED),
-            "getprocedures-metadata",
-            Arrays.asList("PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", "NUM_INPUT_PARAMS", "NUM_OUTPUT_PARAMS", "NUM_RESULT_SETS", "REMARKS", "PROCEDURE_TYPE", "SPECIFIC_NAME"),
-            Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128, 128, 128, 128, 128, 128, 128, 128),
-            new Object[0][0],
-            StatementType.METADATA
-    );
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "getprocedures-metadata",
+        Arrays.asList(
+            "PROCEDURE_CAT",
+            "PROCEDURE_SCHEM",
+            "PROCEDURE_NAME",
+            "NUM_INPUT_PARAMS",
+            "NUM_OUTPUT_PARAMS",
+            "NUM_RESULT_SETS",
+            "REMARKS",
+            "PROCEDURE_TYPE",
+            "SPECIFIC_NAME"),
+        Arrays.asList(
+            "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR",
+            "VARCHAR"),
+        Arrays.asList(
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR),
+        Arrays.asList(128, 128, 128, 128, 128, 128, 128, 128, 128),
+        new Object[0][0],
+        StatementType.METADATA);
   }
 
   @Override
-  public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getProcedureColumns(String catalog = {}, String schemaPattern = {}, String procedureNamePattern = {}, String columnNamePattern = {})", catalog, schemaPattern, procedureNamePattern, columnNamePattern);
+  public ResultSet getProcedureColumns(
+      String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getProcedureColumns(String catalog = {}, String schemaPattern = {}, String procedureNamePattern = {}, String columnNamePattern = {})",
+        catalog,
+        schemaPattern,
+        procedureNamePattern,
+        columnNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) throws SQLException {
-    LOGGER.debug("public ResultSet getTables(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String[] types = {})", catalog, schemaPattern, tableNamePattern, types);
+  public ResultSet getTables(
+      String catalog, String schemaPattern, String tableNamePattern, String[] types)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getTables(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String[] types = {})",
+        catalog,
+        schemaPattern,
+        tableNamePattern,
+        types);
     throwExceptionIfConnectionIsClosed();
     Map.Entry<String, String> pair = applyContext(catalog, schemaPattern);
     String catalogWithContext = pair.getKey();
     String schemaWithContext = pair.getValue();
     Queue<Map.Entry<String, String>> catalogSchemaPairs = new ConcurrentLinkedQueue<>();
-    if (WildcardUtil.isWildcard(schemaWithContext) || WildcardUtil.isMatchAnything(catalogWithContext)) {
+    if (WildcardUtil.isWildcard(schemaWithContext)
+        || WildcardUtil.isMatchAnything(catalogWithContext)) {
       ResultSet resultSet = getSchemas(catalogWithContext, schemaWithContext);
       while (resultSet.next()) {
         catalogSchemaPairs.add(Map.entry(resultSet.getString(2), resultSet.getString(1)));
@@ -902,52 +948,95 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
       catalogSchemaPairs.add(pair);
     }
     // TODO: Limit to 15 pairs to run quickly, remove after demo/find workaround
-    while (catalogSchemaPairs.size() > 15)
-      catalogSchemaPairs.poll();
+    while (catalogSchemaPairs.size() > 15) catalogSchemaPairs.poll();
     String tableWithContext = tableNamePattern == null ? "*" : tableNamePattern;
 
     List<List<Object>> rows = new CopyOnWriteArrayList<>();
     ExecutorService executorService = Executors.newFixedThreadPool(150);
     for (int i = 0; i < 150; i++) {
-      executorService.submit(() -> {
-        while (!catalogSchemaPairs.isEmpty()) {
-          Map.Entry<String, String> currentPair = catalogSchemaPairs.poll();
-          String currentCatalog = currentPair.getKey();
-          String currentSchema = currentPair.getValue();
-          String showTablesSQL = "show tables from " + currentCatalog + "." + currentSchema;
-          if (!WildcardUtil.isMatchAnything(tableWithContext)) {
-            showTablesSQL += " like '" + tableWithContext + "'";
-          }
-          LOGGER.debug("SQL command to fetch tables: {}" + showTablesSQL);
-          try {
-            ResultSet rs = session.getDatabricksClient().executeStatement(
-                    showTablesSQL, session.getWarehouseId(), new HashMap<Integer, ImmutableSqlParameter>(),
-                StatementType.METADATA, session, null /* parentStatement */);
-            while (rs.next()) {
-              rows.add(Arrays.asList(currentCatalog, currentSchema, rs.getString(2), "TABLE", null, null, null, null, null, null));
+      executorService.submit(
+          () -> {
+            while (!catalogSchemaPairs.isEmpty()) {
+              Map.Entry<String, String> currentPair = catalogSchemaPairs.poll();
+              String currentCatalog = currentPair.getKey();
+              String currentSchema = currentPair.getValue();
+              String showTablesSQL = "show tables from " + currentCatalog + "." + currentSchema;
+              if (!WildcardUtil.isMatchAnything(tableWithContext)) {
+                showTablesSQL += " like '" + tableWithContext + "'";
+              }
+              LOGGER.debug("SQL command to fetch tables: {}" + showTablesSQL);
+              try {
+                ResultSet rs =
+                    session
+                        .getDatabricksClient()
+                        .executeStatement(
+                            showTablesSQL,
+                            session.getWarehouseId(),
+                            new HashMap<Integer, ImmutableSqlParameter>(),
+                            StatementType.METADATA,
+                            session,
+                            null /* parentStatement */);
+                while (rs.next()) {
+                  rows.add(
+                      Arrays.asList(
+                          currentCatalog,
+                          currentSchema,
+                          rs.getString(2),
+                          "TABLE",
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null));
+                }
+              } catch (SQLException e) {
+                throw new RuntimeException(e);
+              }
             }
-          } catch (SQLException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
+          });
     }
     executorService.shutdown();
     while (!executorService.isTerminated()) {
       // wait
     }
     // They are ordered by TABLE_TYPE, TABLE_CAT, TABLE_SCHEM and TABLE_NAME.
-    rows.sort(Comparator.comparing((List<Object> i) -> i.get(3).toString())
-            .thenComparing(i -> i.get(0).toString()).thenComparing(i -> i.get(1).toString())
+    rows.sort(
+        Comparator.comparing((List<Object> i) -> i.get(3).toString())
+            .thenComparing(i -> i.get(0).toString())
+            .thenComparing(i -> i.get(1).toString())
             .thenComparing(i -> i.get(2).toString()));
-    return new DatabricksResultSet(new StatementStatus().setState(StatementState.SUCCEEDED),
-            "gettables-metadata",
-            Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS", "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "SELF_REFERENCING_COL_NAME", "REF_GENERATION"),
-            Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128, 128, 128, 128, 128, 128, 128, 128, 128),
-            rows,
-            StatementType.METADATA);
+    return new DatabricksResultSet(
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "gettables-metadata",
+        Arrays.asList(
+            "TABLE_CAT",
+            "TABLE_SCHEM",
+            "TABLE_NAME",
+            "TABLE_TYPE",
+            "REMARKS",
+            "TYPE_CAT",
+            "TYPE_SCHEM",
+            "TYPE_NAME",
+            "SELF_REFERENCING_COL_NAME",
+            "REF_GENERATION"),
+        Arrays.asList(
+            "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR",
+            "VARCHAR", "VARCHAR"),
+        Arrays.asList(
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR),
+        Arrays.asList(128, 128, 128, 128, 128, 128, 128, 128, 128, 128),
+        rows,
+        StatementType.METADATA);
   }
 
   @Override
@@ -964,134 +1053,216 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
     String showCatalogsSQL = "show catalogs";
     LOGGER.debug("SQL command to fetch catalogs: {}" + showCatalogsSQL);
 
-    ResultSet rs = session.getDatabricksClient().executeStatement(
-            showCatalogsSQL, session.getWarehouseId(), new HashMap<Integer, ImmutableSqlParameter>(),
-            StatementType.METADATA, session, null /* parentStatement */);
+    ResultSet rs =
+        session
+            .getDatabricksClient()
+            .executeStatement(
+                showCatalogsSQL,
+                session.getWarehouseId(),
+                new HashMap<Integer, ImmutableSqlParameter>(),
+                StatementType.METADATA,
+                session,
+                null /* parentStatement */);
     List<List<Object>> rows = new ArrayList<>();
     while (rs.next()) {
       rows.add(Collections.singletonList(rs.getString(1)));
     }
     return new DatabricksResultSet(
-            new StatementStatus().setState(StatementState.SUCCEEDED),
-            "getcatalogs-metadata",
-            Collections.singletonList("TABLE_CAT"),
-            Collections.singletonList("VARCHAR"),
-            Collections.singletonList(Types.VARCHAR),
-            Collections.singletonList(128),
-            rows,
-            StatementType.METADATA);
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "getcatalogs-metadata",
+        Collections.singletonList("TABLE_CAT"),
+        Collections.singletonList("VARCHAR"),
+        Collections.singletonList(Types.VARCHAR),
+        Collections.singletonList(128),
+        rows,
+        StatementType.METADATA);
   }
 
   @Override
   public ResultSet getTableTypes() throws SQLException {
     LOGGER.debug("public ResultSet getTableTypes()");
     throwExceptionIfConnectionIsClosed();
-    return new DatabricksResultSet(new StatementStatus().setState(StatementState.SUCCEEDED),
-            "tabletype-metadata",
-            Collections.singletonList("TABLE_TYPE"),
-            Collections.singletonList("VARCHAR"),
-            Collections.singletonList(Types.VARCHAR),
-            Collections.singletonList(128),
-            new String[][] {{"SYSTEM TABLE"}, {"TABLE"}, {"VIEW"}},
-            StatementType.METADATA);
+    return new DatabricksResultSet(
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "tabletype-metadata",
+        Collections.singletonList("TABLE_TYPE"),
+        Collections.singletonList("VARCHAR"),
+        Collections.singletonList(Types.VARCHAR),
+        Collections.singletonList(128),
+        new String[][] {{"SYSTEM TABLE"}, {"TABLE"}, {"VIEW"}},
+        StatementType.METADATA);
   }
 
   @Override
-  public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getColumns(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String columnNamePattern = {})", catalog, schemaPattern, tableNamePattern, columnNamePattern);
+  public ResultSet getColumns(
+      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getColumns(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String columnNamePattern = {})",
+        catalog,
+        schemaPattern,
+        tableNamePattern,
+        columnNamePattern);
     throwExceptionIfConnectionIsClosed();
 
     ResultSet resultSet = getTables(catalog, schemaPattern, tableNamePattern, null);
     Queue<String[]> catalogSchemaTableCombinations = new ConcurrentLinkedQueue<>();
     while (resultSet.next()) {
-      catalogSchemaTableCombinations.add(new String[]{resultSet.getString(1), resultSet.getString(2), resultSet.getString(3)});
+      catalogSchemaTableCombinations.add(
+          new String[] {resultSet.getString(1), resultSet.getString(2), resultSet.getString(3)});
     }
 
     List<List<Object>> rows = new CopyOnWriteArrayList<>();
     ExecutorService executorService = Executors.newFixedThreadPool(150);
     for (int i = 0; i < 150; i++) {
-      executorService.submit(() -> {
-        while (!catalogSchemaTableCombinations.isEmpty()) {
-          String[] combination = catalogSchemaTableCombinations.poll();
-          String showColumnsSQL = "show columns in " + combination[0] + "." + combination[1] + "." + combination[2];
-          LOGGER.debug("SQL command to fetch columns: {}" + showColumnsSQL);
-          try {
-            ResultSet rs = session.getDatabricksClient().executeStatement(showColumnsSQL, session.getWarehouseId(),
-                    new HashMap<Integer, ImmutableSqlParameter>(), StatementType.METADATA, session,
-                null /* parentStatement */);
-            while (rs.next()) {
-              if (rs.getString(1).matches(columnNamePattern)) {
-                rows.add(Arrays.asList(combination[0], combination[1], combination[2], rs.getString(1)));
+      executorService.submit(
+          () -> {
+            while (!catalogSchemaTableCombinations.isEmpty()) {
+              String[] combination = catalogSchemaTableCombinations.poll();
+              String showColumnsSQL =
+                  "show columns in " + combination[0] + "." + combination[1] + "." + combination[2];
+              LOGGER.debug("SQL command to fetch columns: {}" + showColumnsSQL);
+              try {
+                ResultSet rs =
+                    session
+                        .getDatabricksClient()
+                        .executeStatement(
+                            showColumnsSQL,
+                            session.getWarehouseId(),
+                            new HashMap<Integer, ImmutableSqlParameter>(),
+                            StatementType.METADATA,
+                            session,
+                            null /* parentStatement */);
+                while (rs.next()) {
+                  if (rs.getString(1).matches(columnNamePattern)) {
+                    rows.add(
+                        Arrays.asList(
+                            combination[0], combination[1], combination[2], rs.getString(1)));
+                  }
+                }
+              } catch (SQLException e) {
+                throw new RuntimeException(e);
               }
             }
-          } catch (SQLException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
+          });
     }
     executorService.shutdown();
     while (!executorService.isTerminated()) {
       // wait
     }
     // TODO: some columns are missing from result set, determine how to fill those
-    rows.sort(Comparator.comparing((List<Object> i) -> i.get(0).toString())
-            .thenComparing(i -> i.get(1).toString()).thenComparing(i -> i.get(2).toString()));
-    return new DatabricksResultSet(new StatementStatus().setState(StatementState.SUCCEEDED),
-            "metadata-statement",
-            Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME"),
-            Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128, 128, 128),
-            rows,
-            StatementType.METADATA);
+    rows.sort(
+        Comparator.comparing((List<Object> i) -> i.get(0).toString())
+            .thenComparing(i -> i.get(1).toString())
+            .thenComparing(i -> i.get(2).toString()));
+    return new DatabricksResultSet(
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "metadata-statement",
+        Arrays.asList("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME"),
+        Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
+        Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
+        Arrays.asList(128, 128, 128, 128),
+        rows,
+        StatementType.METADATA);
   }
 
   @Override
-  public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getColumnPrivileges(String catalog = {}, String schema = {}, String table = {}, String columnNamePattern = {})", catalog, schema, table, columnNamePattern);
+  public ResultSet getColumnPrivileges(
+      String catalog, String schema, String table, String columnNamePattern) throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getColumnPrivileges(String catalog = {}, String schema = {}, String table = {}, String columnNamePattern = {})",
+        catalog,
+        schema,
+        table,
+        columnNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getTablePrivileges(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {})", catalog, schemaPattern, tableNamePattern);
+  public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getTablePrivileges(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {})",
+        catalog,
+        schemaPattern,
+        tableNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable) throws SQLException {
-    LOGGER.debug("public ResultSet getBestRowIdentifier(String catalog = {}, String schema = {}, String table = {}, int scope = {}, boolean nullable = {})", catalog, schema, table, scope, nullable);
+  public ResultSet getBestRowIdentifier(
+      String catalog, String schema, String table, int scope, boolean nullable)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getBestRowIdentifier(String catalog = {}, String schema = {}, String table = {}, int scope = {}, boolean nullable = {})",
+        catalog,
+        schema,
+        table,
+        scope,
+        nullable);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
-    LOGGER.debug("public ResultSet getVersionColumns(String catalog = {}, String schema = {}, String table = {})", catalog, schema, table);
+  public ResultSet getVersionColumns(String catalog, String schema, String table)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getVersionColumns(String catalog = {}, String schema = {}, String table = {})",
+        catalog,
+        schema,
+        table);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
-    LOGGER.debug("public ResultSet getPrimaryKeys(String catalog = {}, String schema = {}, String table = {})", catalog, schema, table);
+    LOGGER.debug(
+        "public ResultSet getPrimaryKeys(String catalog = {}, String schema = {}, String table = {})",
+        catalog,
+        schema,
+        table);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
-    LOGGER.debug("public ResultSet getImportedKeys(String catalog = {}, String schema = {}, String table = {})", catalog, schema, table);
+  public ResultSet getImportedKeys(String catalog, String schema, String table)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getImportedKeys(String catalog = {}, String schema = {}, String table = {})",
+        catalog,
+        schema,
+        table);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
-    LOGGER.debug("public ResultSet getExportedKeys(String catalog = {}, String schema = {}, String table = {})", catalog, schema, table);
+  public ResultSet getExportedKeys(String catalog, String schema, String table)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getExportedKeys(String catalog = {}, String schema = {}, String table = {})",
+        catalog,
+        schema,
+        table);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getCrossReference(String parentCatalog, String parentSchema, String parentTable, String foreignCatalog, String foreignSchema, String foreignTable) throws SQLException {
-    LOGGER.debug("public ResultSet getCrossReference(String parentCatalog = {}, String parentSchema = {}, String parentTable = {}, String foreignCatalog = {}, String foreignSchema = {}, String foreignTable = {})", parentCatalog, parentSchema, parentTable, foreignCatalog, foreignSchema, foreignTable);
+  public ResultSet getCrossReference(
+      String parentCatalog,
+      String parentSchema,
+      String parentTable,
+      String foreignCatalog,
+      String foreignSchema,
+      String foreignTable)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getCrossReference(String parentCatalog = {}, String parentSchema = {}, String parentTable = {}, String foreignCatalog = {}, String foreignSchema = {}, String foreignTable = {})",
+        parentCatalog,
+        parentSchema,
+        parentTable,
+        foreignCatalog,
+        foreignSchema,
+        foreignTable);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -1101,417 +1272,422 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
     throwExceptionIfConnectionIsClosed();
 
     return new DatabricksResultSet(
-            new StatementStatus().setState(StatementState.SUCCEEDED),
-            "typeinfo-metadata",
-            Arrays.asList(
-                    "TYPE_NAME",
-                    "DATA_TYPE",
-                    "PRECISION",
-                    "LITERAL_PREFIX",
-                    "LITERAL_SUFFIX",
-                    "CREATE_PARAMS",
-                    "NULLABLE",
-                    "CASE_SENSITIVE",
-                    "SEARCHABLE",
-                    "UNSIGNED_ATTRIBUTE",
-                    "FIXED_PREC_SCALE",
-                    "AUTO_INCREMENT",
-                    "LOCAL_TYPE_NAME",
-                    "MINIMUM_SCALE",
-                    "MAXIMUM_SCALE",
-                    "SQL_DATA_TYPE",
-                    "SQL_DATETIME_SUB",
-                    "NUM_PREC_RADIX"),
-            Arrays.asList(
-                    "VARCHAR", "INTEGER", "INTEGER", "VARCHAR", "VARCHAR", "VARCHAR", "SMALLINT", "BIT", "SMALLINT",
-                    "BIT", "BIT", "BIT", "VARCHAR", "SMALLINT", "SMALLINT", "INTEGER", "INTEGER",
-                    "INTEGER"),
-            Arrays.asList(
-                    Types.VARCHAR,
-                    Types.INTEGER,
-                    Types.INTEGER,
-                    Types.VARCHAR,
-                    Types.VARCHAR,
-                    Types.VARCHAR,
-                    Types.SMALLINT,
-                    Types.BOOLEAN,
-                    Types.SMALLINT,
-                    Types.BOOLEAN,
-                    Types.BOOLEAN,
-                    Types.BOOLEAN,
-                    Types.VARCHAR,
-                    Types.SMALLINT,
-                    Types.SMALLINT,
-                    Types.INTEGER,
-                    Types.INTEGER,
-                    Types.INTEGER),
-            Arrays.asList(
-                    128,
-                    10,
-                    10,
-                    128,
-                    128,
-                    128,
-                    5,
-                    1,
-                    5,
-                    1,
-                    1,
-                    1,
-                    128,
-                    5,
-                    5,
-                    10,
-                    10,
-                    10),
-            new Object[][]{
-                    {
-                            "TINYINT",
-                            Types.TINYINT,
-                            3,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "TINYINT",
-                            0,
-                            0,
-                            Types.TINYINT,
-                            null,
-                            10
-                    },
-                    {
-                            "BIGINT",
-                            Types.BIGINT,
-                            19,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "BIGINT",
-                            0,
-                            0,
-                            Types.BIGINT,
-                            null,
-                            10
-                    },
-                    {
-                            "BINARY",
-                            Types.BINARY,
-                            32767,
-                            "0x",
-                            null,
-                            "LENGTH",
-                            typeNullable,
-                            false,
-                            typePredNone,
-                            null,
-                            false,
-                            null,
-                            "BINARY",
-                            null,
-                            null,
-                            Types.BINARY,
-                            null,
-                            null
-                    },
-                    {
-                            "CHAR",
-                            Types.CHAR,
-                            255,
-                            "'",
-                            "'",
-                            "LENGTH",
-                            typeNullable,
-                            true,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "CHAR",
-                            null,
-                            null,
-                            Types.CHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "DECIMAL",
-                            Types.DECIMAL,
-                            38,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "DECIMAL",
-                            0,
-                            0,
-                            Types.DECIMAL,
-                            null,
-                            10
-                    },
-                    {
-                            "INT",
-                            Types.INTEGER,
-                            10,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "INT",
-                            0,
-                            0,
-                            Types.INTEGER,
-                            null,
-                            10
-                    },
-                    {
-                            "SMALLINT",
-                            Types.SMALLINT,
-                            5,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "SMALLINT",
-                            0,
-                            0,
-                            Types.SMALLINT,
-                            null,
-                            10
-                    },
-                    {
-                            "FLOAT",
-                            Types.FLOAT,
-                            7,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "FLOAT",
-                            null,
-                            null,
-                            Types.FLOAT,
-                            null,
-                            2
-                    },
-                    {
-                            "DOUBLE",
-                            Types.DOUBLE,
-                            15,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            false,
-                            typePredBasic,
-                            false,
-                            false,
-                            null,
-                            "DOUBLE",
-                            null,
-                            null,
-                            Types.DOUBLE,
-                            null,
-                            2
-                    },
-                    {
-                            "ARRAY",
-                            Types.VARCHAR,
-                            32767,
-                            "'",
-                            "'",
-                            "Type",
-                            typeNullable,
-                            false,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "ARRAY",
-                            null,
-                            null,
-                            Types.VARCHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "MAP",
-                            Types.VARCHAR,
-                            32767,
-                            "'",
-                            "'",
-                            "Key,Value",
-                            typeNullable,
-                            false,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "MAP",
-                            null,
-                            null,
-                            Types.VARCHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "STRING",
-                            Types.VARCHAR,
-                            510,
-                            "'",
-                            "'",
-                            "max length",
-                            typeNullable,
-                            true,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "STRING",
-                            null,
-                            null,
-                            Types.VARCHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "STRUCT",
-                            Types.VARCHAR,
-                            32767,
-                            "'",
-                            "'",
-                            "Column Type, ...",
-                            typeNullable,
-                            false,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "STRUCT",
-                            null,
-                            null,
-                            Types.VARCHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "VARCHAR",
-                            Types.VARCHAR,
-                            510,
-                            "'",
-                            "'",
-                            "max length",
-                            typeNullable,
-                            true,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "VARCHAR",
-                            null,
-                            null,
-                            Types.VARCHAR,
-                            null,
-                            null
-                    },
-                    {
-                            "BOOLEAN",
-                            Types.BOOLEAN,
-                            1,
-                            null,
-                            null,
-                            null,
-                            typeNullable,
-                            true,
-                            typePredBasic,
-                            null,
-                            false,
-                            null,
-                            "BOOLEAN",
-                            null,
-                            null,
-                            Types.BOOLEAN,
-                            null,
-                            null
-                    },
-                    {
-                            "DATE",
-                            Types.DATE,
-                            10,
-                            "'",
-                            "'",
-                            null,
-                            typeNullable,
-                            false,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "DATE",
-                            null,
-                            null,
-                            Types.DATE,
-                            null,
-                            null
-                    },
-                    {
-                            "TIMESTAMP",
-                            Types.TIMESTAMP,
-                            29,
-                            "'",
-                            "'",
-                            null,
-                            typeNullable,
-                            false,
-                            typeSearchable,
-                            null,
-                            false,
-                            null,
-                            "TIMESTAMP",
-                            0,
-                            0,
-                            Types.DATE,
-                            null,
-                            null
-                    }
-            },
-            StatementType.METADATA);
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "typeinfo-metadata",
+        Arrays.asList(
+            "TYPE_NAME",
+            "DATA_TYPE",
+            "PRECISION",
+            "LITERAL_PREFIX",
+            "LITERAL_SUFFIX",
+            "CREATE_PARAMS",
+            "NULLABLE",
+            "CASE_SENSITIVE",
+            "SEARCHABLE",
+            "UNSIGNED_ATTRIBUTE",
+            "FIXED_PREC_SCALE",
+            "AUTO_INCREMENT",
+            "LOCAL_TYPE_NAME",
+            "MINIMUM_SCALE",
+            "MAXIMUM_SCALE",
+            "SQL_DATA_TYPE",
+            "SQL_DATETIME_SUB",
+            "NUM_PREC_RADIX"),
+        Arrays.asList(
+            "VARCHAR",
+            "INTEGER",
+            "INTEGER",
+            "VARCHAR",
+            "VARCHAR",
+            "VARCHAR",
+            "SMALLINT",
+            "BIT",
+            "SMALLINT",
+            "BIT",
+            "BIT",
+            "BIT",
+            "VARCHAR",
+            "SMALLINT",
+            "SMALLINT",
+            "INTEGER",
+            "INTEGER",
+            "INTEGER"),
+        Arrays.asList(
+            Types.VARCHAR,
+            Types.INTEGER,
+            Types.INTEGER,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.SMALLINT,
+            Types.BOOLEAN,
+            Types.SMALLINT,
+            Types.BOOLEAN,
+            Types.BOOLEAN,
+            Types.BOOLEAN,
+            Types.VARCHAR,
+            Types.SMALLINT,
+            Types.SMALLINT,
+            Types.INTEGER,
+            Types.INTEGER,
+            Types.INTEGER),
+        Arrays.asList(128, 10, 10, 128, 128, 128, 5, 1, 5, 1, 1, 1, 128, 5, 5, 10, 10, 10),
+        new Object[][] {
+          {
+            "TINYINT",
+            Types.TINYINT,
+            3,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "TINYINT",
+            0,
+            0,
+            Types.TINYINT,
+            null,
+            10
+          },
+          {
+            "BIGINT",
+            Types.BIGINT,
+            19,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "BIGINT",
+            0,
+            0,
+            Types.BIGINT,
+            null,
+            10
+          },
+          {
+            "BINARY",
+            Types.BINARY,
+            32767,
+            "0x",
+            null,
+            "LENGTH",
+            typeNullable,
+            false,
+            typePredNone,
+            null,
+            false,
+            null,
+            "BINARY",
+            null,
+            null,
+            Types.BINARY,
+            null,
+            null
+          },
+          {
+            "CHAR",
+            Types.CHAR,
+            255,
+            "'",
+            "'",
+            "LENGTH",
+            typeNullable,
+            true,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "CHAR",
+            null,
+            null,
+            Types.CHAR,
+            null,
+            null
+          },
+          {
+            "DECIMAL",
+            Types.DECIMAL,
+            38,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "DECIMAL",
+            0,
+            0,
+            Types.DECIMAL,
+            null,
+            10
+          },
+          {
+            "INT",
+            Types.INTEGER,
+            10,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "INT",
+            0,
+            0,
+            Types.INTEGER,
+            null,
+            10
+          },
+          {
+            "SMALLINT",
+            Types.SMALLINT,
+            5,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "SMALLINT",
+            0,
+            0,
+            Types.SMALLINT,
+            null,
+            10
+          },
+          {
+            "FLOAT",
+            Types.FLOAT,
+            7,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "FLOAT",
+            null,
+            null,
+            Types.FLOAT,
+            null,
+            2
+          },
+          {
+            "DOUBLE",
+            Types.DOUBLE,
+            15,
+            null,
+            null,
+            null,
+            typeNullable,
+            false,
+            typePredBasic,
+            false,
+            false,
+            null,
+            "DOUBLE",
+            null,
+            null,
+            Types.DOUBLE,
+            null,
+            2
+          },
+          {
+            "ARRAY",
+            Types.VARCHAR,
+            32767,
+            "'",
+            "'",
+            "Type",
+            typeNullable,
+            false,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "ARRAY",
+            null,
+            null,
+            Types.VARCHAR,
+            null,
+            null
+          },
+          {
+            "MAP",
+            Types.VARCHAR,
+            32767,
+            "'",
+            "'",
+            "Key,Value",
+            typeNullable,
+            false,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "MAP",
+            null,
+            null,
+            Types.VARCHAR,
+            null,
+            null
+          },
+          {
+            "STRING",
+            Types.VARCHAR,
+            510,
+            "'",
+            "'",
+            "max length",
+            typeNullable,
+            true,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "STRING",
+            null,
+            null,
+            Types.VARCHAR,
+            null,
+            null
+          },
+          {
+            "STRUCT",
+            Types.VARCHAR,
+            32767,
+            "'",
+            "'",
+            "Column Type, ...",
+            typeNullable,
+            false,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "STRUCT",
+            null,
+            null,
+            Types.VARCHAR,
+            null,
+            null
+          },
+          {
+            "VARCHAR",
+            Types.VARCHAR,
+            510,
+            "'",
+            "'",
+            "max length",
+            typeNullable,
+            true,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "VARCHAR",
+            null,
+            null,
+            Types.VARCHAR,
+            null,
+            null
+          },
+          {
+            "BOOLEAN",
+            Types.BOOLEAN,
+            1,
+            null,
+            null,
+            null,
+            typeNullable,
+            true,
+            typePredBasic,
+            null,
+            false,
+            null,
+            "BOOLEAN",
+            null,
+            null,
+            Types.BOOLEAN,
+            null,
+            null
+          },
+          {
+            "DATE",
+            Types.DATE,
+            10,
+            "'",
+            "'",
+            null,
+            typeNullable,
+            false,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "DATE",
+            null,
+            null,
+            Types.DATE,
+            null,
+            null
+          },
+          {
+            "TIMESTAMP",
+            Types.TIMESTAMP,
+            29,
+            "'",
+            "'",
+            null,
+            typeNullable,
+            false,
+            typeSearchable,
+            null,
+            false,
+            null,
+            "TIMESTAMP",
+            0,
+            0,
+            Types.DATE,
+            null,
+            null
+          }
+        },
+        StatementType.METADATA);
   }
 
   @Override
-  public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate) throws SQLException {
-    LOGGER.debug("public ResultSet getIndexInfo(String catalog = {}, String schema = {}, String table = {}, boolean unique = {}, boolean approximate = {})", catalog, schema, table, unique, approximate);
+  public ResultSet getIndexInfo(
+      String catalog, String schema, String table, boolean unique, boolean approximate)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getIndexInfo(String catalog = {}, String schema = {}, String table = {}, boolean unique = {}, boolean approximate = {})",
+        catalog,
+        schema,
+        table,
+        unique,
+        approximate);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -1524,7 +1700,10 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
-    LOGGER.debug("public boolean supportsResultSetConcurrency(int type = {}, int concurrency = {})", type, concurrency);
+    LOGGER.debug(
+        "public boolean supportsResultSetConcurrency(int type = {}, int concurrency = {})",
+        type,
+        concurrency);
     throwExceptionIfConnectionIsClosed();
     return type == ResultSet.TYPE_FORWARD_ONLY && concurrency == ResultSet.CONCUR_READ_ONLY;
   }
@@ -1599,20 +1778,40 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) throws SQLException {
-    LOGGER.debug("public ResultSet getUDTs(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {}, int[] types = {})", catalog, schemaPattern, typeNamePattern, types);
+  public ResultSet getUDTs(
+      String catalog, String schemaPattern, String typeNamePattern, int[] types)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getUDTs(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {}, int[] types = {})",
+        catalog,
+        schemaPattern,
+        typeNamePattern,
+        types);
     // TODO: implement, returning only empty set for now
     throwExceptionIfConnectionIsClosed();
     return new DatabricksResultSet(
-            new StatementStatus().setState(StatementState.SUCCEEDED),
-            "getudts-metadata",
-            Arrays.asList("TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE", "REMAKRS", "BASE_TYPE"),
-            Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128, 128, 128, 128, 128, 128),
-            new String[0][0],
-            StatementType.METADATA
-    );
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "getudts-metadata",
+        Arrays.asList(
+            "TYPE_CAT",
+            "TYPE_SCHEM",
+            "TYPE_NAME",
+            "CLASS_NAME",
+            "DATA_TYPE",
+            "REMAKRS",
+            "BASE_TYPE"),
+        Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
+        Arrays.asList(
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR),
+        Arrays.asList(128, 128, 128, 128, 128, 128, 128),
+        new String[0][0],
+        StatementType.METADATA);
   }
 
   @Override
@@ -1650,20 +1849,37 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getSuperTypes(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {})", catalog, schemaPattern, typeNamePattern);
+  public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getSuperTypes(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {})",
+        catalog,
+        schemaPattern,
+        typeNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getSuperTables(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {})", catalog, schemaPattern, tableNamePattern);
+  public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getSuperTables(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {})",
+        catalog,
+        schemaPattern,
+        tableNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getAttributes(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {}, String attributeNamePattern = {})", catalog, schemaPattern, typeNamePattern, attributeNamePattern);
+  public ResultSet getAttributes(
+      String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getAttributes(String catalog = {}, String schemaPattern = {}, String typeNamePattern = {}, String attributeNamePattern = {})",
+        catalog,
+        schemaPattern,
+        typeNamePattern,
+        attributeNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -1735,13 +1951,17 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-    LOGGER.debug("public ResultSet getSchemas(String catalog = {}, String schemaPattern = {})", catalog, schemaPattern);
+    LOGGER.debug(
+        "public ResultSet getSchemas(String catalog = {}, String schemaPattern = {})",
+        catalog,
+        schemaPattern);
     throwExceptionIfConnectionIsClosed();
     Map.Entry<String, String> pair = applyContext(catalog, schemaPattern);
     String catalogWithContext = pair.getKey();
     String schemaWithContext = pair.getValue();
 
-    // Since catalog must be an identifier or all catalogs (null), we need not care about catalog regex
+    // Since catalog must be an identifier or all catalogs (null), we need not care about catalog
+    // regex
     Queue<String> catalogs = new ConcurrentLinkedQueue<>();
     if (WildcardUtil.isMatchAnything(catalogWithContext)) {
       ResultSet rs = getCatalogs();
@@ -1752,49 +1972,60 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
       catalogs.add(catalogWithContext);
     }
     // TODO: Remove post demo
-    while (catalogs.size() > 5)
-      catalogs.poll();
+    while (catalogs.size() > 5) catalogs.poll();
 
     List<List<Object>> rows = new CopyOnWriteArrayList<>();
     ExecutorService executorService = Executors.newFixedThreadPool(150);
     for (int i = 0; i < 150; i++) {
-      executorService.submit(() -> {
-        while (!catalogs.isEmpty()) {
-          String currentCatalog = catalogs.poll();
-          // TODO: Emoji characters are not being handled correctly by SDK/SEA, hence, skipping for now
-//          if (WildcardUtil.containsEmoji(currentCatalog))
-//            return;
-          String showSchemaSQL = "show schemas in `" + currentCatalog + "`";
-          if (!WildcardUtil.isMatchAnything(schemaWithContext)) {
-            showSchemaSQL += " like '" + schemaWithContext + "'";
-          }
-          LOGGER.debug("SQL command to fetch schemas: {}" + showSchemaSQL);
-          try {
-            ResultSet rs = session.getDatabricksClient().executeStatement(
-                    showSchemaSQL, session.getWarehouseId(), new HashMap<Integer, ImmutableSqlParameter>(),
-                    StatementType.METADATA, session, null /* parentStatement */);
-            while (rs.next()) {
-              rows.add(Arrays.asList(rs.getString(1), currentCatalog));
+      executorService.submit(
+          () -> {
+            while (!catalogs.isEmpty()) {
+              String currentCatalog = catalogs.poll();
+              // TODO: Emoji characters are not being handled correctly by SDK/SEA, hence, skipping
+              // for now
+              //          if (WildcardUtil.containsEmoji(currentCatalog))
+              //            return;
+              String showSchemaSQL = "show schemas in `" + currentCatalog + "`";
+              if (!WildcardUtil.isMatchAnything(schemaWithContext)) {
+                showSchemaSQL += " like '" + schemaWithContext + "'";
+              }
+              LOGGER.debug("SQL command to fetch schemas: {}" + showSchemaSQL);
+              try {
+                ResultSet rs =
+                    session
+                        .getDatabricksClient()
+                        .executeStatement(
+                            showSchemaSQL,
+                            session.getWarehouseId(),
+                            new HashMap<Integer, ImmutableSqlParameter>(),
+                            StatementType.METADATA,
+                            session,
+                            null /* parentStatement */);
+                while (rs.next()) {
+                  rows.add(Arrays.asList(rs.getString(1), currentCatalog));
+                }
+              } catch (SQLException e) {
+                throw new RuntimeException(e);
+              }
             }
-          } catch (SQLException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
+          });
     }
     executorService.shutdown();
     while (!executorService.isTerminated()) {
       // wait
     }
-    rows.sort(Comparator.comparing((List<Object> i) -> i.get(1).toString()).thenComparing(i -> i.get(0).toString()));
-    return new DatabricksResultSet(new StatementStatus().setState(StatementState.SUCCEEDED),
-            "metadata-statement",
-            Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
-            Arrays.asList("VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128),
-            rows,
-            StatementType.METADATA);
+    rows.sort(
+        Comparator.comparing((List<Object> i) -> i.get(1).toString())
+            .thenComparing(i -> i.get(0).toString()));
+    return new DatabricksResultSet(
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "metadata-statement",
+        Arrays.asList("TABLE_SCHEM", "TABLE_CATALOG"),
+        Arrays.asList("VARCHAR", "VARCHAR"),
+        Arrays.asList(Types.VARCHAR, Types.VARCHAR),
+        Arrays.asList(128, 128),
+        rows,
+        StatementType.METADATA);
   }
 
   @Override
@@ -1818,38 +2049,70 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getFunctions(String catalog = {}, String schemaPattern = {}, String functionNamePattern = {})", catalog, schemaPattern, functionNamePattern);
+  public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getFunctions(String catalog = {}, String schemaPattern = {}, String functionNamePattern = {})",
+        catalog,
+        schemaPattern,
+        functionNamePattern);
     throwExceptionIfConnectionIsClosed();
     // TODO: implement, returning only empty set for now
     throwExceptionIfConnectionIsClosed();
     return new DatabricksResultSet(
-            new StatementStatus().setState(StatementState.SUCCEEDED),
-            "getfunctions-metadata",
-            Arrays.asList("FUNCTION_CAT", "FUNCTION_SCHEM", "FUNCTION_NAME", "REMARKS", "FUNCTION_TYPE", "SPECIFIC_NAME"),
-            Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
-            Arrays.asList(Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR),
-            Arrays.asList(128, 128, 128, 128, 128, 128),
-            new Object[0][0],
-            StatementType.METADATA
-    );
+        new StatementStatus().setState(StatementState.SUCCEEDED),
+        "getfunctions-metadata",
+        Arrays.asList(
+            "FUNCTION_CAT",
+            "FUNCTION_SCHEM",
+            "FUNCTION_NAME",
+            "REMARKS",
+            "FUNCTION_TYPE",
+            "SPECIFIC_NAME"),
+        Arrays.asList("VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR"),
+        Arrays.asList(
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR,
+            Types.VARCHAR),
+        Arrays.asList(128, 128, 128, 128, 128, 128),
+        new Object[0][0],
+        StatementType.METADATA);
 
-//    // TODO: Handle null catalog, schema, function behaviour
-//
-//    String showSchemaSQL = "show functions in " + catalog + "." + schemaPattern + " like '" + functionNamePattern + "'";
-//    return session.getDatabricksClient().executeStatement(showSchemaSQL, session.getWarehouseId(),
-//        new HashMap<Integer, ImmutableSqlParameter>(), StatementType.METADATA, session);
+    //    // TODO: Handle null catalog, schema, function behaviour
+    //
+    //    String showSchemaSQL = "show functions in " + catalog + "." + schemaPattern + " like '" +
+    // functionNamePattern + "'";
+    //    return session.getDatabricksClient().executeStatement(showSchemaSQL,
+    // session.getWarehouseId(),
+    //        new HashMap<Integer, ImmutableSqlParameter>(), StatementType.METADATA, session);
   }
 
   @Override
-  public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getFunctionColumns(String catalog = {}, String schemaPattern = {}, String functionNamePattern = {}, String columnNamePattern = {})", catalog, schemaPattern, functionNamePattern, columnNamePattern);
+  public ResultSet getFunctionColumns(
+      String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getFunctionColumns(String catalog = {}, String schemaPattern = {}, String functionNamePattern = {}, String columnNamePattern = {})",
+        catalog,
+        schemaPattern,
+        functionNamePattern,
+        columnNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
-    LOGGER.debug("public ResultSet getPseudoColumns(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String columnNamePattern = {})", catalog, schemaPattern, tableNamePattern, columnNamePattern);
+  public ResultSet getPseudoColumns(
+      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      throws SQLException {
+    LOGGER.debug(
+        "public ResultSet getPseudoColumns(String catalog = {}, String schemaPattern = {}, String tableNamePattern = {}, String columnNamePattern = {})",
+        catalog,
+        schemaPattern,
+        tableNamePattern,
+        columnNamePattern);
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -1879,8 +2142,12 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
     }
   }
 
-  private Map.Entry<String, String> applyContext(String catalog, String schema) throws SQLException {
-    LOGGER.debug("private Map.Entry<String, String> applyContext(String catalog = {}, String schema = {})", catalog, schema);
+  private Map.Entry<String, String> applyContext(String catalog, String schema)
+      throws SQLException {
+    LOGGER.debug(
+        "private Map.Entry<String, String> applyContext(String catalog = {}, String schema = {})",
+        catalog,
+        schema);
     if (catalog == null) {
       catalog = connection.getConnection().getCatalog();
     }

--- a/src/main/java/com/databricks/jdbc/core/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksPreparedStatement.java
@@ -3,9 +3,6 @@ package com.databricks.jdbc.core;
 import static com.databricks.jdbc.core.DatabricksTypes.*;
 
 import com.databricks.jdbc.client.StatementType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -14,6 +11,8 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksPreparedStatement extends DatabricksStatement implements PreparedStatement {
 
@@ -188,11 +187,13 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   private void setObject(int parameterIndex, Object x, String databricksType) {
-    this.parameterBindings.put(parameterIndex, ImmutableSqlParameter.builder()
-        .type(databricksType)
-        .value(x)
-        .cardinal(parameterIndex)
-        .build());
+    this.parameterBindings.put(
+        parameterIndex,
+        ImmutableSqlParameter.builder()
+            .type(databricksType)
+            .value(x)
+            .cardinal(parameterIndex)
+            .build());
   }
 
   @Override
@@ -210,7 +211,8 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+      throws SQLException {
     LOGGER.debug("public void setCharacterStream(int parameterIndex, Reader reader, int length)");
     throw new UnsupportedOperationException("Not implemented");
   }
@@ -295,7 +297,8 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+      throws SQLException {
     LOGGER.debug("public void setNCharacterStream(int parameterIndex, Reader value, long length)");
     throw new UnsupportedOperationException("Not implemented");
   }
@@ -313,7 +316,8 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+      throws SQLException {
     LOGGER.debug("public void setBlob(int parameterIndex, InputStream inputStream, long length)");
     throw new UnsupportedOperationException("Not implemented");
   }
@@ -331,8 +335,10 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
-    LOGGER.debug("public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
+  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+      throws SQLException {
+    LOGGER.debug(
+        "public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)");
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -349,7 +355,8 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+      throws SQLException {
     LOGGER.debug("public void setCharacterStream(int parameterIndex, Reader reader, long length)");
     throw new UnsupportedOperationException("Not implemented");
   }

--- a/src/main/java/com/databricks/jdbc/core/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksResultSet.java
@@ -5,7 +5,6 @@ import com.databricks.jdbc.core.converters.*;
 import com.databricks.sdk.service.sql.ResultData;
 import com.databricks.sdk.service.sql.ResultManifest;
 import com.databricks.sdk.service.sql.StatementStatus;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -31,11 +30,17 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
   private boolean isClosed;
 
   public DatabricksResultSet(
-      StatementStatus statementStatus, String statementId, ResultData resultData, ResultManifest resultManifest,
-      StatementType statementType, IDatabricksSession session, IDatabricksStatement parentStatement) {
+      StatementStatus statementStatus,
+      String statementId,
+      ResultData resultData,
+      ResultManifest resultManifest,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatement parentStatement) {
     this.statementStatus = statementStatus;
     this.statementId = statementId;
-    this.executionResult = ExecutionResultFactory.getResultSet(resultData, resultManifest, statementId, session);
+    this.executionResult =
+        ExecutionResultFactory.getResultSet(resultData, resultManifest, statementId, session);
     this.resultSetMetaData = new DatabricksResultSetMetaData(statementId, resultManifest);
     this.statementType = statementType;
     this.updateCount = null;
@@ -43,24 +48,52 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     this.isClosed = false;
   }
 
-  public DatabricksResultSet(StatementStatus statementStatus, String statementId, List<String> columnNames, List<String> columnTypeText,
-                             List<Integer> columnTypes, List<Integer> columnTypePrecisions, Object[][] rows, StatementType statementType) {
+  public DatabricksResultSet(
+      StatementStatus statementStatus,
+      String statementId,
+      List<String> columnNames,
+      List<String> columnTypeText,
+      List<Integer> columnTypes,
+      List<Integer> columnTypePrecisions,
+      Object[][] rows,
+      StatementType statementType) {
     this.statementStatus = statementStatus;
     this.statementId = statementId;
     this.executionResult = ExecutionResultFactory.getResultSet(rows);
-    this.resultSetMetaData = new DatabricksResultSetMetaData(statementId, columnNames, columnTypeText, columnTypes, columnTypePrecisions, rows.length);
+    this.resultSetMetaData =
+        new DatabricksResultSetMetaData(
+            statementId,
+            columnNames,
+            columnTypeText,
+            columnTypes,
+            columnTypePrecisions,
+            rows.length);
     this.statementType = statementType;
     this.updateCount = null;
     this.parentStatement = null;
     this.isClosed = false;
   }
 
-  public DatabricksResultSet(StatementStatus statementStatus, String statementId, List<String> columnNames, List<String> columnTypeText,
-                             List<Integer> columnTypes, List<Integer> columnTypePrecisions, List<List<Object>> rows, StatementType statementType) {
+  public DatabricksResultSet(
+      StatementStatus statementStatus,
+      String statementId,
+      List<String> columnNames,
+      List<String> columnTypeText,
+      List<Integer> columnTypes,
+      List<Integer> columnTypePrecisions,
+      List<List<Object>> rows,
+      StatementType statementType) {
     this.statementStatus = statementStatus;
     this.statementId = statementId;
     this.executionResult = ExecutionResultFactory.getResultSet(rows);
-    this.resultSetMetaData = new DatabricksResultSetMetaData(statementId, columnNames, columnTypeText, columnTypes, columnTypePrecisions, rows.size());
+    this.resultSetMetaData =
+        new DatabricksResultSetMetaData(
+            statementId,
+            columnNames,
+            columnTypeText,
+            columnTypes,
+            columnTypePrecisions,
+            rows.size());
     this.statementType = statementType;
     this.updateCount = null;
     this.parentStatement = null;
@@ -90,11 +123,12 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     return this == null;
   }
 
-  // TODO (Madhav): Clean up code by removing code duplicity by having common functions that branch out and to reuse converter objects.
+  // TODO (Madhav): Clean up code by removing code duplicity by having common functions that branch
+  // out and to reuse converter objects.
   @Override
   public String getString(int columnIndex) throws SQLException {
     Object obj = getObjectInternal(columnIndex);
-    if(obj == null) {
+    if (obj == null) {
       return null;
     }
     int columnType = resultSetMetaData.getColumnType(columnIndex);
@@ -662,12 +696,14 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
+  public void updateBinaryStream(String columnLabel, InputStream x, int length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
+  public void updateCharacterStream(String columnLabel, Reader reader, int length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -957,7 +993,8 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
   }
 
   @Override
-  public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+  public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -977,27 +1014,32 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+  public void updateAsciiStream(String columnLabel, InputStream x, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+  public void updateBinaryStream(String columnLabel, InputStream x, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+  public void updateCharacterStream(String columnLabel, Reader reader, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+  public void updateBlob(int columnIndex, InputStream inputStream, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+  public void updateBlob(String columnLabel, InputStream inputStream, long length)
+      throws SQLException {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -1128,8 +1170,7 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     }
     if (this.statementType == StatementType.METADATA || this.statementType == StatementType.QUERY) {
       updateCount = 0L;
-    }
-    else if (hasUpdateCount()) {
+    } else if (hasUpdateCount()) {
       long rowsUpdated = 0;
       while (next()) {
         rowsUpdated += this.getLong(AFFECTED_ROWS_COUNT);
@@ -1158,9 +1199,7 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     return executionResult.getObject(columnIndex - 1);
   }
 
-  /**
-   * For String values, return value without decimal fraction
-   */
+  /** For String values, return value without decimal fraction */
   private String getNumberStringWithoutDecimal(String s, int columnType) {
     if (s.contains(DECIMAL) && (columnType == Types.DOUBLE || columnType == Types.FLOAT)) {
       return s.substring(0, s.indexOf(DECIMAL));
@@ -1168,8 +1207,9 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     return s;
   }
 
-  private AbstractObjectConverter getObjectConverter(Object object, int columnType) throws DatabricksSQLException {
-    switch(columnType) {
+  private AbstractObjectConverter getObjectConverter(Object object, int columnType)
+      throws DatabricksSQLException {
+    switch (columnType) {
       case Types.TINYINT:
         return new ByteConverter(object);
       case Types.SMALLINT:

--- a/src/main/java/com/databricks/jdbc/core/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksResultSetMetaData.java
@@ -5,7 +5,6 @@ import com.databricks.sdk.service.sql.ColumnInfoTypeName;
 import com.databricks.sdk.service.sql.ResultManifest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -26,10 +25,11 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     ImmutableMap.Builder<String, Integer> columnIndexBuilder = ImmutableMap.builder();
     int currIndex = 0;
     for (ColumnInfo columnInfo : resultManifest.getSchema().getColumns()) {
-      ImmutableDatabricksColumn.Builder columnBuilder = ImmutableDatabricksColumn.builder()
-          .columnName(columnInfo.getName())
-          .columnType(getColumnType(columnInfo.getTypeName()))
-          .columnTypeText(columnInfo.getTypeText());
+      ImmutableDatabricksColumn.Builder columnBuilder =
+          ImmutableDatabricksColumn.builder()
+              .columnName(columnInfo.getName())
+              .columnType(getColumnType(columnInfo.getTypeName()))
+              .columnTypeText(columnInfo.getTypeText());
       if (columnInfo.getTypePrecision() != null) {
         columnBuilder.typePrecision(columnInfo.getTypePrecision().intValue());
       } else if (columnInfo.getTypeName().equals(ColumnInfoTypeName.STRING)) {
@@ -46,15 +46,21 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.totalRows = resultManifest.getTotalRowCount();
   }
 
-  public DatabricksResultSetMetaData(String statementId, List<String> columnNames, List<String> columnTypeText,
-     List<Integer> columnTypes, List<Integer> columnTypePrecisions, long totalRows) {
+  public DatabricksResultSetMetaData(
+      String statementId,
+      List<String> columnNames,
+      List<String> columnTypeText,
+      List<Integer> columnTypes,
+      List<Integer> columnTypePrecisions,
+      long totalRows) {
     // TODO: instead of passing precisions, maybe it can be set by default?
     this.statementId = statementId;
 
     ImmutableList.Builder<ImmutableDatabricksColumn> columnsBuilder = ImmutableList.builder();
     ImmutableMap.Builder<String, Integer> columnIndexBuilder = ImmutableMap.builder();
     for (int i = 0; i < columnNames.size(); i++) {
-      ImmutableDatabricksColumn.Builder columnBuilder = ImmutableDatabricksColumn.builder()
+      ImmutableDatabricksColumn.Builder columnBuilder =
+          ImmutableDatabricksColumn.builder()
               .columnName(columnNames.get(i))
               .columnType(columnTypes.get(i))
               .columnTypeText(columnTypeText.get(i))
@@ -106,7 +112,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
 
   @Override
   public int getColumnDisplaySize(int column) throws SQLException {
-    //TODO: to be fixed
+    // TODO: to be fixed
     return 10;
   }
 
@@ -234,6 +240,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
 
   /**
    * Returns index of column-name in metadata starting from 1
+   *
    * @param columnName column-name
    * @return index of column if exists, else -1
    */

--- a/src/main/java/com/databricks/jdbc/core/DatabricksSQLException.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksSQLException.java
@@ -2,9 +2,7 @@ package com.databricks.jdbc.core;
 
 import java.sql.SQLException;
 
-/**
- * Top level exception for Databricks driver
- */
+/** Top level exception for Databricks driver */
 public class DatabricksSQLException extends SQLException {
 
   public DatabricksSQLException(String reason, String sqlState, int vendorCode) {

--- a/src/main/java/com/databricks/jdbc/core/DatabricksSQLFeatureNotSupportedException.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksSQLFeatureNotSupportedException.java
@@ -4,6 +4,7 @@ import java.sql.SQLFeatureNotSupportedException;
 
 public class DatabricksSQLFeatureNotSupportedException extends SQLFeatureNotSupportedException {
   String featureName;
+
   public DatabricksSQLFeatureNotSupportedException(String reason) {
     // TODO: Add proper error code
     super(reason);

--- a/src/main/java/com/databricks/jdbc/core/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksSession.java
@@ -4,14 +4,11 @@ import com.databricks.jdbc.client.DatabricksClient;
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
-/**
- * Implementation for Session interface, which maintains an underlying session in SQL Gateway.
- */
+/** Implementation for Session interface, which maintains an underlying session in SQL Gateway. */
 public class DatabricksSession implements IDatabricksSession {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksSession.class);
@@ -28,6 +25,7 @@ public class DatabricksSession implements IDatabricksSession {
 
   /**
    * Creates an instance of Databricks session for given connection context
+   *
    * @param connectionContext underlying connection context
    */
   public DatabricksSession(IDatabricksConnectionContext connectionContext) {
@@ -37,11 +35,10 @@ public class DatabricksSession implements IDatabricksSession {
     this.warehouseId = connectionContext.getWarehouse();
   }
 
-  /**
-   * Construct method to be used for mocking in a test case.
-   */
+  /** Construct method to be used for mocking in a test case. */
   @VisibleForTesting
-  DatabricksSession(IDatabricksConnectionContext connectionContext, DatabricksClient databricksClient) {
+  DatabricksSession(
+      IDatabricksConnectionContext connectionContext, DatabricksClient databricksClient) {
     this.databricksClient = databricksClient;
     this.isSessionOpen = false;
     this.session = null;

--- a/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
@@ -1,13 +1,11 @@
 package com.databricks.jdbc.core;
 
-
 import com.databricks.jdbc.client.StatementType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.*;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksStatement implements IDatabricksStatement, Statement {
 
@@ -39,8 +37,7 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   @Override
   public int executeUpdate(String sql) throws SQLException {
     checkIfClosed();
-    executeInternal(
-            sql, new HashMap<Integer, ImmutableSqlParameter>(), StatementType.UPDATE);
+    executeInternal(sql, new HashMap<Integer, ImmutableSqlParameter>(), StatementType.UPDATE);
     return (int) resultSet.getUpdateCount();
   }
 
@@ -133,7 +130,8 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   @Override
   public boolean execute(String sql) throws SQLException {
     checkIfClosed();
-    resultSet = executeInternal(sql, new HashMap<Integer, ImmutableSqlParameter>(), StatementType.SQL);
+    resultSet =
+        executeInternal(sql, new HashMap<Integer, ImmutableSqlParameter>(), StatementType.SQL);
     return !resultSet.hasUpdateCount();
   }
 
@@ -203,7 +201,8 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   public void addBatch(String sql) throws SQLException {
     LOGGER.debug("public void addBatch(String sql = {})", sql);
     checkIfClosed();
-    throw new DatabricksSQLFeatureNotSupportedException("Method not supported", "addBatch(String sql)");
+    throw new DatabricksSQLFeatureNotSupportedException(
+        "Method not supported", "addBatch(String sql)");
   }
 
   @Override
@@ -344,6 +343,7 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
     LOGGER.debug("public boolean isWrapperFor(Class<?> iface)");
     throw new UnsupportedOperationException("Not implemented");
   }
+
   @Override
   public void handleResultSetClose(IDatabricksResultSet resultSet) throws SQLException {
     // Don't throw exception, we are already closing here
@@ -352,11 +352,25 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
     }
   }
 
-  DatabricksResultSet executeInternal(String sql, Map<Integer, ImmutableSqlParameter> params, StatementType statementType)
-          throws SQLException {
-    LOGGER.debug("DatabricksResultSet executeInternal(String sql = {}, Map<Integer, ImmutableSqlParameter> params = {}, StatementType statementType = {})", sql, params, statementType);
-    resultSet = connection.getSession().getDatabricksClient().executeStatement(
-        sql, connection.getSession().getWarehouseId(), params, statementType, connection.getSession(), this);
+  DatabricksResultSet executeInternal(
+      String sql, Map<Integer, ImmutableSqlParameter> params, StatementType statementType)
+      throws SQLException {
+    LOGGER.debug(
+        "DatabricksResultSet executeInternal(String sql = {}, Map<Integer, ImmutableSqlParameter> params = {}, StatementType statementType = {})",
+        sql,
+        params,
+        statementType);
+    resultSet =
+        connection
+            .getSession()
+            .getDatabricksClient()
+            .executeStatement(
+                sql,
+                connection.getSession().getWarehouseId(),
+                params,
+                statementType,
+                connection.getSession(),
+                this);
     this.isClosed = false;
     return resultSet;
   }

--- a/src/main/java/com/databricks/jdbc/core/DatabricksTypes.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksTypes.java
@@ -5,7 +5,8 @@ import java.sql.Timestamp;
 import java.sql.Types;
 
 /**
- * Databricks types as supported in https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
+ * Databricks types as supported in
+ * https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
  */
 public class DatabricksTypes {
 
@@ -31,6 +32,7 @@ public class DatabricksTypes {
   /**
    * Converts SQL type into Databricks type as defined in
    * https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
+   *
    * @param sqlType SQL type input
    * @return databricks type
    */
@@ -80,6 +82,7 @@ public class DatabricksTypes {
   /**
    * Infers Databricks type from class of given object as defined in
    * https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
+   *
    * @param obj input object
    * @return inferred Databricks type
    */

--- a/src/main/java/com/databricks/jdbc/core/EmptyResultSet.java
+++ b/src/main/java/com/databricks/jdbc/core/EmptyResultSet.java
@@ -8,9 +8,7 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.Map;
 
-/**
- * Empty implementation of ResultSet
- */
+/** Empty implementation of ResultSet */
 class EmptyResultSet implements ResultSet {
   private boolean isClosed;
 
@@ -510,8 +508,7 @@ class EmptyResultSet implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x, int length)
-      throws SQLException {
+  public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
     checkIfClosed();
   }
 
@@ -854,8 +851,7 @@ class EmptyResultSet implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x, long length)
-      throws SQLException {
+  public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
     checkIfClosed();
   }
 

--- a/src/main/java/com/databricks/jdbc/core/ExecutionResultFactory.java
+++ b/src/main/java/com/databricks/jdbc/core/ExecutionResultFactory.java
@@ -2,7 +2,6 @@ package com.databricks.jdbc.core;
 
 import com.databricks.sdk.service.sql.ResultData;
 import com.databricks.sdk.service.sql.ResultManifest;
-
 import java.util.List;
 
 class ExecutionResultFactory {

--- a/src/main/java/com/databricks/jdbc/core/IDatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/core/IDatabricksConnection.java
@@ -2,24 +2,19 @@ package com.databricks.jdbc.core;
 
 import java.sql.Connection;
 
-/**
- * Interface providing Databricks specific Connection APIs.
- */
+/** Interface providing Databricks specific Connection APIs. */
 public interface IDatabricksConnection {
 
-  /**
-   * Returns the underlying session for the connection.
-   */
+  /** Returns the underlying session for the connection. */
   IDatabricksSession getSession();
 
   /**
    * Closes a statement from the connection's active set.
+   *
    * @param statement
    */
   void closeStatement(IDatabricksStatement statement);
 
-  /**
-   * Returns the corresponding sql connection object
-   */
+  /** Returns the corresponding sql connection object */
   Connection getConnection();
 }

--- a/src/main/java/com/databricks/jdbc/core/IDatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/core/IDatabricksResultSet.java
@@ -1,7 +1,6 @@
 package com.databricks.jdbc.core;
 
 import com.databricks.sdk.service.sql.StatementStatus;
-
 import java.sql.SQLException;
 
 public interface IDatabricksResultSet {

--- a/src/main/java/com/databricks/jdbc/core/IDatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/core/IDatabricksSession.java
@@ -1,16 +1,14 @@
 package com.databricks.jdbc.core;
 
 import com.databricks.jdbc.client.DatabricksClient;
-
 import javax.annotation.Nullable;
 
-/**
- * Session interface to represent an open connection to Databricks server.
- */
+/** Session interface to represent an open connection to Databricks server. */
 public interface IDatabricksSession {
 
   /**
    * Get the unique session-Id associated with the session.
+   *
    * @return session-Id
    */
   @Nullable
@@ -18,48 +16,36 @@ public interface IDatabricksSession {
 
   /**
    * Get the warehouse associated with the session.
+   *
    * @return warehouse-Id
    */
   String getWarehouseId();
 
   /**
    * Checks if session is open and valid.
+   *
    * @return true if session is open
    */
   boolean isOpen();
 
-  /**
-   * Opens a new session.
-   */
+  /** Opens a new session. */
   void open();
 
-  /**
-   * Closes the session.
-   */
+  /** Closes the session. */
   void close();
 
-  /**
-   * Returns the client for connecting to Databricks server
-   */
+  /** Returns the client for connecting to Databricks server */
   DatabricksClient getDatabricksClient();
 
-  /**
-   * Returns default catalog associated with the session
-   */
+  /** Returns default catalog associated with the session */
   String getCatalog();
 
-  /**
-   * Returns default schema associated with the session
-   */
+  /** Returns default schema associated with the session */
   String getSchema();
 
-  /**
-   * Sets the default catalog
-   */
+  /** Sets the default catalog */
   void setCatalog(String catalog);
 
-  /**
-   * Sets the default schema
-   */
+  /** Sets the default schema */
   void setSchema(String schema);
 }

--- a/src/main/java/com/databricks/jdbc/core/IDatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/core/IDatabricksStatement.java
@@ -2,14 +2,10 @@ package com.databricks.jdbc.core;
 
 import java.sql.SQLException;
 
-/**
- * Interface for Databricks specific statement.
- */
+/** Interface for Databricks specific statement. */
 public interface IDatabricksStatement {
 
-  /**
-   * Returns the underlying session-Id for the statement.
-   */
+  /** Returns the underlying session-Id for the statement. */
   String getSessionId();
 
   void close(boolean removeFromSession) throws SQLException;

--- a/src/main/java/com/databricks/jdbc/core/IExecutionResult.java
+++ b/src/main/java/com/databricks/jdbc/core/IExecutionResult.java
@@ -2,13 +2,12 @@ package com.databricks.jdbc.core;
 
 import java.sql.SQLException;
 
-/**
- * Interface to provide methods over an underlying statement result
- */
+/** Interface to provide methods over an underlying statement result */
 interface IExecutionResult {
 
   /**
    * Get the object for given column index. Here index starts with 0.
+   *
    * @param columnIndex index of column starting with 0
    * @return object at given index
    * @throws SQLException
@@ -17,23 +16,21 @@ interface IExecutionResult {
 
   /**
    * Gets the current row position, starting with 0.
+   *
    * @return the current row position
    */
   long getCurrentRow();
 
   /**
    * Moves the cursor to next row and returns true if this can be done
+   *
    * @return true if cursor is moved at next row
    */
   boolean next();
 
-  /**
-   * Returns if there is next row in the result set
-   */
+  /** Returns if there is next row in the result set */
   boolean hasNext();
 
-  /**
-   * Closes the result set and releases any in-memory chunks or data
-   */
+  /** Closes the result set and releases any in-memory chunks or data */
   void close();
 }

--- a/src/main/java/com/databricks/jdbc/core/InlineJsonResult.java
+++ b/src/main/java/com/databricks/jdbc/core/InlineJsonResult.java
@@ -4,7 +4,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.databricks.sdk.service.sql.ResultData;
 import com.databricks.sdk.service.sql.ResultManifest;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,14 +23,29 @@ public class InlineJsonResult implements IExecutionResult {
     this.currentRow = -1;
     this.isClosed = false;
   }
+
   InlineJsonResult(Object[][] rows) {
-    this.data = Arrays.stream(rows).map(a -> Arrays.stream(a).map(o -> o == null ? null : o.toString()).collect(Collectors.toList())).collect(Collectors.toList());
+    this.data =
+        Arrays.stream(rows)
+            .map(
+                a ->
+                    Arrays.stream(a)
+                        .map(o -> o == null ? null : o.toString())
+                        .collect(Collectors.toList()))
+            .collect(Collectors.toList());
     this.currentRow = -1;
     this.isClosed = false;
   }
 
   InlineJsonResult(List<List<Object>> rows) {
-    this.data = rows.stream().map(a -> a.stream().map(o -> o == null ? null : o.toString()).collect(Collectors.toList())).collect(Collectors.toList());
+    this.data =
+        rows.stream()
+            .map(
+                a ->
+                    a.stream()
+                        .map(o -> o == null ? null : o.toString())
+                        .collect(Collectors.toList()))
+            .collect(Collectors.toList());
     this.currentRow = -1;
     this.isClosed = false;
   }
@@ -40,7 +54,9 @@ public class InlineJsonResult implements IExecutionResult {
     if (dataArray == null) {
       return new ArrayList<>();
     }
-    return dataArray.stream().map(c -> c.stream().collect(toImmutableList())).collect(toImmutableList());
+    return dataArray.stream()
+        .map(c -> c.stream().collect(toImmutableList()))
+        .collect(toImmutableList());
   }
 
   @Override
@@ -72,8 +88,7 @@ public class InlineJsonResult implements IExecutionResult {
   }
 
   @Override
-  public synchronized boolean hasNext()
-  {
+  public synchronized boolean hasNext() {
     return !this.isClosed() && currentRow < data.size() - 1;
   }
 

--- a/src/main/java/com/databricks/jdbc/core/SingleChunkDownloader.java
+++ b/src/main/java/com/databricks/jdbc/core/SingleChunkDownloader.java
@@ -2,19 +2,17 @@ package com.databricks.jdbc.core;
 
 import com.databricks.jdbc.client.DatabricksHttpException;
 import com.databricks.jdbc.client.IDatabricksHttpClient;
-
 import java.util.concurrent.Callable;
 
-/**
- * Task class to manage download for a single chunk.
- */
+/** Task class to manage download for a single chunk. */
 class SingleChunkDownloader implements Callable<Void> {
 
   private final ArrowResultChunk chunk;
   private final IDatabricksHttpClient httpClient;
   private final ChunkDownloader chunkDownloader;
 
-  SingleChunkDownloader(ArrowResultChunk chunk, IDatabricksHttpClient httpClient, ChunkDownloader chunkDownloader) {
+  SingleChunkDownloader(
+      ArrowResultChunk chunk, IDatabricksHttpClient httpClient, ChunkDownloader chunkDownloader) {
     this.chunk = chunk;
     this.httpClient = httpClient;
     this.chunkDownloader = chunkDownloader;

--- a/src/main/java/com/databricks/jdbc/core/SqlParameter.java
+++ b/src/main/java/com/databricks/jdbc/core/SqlParameter.java
@@ -6,6 +6,8 @@ import org.immutables.value.Value;
 public interface SqlParameter {
 
   Object value();
+
   String type();
+
   int cardinal();
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/AbstractObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/AbstractObjectConverter.java
@@ -1,75 +1,77 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.sql.Date;
+import java.sql.Timestamp;
 
 public abstract class AbstractObjectConverter {
 
-    // TODO (Madhav): Ensure proper handling of null values in the conversions.
-    long[] POWERS_OF_TEN = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
+  // TODO (Madhav): Ensure proper handling of null values in the conversions.
+  long[] POWERS_OF_TEN = {
+    1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
+  };
 
-    int DEFAULT_TIMESTAMP_SCALE = 3;
-    Object object;
-    AbstractObjectConverter(Object object) throws DatabricksSQLException {
-        this.object = object;
-    }
+  int DEFAULT_TIMESTAMP_SCALE = 3;
+  Object object;
 
-    public byte convertToByte() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  AbstractObjectConverter(Object object) throws DatabricksSQLException {
+    this.object = object;
+  }
 
-    public short convertToShort() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public byte convertToByte() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public int convertToInt() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public short convertToShort() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public long convertToLong() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public int convertToInt() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public float convertToFloat() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public long convertToLong() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public double convertToDouble() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public float convertToFloat() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public double convertToDouble() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public char convertToChar() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public String convertToString() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public char convertToChar() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public String convertToString() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 
-    public Date convertToDate() throws DatabricksSQLException {
-        throw new DatabricksSQLException("Unsupported conversion operation");
-    }
+  public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
+
+  public Date convertToDate() throws DatabricksSQLException {
+    throw new DatabricksSQLException("Unsupported conversion operation");
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/BigDecimalConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/BigDecimalConverter.java
@@ -1,90 +1,84 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 
 public class BigDecimalConverter extends AbstractObjectConverter {
 
-    private BigDecimal object;
-    public BigDecimalConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = new BigDecimal((String) object);
-        }
-        else {
-            this.object = (BigDecimal) object;
-        }
-    }
+  private BigDecimal object;
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return this.object;
+  public BigDecimalConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = new BigDecimal((String) object);
+    } else {
+      this.object = (BigDecimal) object;
     }
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        try {
-            return this.object.toBigInteger().byteValueExact();
-        }
-        catch(ArithmeticException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return this.object.toBigInteger().toByteArray();
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    try {
+      return this.object.toBigInteger().byteValueExact();
+    } catch (ArithmeticException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        try {
-            return this.object.toBigInteger().shortValueExact();
-        }
-        catch(ArithmeticException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return this.object.toBigInteger().toByteArray();
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        try {
-            return this.object.toBigInteger().intValueExact();
-        }
-        catch(ArithmeticException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    try {
+      return this.object.toBigInteger().shortValueExact();
+    } catch (ArithmeticException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        try {
-            return this.object.toBigInteger().longValueExact();
-        }
-        catch(ArithmeticException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    try {
+      return this.object.toBigInteger().intValueExact();
+    } catch (ArithmeticException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return this.object.floatValue();
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    try {
+      return this.object.toBigInteger().longValueExact();
+    } catch (ArithmeticException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return this.object.doubleValue();
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return this.object.floatValue();
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return this.object.equals(BigDecimal.valueOf(0)) ? false : true;
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return this.object.doubleValue();
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return this.object.equals(BigDecimal.valueOf(0)) ? false : true;
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/BooleanConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/BooleanConverter.java
@@ -1,74 +1,73 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
 
 public class BooleanConverter extends AbstractObjectConverter {
 
-    private Boolean object;
-    public BooleanConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Boolean.parseBoolean((String) object);
-        }
-        else {
-            this.object = (boolean) object;
-        }
-    }
+  private Boolean object;
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return this.object;
+  public BooleanConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Boolean.parseBoolean((String) object);
+    } else {
+      this.object = (boolean) object;
     }
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        return (byte) (this.object ? 1 : 0);
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        return (short) (this.object ? 1 : 0);
-    }
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    return (byte) (this.object ? 1 : 0);
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        return this.object ? 1 : 0;
-    }
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    return (short) (this.object ? 1 : 0);
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return this.object ? 1L : 0L;
-    }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    return this.object ? 1 : 0;
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return this.object ? 1f : 0f;
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return this.object ? 1L : 0L;
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) (this.object ? 1 : 0);
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return this.object ? 1f : 0f;
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return BigDecimal.valueOf(this.object ? 1 : 0);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) (this.object ? 1 : 0);
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return this.object ? new byte[]{1} : new byte[]{0};
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return BigDecimal.valueOf(this.object ? 1 : 0);
+  }
 
-    @Override
-    public char convertToChar() throws DatabricksSQLException {
-        return this.object ? '1' : '0';
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return this.object ? new byte[] {1} : new byte[] {0};
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public char convertToChar() throws DatabricksSQLException {
+    return this.object ? '1' : '0';
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/ByteConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/ByteConverter.java
@@ -1,69 +1,68 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
 
 public class ByteConverter extends AbstractObjectConverter {
 
-    private byte object;
-    public ByteConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Byte.parseByte((String) object);
-        }
-        else {
-            this.object = (byte) object;
-        }
-    }
+  private byte object;
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        return this.object;
+  public ByteConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Byte.parseByte((String) object);
+    } else {
+      this.object = (byte) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0 ? false : true);
-    }
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        return (short) this.object;
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0 ? false : true);
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        return (int) this.object;
-    }
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    return (short) this.object;
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return (long) this.object;
-    }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    return (int) this.object;
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return (float) this.object;
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return (long) this.object;
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) this.object;
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return (float) this.object;
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return BigDecimal.valueOf((long) this.object);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) this.object;
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return new byte[]{this.object};
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return BigDecimal.valueOf((long) this.object);
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return new String(new byte[]{this.object});
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return new byte[] {this.object};
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return new String(new byte[] {this.object});
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/DateConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/DateConverter.java
@@ -1,8 +1,6 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
-import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -10,53 +8,53 @@ import java.time.temporal.ChronoUnit;
 
 public class DateConverter extends AbstractObjectConverter {
 
-    private Date object;
-    public DateConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Date.valueOf((String) object);
-        }
-        else {
-            this.object = (Date) object;
-        }
-    }
+  private Date object;
 
-    @Override
-    public Date convertToDate() throws DatabricksSQLException {
-        return this.object;
+  public DateConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Date.valueOf((String) object);
+    } else {
+      this.object = (Date) object;
     }
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        long epochDays = convertToLong();
-        if((short) epochDays == epochDays) {
-            return (short) epochDays;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public Date convertToDate() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        long epochDays = convertToLong();
-        if((int) epochDays == epochDays) {
-            return (int) epochDays;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    long epochDays = convertToLong();
+    if ((short) epochDays == epochDays) {
+      return (short) epochDays;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        LocalDate localStartDate = LocalDate.ofEpochDay(0);
-        return ChronoUnit.DAYS.between(localStartDate, this.object.toLocalDate());
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    long epochDays = convertToLong();
+    if ((int) epochDays == epochDays) {
+      return (int) epochDays;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return this.object.toString();
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    LocalDate localStartDate = LocalDate.ofEpochDay(0);
+    return ChronoUnit.DAYS.between(localStartDate, this.object.toLocalDate());
+  }
 
-    @Override
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        return Timestamp.valueOf(this.object.toLocalDate().atStartOfDay());
-    }
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return this.object.toString();
+  }
+
+  @Override
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    return Timestamp.valueOf(this.object.toLocalDate().atStartOfDay());
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/DoubleConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/DoubleConverter.java
@@ -1,86 +1,84 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.nio.ByteBuffer;
 
 public class DoubleConverter extends AbstractObjectConverter {
 
-    private double object;
-    public DoubleConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Double.parseDouble((String) object);
-        }
-        else {
-            this.object = (double) object;
-        }
-    }
+  private double object;
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return this.object;
+  public DoubleConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Double.parseDouble((String) object);
+    } else {
+      this.object = (double) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0f ? false : true);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        if(this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
-            return (byte) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0f ? false : true);
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        if(this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
-            return (short) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    if (this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
+      return (byte) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        if(this.object >= Integer.MIN_VALUE && this.object <= Integer.MAX_VALUE) {
-            return (int) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    if (this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
+      return (short) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        if(this.object >= Long.MIN_VALUE && this.object < Long.MAX_VALUE) {
-            return (long) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    if (this.object >= Integer.MIN_VALUE && this.object <= Integer.MAX_VALUE) {
+      return (int) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        if(this.object >= -Float.MAX_VALUE && this.object <= Float.MAX_VALUE) {
-            return (float) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    if (this.object >= Long.MIN_VALUE && this.object < Long.MAX_VALUE) {
+      return (long) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return new BigDecimal(Double.toString(this.object));
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    if (this.object >= -Float.MAX_VALUE && this.object <= Float.MAX_VALUE) {
+      return (float) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return ByteBuffer.allocate(8).putDouble(this.object).array();
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return new BigDecimal(Double.toString(this.object));
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return ByteBuffer.allocate(8).putDouble(this.object).array();
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/FloatConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/FloatConverter.java
@@ -1,82 +1,81 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.nio.ByteBuffer;
 
 public class FloatConverter extends AbstractObjectConverter {
 
-    private float object;
-    public FloatConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Float.parseFloat((String) object);
-        }
-        else {
-            this.object = (float) object;
-        }
-    }
+  private float object;
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return this.object;
+  public FloatConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Float.parseFloat((String) object);
+    } else {
+      this.object = (float) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0f ? false : true);
-    }
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        if(this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
-            return (byte) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        if(this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
-            return (short) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0f ? false : true);
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        if(this.object >= Integer.MIN_VALUE && this.object < Integer.MAX_VALUE) {
-            return (int) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    if (this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
+      return (byte) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        if(this.object >= Long.MIN_VALUE && this.object < Long.MAX_VALUE) {
-            return (long) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    if (this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
+      return (short) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) this.object;
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    if (this.object >= Integer.MIN_VALUE && this.object < Integer.MAX_VALUE) {
+      return (int) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return new BigDecimal(Float.toString(this.object));
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    if (this.object >= Long.MIN_VALUE && this.object < Long.MAX_VALUE) {
+      return (long) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return ByteBuffer.allocate(4).putFloat(this.object).array();
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) this.object;
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return new BigDecimal(Float.toString(this.object));
+  }
+
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return ByteBuffer.allocate(4).putFloat(this.object).array();
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/IntConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/IntConverter.java
@@ -1,101 +1,100 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.nio.ByteBuffer;
 
 public class IntConverter extends AbstractObjectConverter {
 
-    private int object;
-    public IntConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Integer.parseInt((String) object);
-        }
-        else {
-            this.object = (int) object;
-        }
-    }
+  private int object;
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        return this.object;
+  public IntConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Integer.parseInt((String) object);
+    } else {
+      this.object = (int) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0 ? false : true);
-    }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        if(this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
-            return (byte) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0 ? false : true);
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        if(this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
-            return (short) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    if (this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
+      return (byte) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return (long) this.object;
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    if (this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
+      return (short) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return (float) this.object;
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return (long) this.object;
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) this.object;
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return (float) this.object;
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return BigDecimal.valueOf((long) this.object);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) this.object;
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return ByteBuffer.allocate(4).putInt(this.object).array();
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return BigDecimal.valueOf((long) this.object);
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return ByteBuffer.allocate(4).putInt(this.object).array();
+  }
 
-    @Override
-    public Date convertToDate() throws DatabricksSQLException {
-        LocalDate localDate = LocalDate.ofEpochDay(this.object);
-        return Date.valueOf(localDate);
-    }
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 
-    @Override
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        return convertToTimestamp(super.DEFAULT_TIMESTAMP_SCALE);
-    }
+  @Override
+  public Date convertToDate() throws DatabricksSQLException {
+    LocalDate localDate = LocalDate.ofEpochDay(this.object);
+    return Date.valueOf(localDate);
+  }
 
-    @Override
-    public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
-        if(scale > 9) {
-            throw new DatabricksSQLException("Unsupported scale");
-        }
-        long nanoseconds = (long) this.object * super.POWERS_OF_TEN[9 - scale];
-        Time time = new Time(nanoseconds/super.POWERS_OF_TEN[6]);
-        return new Timestamp(time.getTime());
+  @Override
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    return convertToTimestamp(super.DEFAULT_TIMESTAMP_SCALE);
+  }
+
+  @Override
+  public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
+    if (scale > 9) {
+      throw new DatabricksSQLException("Unsupported scale");
     }
+    long nanoseconds = (long) this.object * super.POWERS_OF_TEN[9 - scale];
+    Time time = new Time(nanoseconds / super.POWERS_OF_TEN[6]);
+    return new Timestamp(time.getTime());
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/LongConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/LongConverter.java
@@ -1,105 +1,103 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
-import java.math.MathContext;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.nio.ByteBuffer;
 
 public class LongConverter extends AbstractObjectConverter {
 
-    private long object;
-    public LongConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Long.parseLong((String) object);
-        }
-        else {
-            this.object = (long) object;
-        }
-    }
+  private long object;
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return this.object;
+  public LongConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Long.parseLong((String) object);
+    } else {
+      this.object = (long) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0 ? false : true);
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        if(this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
-            return (byte) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0 ? false : true);
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        if(this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
-            return (short) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    if (this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
+      return (byte) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        if(this.object >= Integer.MIN_VALUE && this.object <= Integer.MAX_VALUE) {
-            return (int) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    if (this.object >= Short.MIN_VALUE && this.object <= Short.MAX_VALUE) {
+      return (short) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return (float) this.object;
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    if (this.object >= Integer.MIN_VALUE && this.object <= Integer.MAX_VALUE) {
+      return (int) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) this.object;
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return (float) this.object;
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return BigDecimal.valueOf(this.object);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) this.object;
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return ByteBuffer.allocate(8).putLong(this.object).array();
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return BigDecimal.valueOf(this.object);
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return ByteBuffer.allocate(8).putLong(this.object).array();
+  }
 
-    @Override
-    public Date convertToDate() throws DatabricksSQLException {
-        LocalDate localDate = LocalDate.ofEpochDay(this.object);
-        return Date.valueOf(localDate);
-    }
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 
-    @Override
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        return convertToTimestamp(super.DEFAULT_TIMESTAMP_SCALE);
-    }
+  @Override
+  public Date convertToDate() throws DatabricksSQLException {
+    LocalDate localDate = LocalDate.ofEpochDay(this.object);
+    return Date.valueOf(localDate);
+  }
 
-    @Override
-    public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
-        if(scale > 9) {
-            throw new DatabricksSQLException("Unsupported scale");
-        }
-        long nanoseconds = this.object * super.POWERS_OF_TEN[9 - scale];
-        Time time = new Time(nanoseconds/super.POWERS_OF_TEN[6]);
-        return new Timestamp(time.getTime());
+  @Override
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    return convertToTimestamp(super.DEFAULT_TIMESTAMP_SCALE);
+  }
+
+  @Override
+  public Timestamp convertToTimestamp(int scale) throws DatabricksSQLException {
+    if (scale > 9) {
+      throw new DatabricksSQLException("Unsupported scale");
     }
+    long nanoseconds = this.object * super.POWERS_OF_TEN[9 - scale];
+    Time time = new Time(nanoseconds / super.POWERS_OF_TEN[6]);
+    return new Timestamp(time.getTime());
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/ShortConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/ShortConverter.java
@@ -1,73 +1,72 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 
 public class ShortConverter extends AbstractObjectConverter {
 
-    private short object;
-    public ShortConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Short.parseShort((String) object);
-        }
-        else {
-            this.object = (short) object;
-        }
-    }
+  private short object;
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        return this.object;
+  public ShortConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Short.parseShort((String) object);
+    } else {
+      this.object = (short) object;
     }
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        return (this.object == 0 ? false : true);
-    }
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        if(this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
-            return (byte) this.object;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    return (this.object == 0 ? false : true);
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        return (int) this.object;
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    if (this.object >= Byte.MIN_VALUE && this.object <= Byte.MAX_VALUE) {
+      return (byte) this.object;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return (long) this.object;
-    }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    return (int) this.object;
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        return (float) this.object;
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return (long) this.object;
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        return (double) this.object;
-    }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    return (float) this.object;
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return BigDecimal.valueOf((long) this.object);
-    }
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    return (double) this.object;
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return ByteBuffer.allocate(2).putShort(this.object).array();
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return BigDecimal.valueOf((long) this.object);
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return String.valueOf(this.object);
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return ByteBuffer.allocate(2).putShort(this.object).array();
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return String.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/StringConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/StringConverter.java
@@ -1,114 +1,113 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 
 public class StringConverter extends AbstractObjectConverter {
 
-    private String object;
-    public StringConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        this.object = (String) object;
-    }
+  private String object;
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return this.object;
-    }
+  public StringConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    this.object = (String) object;
+  }
 
-    @Override
-    public char convertToChar() throws DatabricksSQLException {
-        if(this.object.length() == 1) {
-            return this.object.charAt(0);
-        }
-        throw new DatabricksSQLException("Invalid conversion");
-    }
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public boolean convertToBoolean() throws DatabricksSQLException {
-        if("0".equals(this.object) || "false".equalsIgnoreCase(this.object)) {
-            return false;
-        }
-        else if("1".equals(this.object) || "true".equalsIgnoreCase(this.object)) {
-            return true;
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public char convertToChar() throws DatabricksSQLException {
+    if (this.object.length() == 1) {
+      return this.object.charAt(0);
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public byte convertToByte() throws DatabricksSQLException {
-        byte[] byteArray = this.object.getBytes();
-        if(byteArray.length == 1) {
-            return this.object.getBytes()[0];
-        }
-        throw new DatabricksSQLException("Invalid conversion");
+  @Override
+  public boolean convertToBoolean() throws DatabricksSQLException {
+    if ("0".equals(this.object) || "false".equalsIgnoreCase(this.object)) {
+      return false;
+    } else if ("1".equals(this.object) || "true".equalsIgnoreCase(this.object)) {
+      return true;
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public short convertToShort() throws DatabricksSQLException {
-        try {
-            return Short.parseShort(this.object);
-        } catch (NumberFormatException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public byte convertToByte() throws DatabricksSQLException {
+    byte[] byteArray = this.object.getBytes();
+    if (byteArray.length == 1) {
+      return this.object.getBytes()[0];
     }
+    throw new DatabricksSQLException("Invalid conversion");
+  }
 
-    @Override
-    public int convertToInt() throws DatabricksSQLException {
-        try {
-            return Integer.parseInt(this.object);
-        } catch (NumberFormatException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public short convertToShort() throws DatabricksSQLException {
+    try {
+      return Short.parseShort(this.object);
+    } catch (NumberFormatException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        try {
-            return Long.parseLong(this.object);
-        } catch (NumberFormatException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public int convertToInt() throws DatabricksSQLException {
+    try {
+      return Integer.parseInt(this.object);
+    } catch (NumberFormatException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public float convertToFloat() throws DatabricksSQLException {
-        try {
-            return Float.parseFloat(this.object);
-        } catch (NumberFormatException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    try {
+      return Long.parseLong(this.object);
+    } catch (NumberFormatException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public double convertToDouble() throws DatabricksSQLException {
-        try {
-            return Double.parseDouble(this.object);
-        } catch (NumberFormatException e) {
-            throw new DatabricksSQLException("Invalid conversion");
-        }
+  @Override
+  public float convertToFloat() throws DatabricksSQLException {
+    try {
+      return Float.parseFloat(this.object);
+    } catch (NumberFormatException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
-        return new BigDecimal(this.object);
+  @Override
+  public double convertToDouble() throws DatabricksSQLException {
+    try {
+      return Double.parseDouble(this.object);
+    } catch (NumberFormatException e) {
+      throw new DatabricksSQLException("Invalid conversion");
     }
+  }
 
-    @Override
-    public byte[] convertToByteArray() throws DatabricksSQLException {
-        return this.object.getBytes();
-    }
+  @Override
+  public BigDecimal convertToBigDecimal() throws DatabricksSQLException {
+    return new BigDecimal(this.object);
+  }
 
-    @Override
-    public Date convertToDate() throws DatabricksSQLException {
-        return Date.valueOf(this.object);
-    }
+  @Override
+  public byte[] convertToByteArray() throws DatabricksSQLException {
+    return this.object.getBytes();
+  }
 
-    @Override
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        return Timestamp.valueOf(this.object);
-    }
+  @Override
+  public Date convertToDate() throws DatabricksSQLException {
+    return Date.valueOf(this.object);
+  }
+
+  @Override
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    return Timestamp.valueOf(this.object);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/core/converters/TimestampConverter.java
+++ b/src/main/java/com/databricks/jdbc/core/converters/TimestampConverter.java
@@ -1,41 +1,39 @@
 package com.databricks.jdbc.core.converters;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-
-import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 
 public class TimestampConverter extends AbstractObjectConverter {
 
-    private Timestamp object;
-    public TimestampConverter(Object object) throws DatabricksSQLException {
-        super(object);
-        if (object instanceof String) {
-            this.object = Timestamp.valueOf((String) object);
-        }
-        else {
-            this.object = (Timestamp) object;
-        }
-    }
+  private Timestamp object;
 
-    @Override
-    public Timestamp convertToTimestamp() throws DatabricksSQLException {
-        return this.object;
+  public TimestampConverter(Object object) throws DatabricksSQLException {
+    super(object);
+    if (object instanceof String) {
+      this.object = Timestamp.valueOf((String) object);
+    } else {
+      this.object = (Timestamp) object;
     }
+  }
 
-    @Override
-    public Date convertToDate() throws DatabricksSQLException {
-        return Date.valueOf(this.object.toLocalDateTime().toLocalDate());
-    }
+  @Override
+  public Timestamp convertToTimestamp() throws DatabricksSQLException {
+    return this.object;
+  }
 
-    @Override
-    public long convertToLong() throws DatabricksSQLException {
-        return this.object.getTime();
-    }
+  @Override
+  public Date convertToDate() throws DatabricksSQLException {
+    return Date.valueOf(this.object.toLocalDateTime().toLocalDate());
+  }
 
-    @Override
-    public String convertToString() throws DatabricksSQLException {
-        return this.object.toString();
-    }
+  @Override
+  public long convertToLong() throws DatabricksSQLException {
+    return this.object.getTime();
+  }
+
+  @Override
+  public String convertToString() throws DatabricksSQLException {
+    return this.object.toString();
+  }
 }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
@@ -2,12 +2,11 @@ package com.databricks.jdbc.driver;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksConnectionContext implements IDatabricksConnectionContext {
 
@@ -15,11 +14,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   private final String host;
   private final int port;
 
-  @VisibleForTesting
-  final ImmutableMap<String, String> parameters;
+  @VisibleForTesting final ImmutableMap<String, String> parameters;
 
   /**
    * Parses connection Url and properties into a Databricks specific connection context
+   *
    * @param url Databricks server connection Url
    * @param properties connection properties
    * @return a connection context
@@ -37,7 +36,10 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
       String[] hostAndPort = hostUrlVal.split(DatabricksJdbcConstants.PORT_DELIMITER);
       String hostValue = hostAndPort[0];
-      int portValue = hostAndPort.length == 2 ? Integer.valueOf(hostAndPort[1]) : DatabricksJdbcConstants.DEFAULT_PORT;
+      int portValue =
+          hostAndPort.length == 2
+              ? Integer.valueOf(hostAndPort[1])
+              : DatabricksJdbcConstants.DEFAULT_PORT;
 
       ImmutableMap.Builder<String, String> parametersBuilder = ImmutableMap.builder();
       String[] urlParts = urlMinusHost.split(DatabricksJdbcConstants.URL_DELIMITER);
@@ -62,7 +64,8 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
     throw new IllegalArgumentException("Invalid url incorrect");
   }
 
-  private DatabricksConnectionContext(String host, int port, ImmutableMap<String, String> parameters) {
+  private DatabricksConnectionContext(
+      String host, int port, ImmutableMap<String, String> parameters) {
     this.host = host;
     this.port = port;
     this.parameters = parameters;
@@ -75,11 +78,10 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public String getHostUrl() {
     LOGGER.debug("public String getHostUrl()");
-    StringBuilder hostUrlBuilder = new StringBuilder().append(DatabricksJdbcConstants.HTTPS_SCHEMA)
-        .append(this.host);
+    StringBuilder hostUrlBuilder =
+        new StringBuilder().append(DatabricksJdbcConstants.HTTPS_SCHEMA).append(this.host);
     if (port != 0) {
-      hostUrlBuilder.append(DatabricksJdbcConstants.PORT_DELIMITER)
-          .append(port);
+      hostUrlBuilder.append(DatabricksJdbcConstants.PORT_DELIMITER).append(port);
     }
     return hostUrlBuilder.toString();
   }
@@ -101,7 +103,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
     } else {
       Matcher sqlUrlMatcher = DatabricksJdbcConstants.HTTP_PATH_SQL_PATTERN.matcher(httpPath);
       if (sqlUrlMatcher.matches()) {
-        warehouseId = httpPath.substring(httpPath.lastIndexOf('/') +1);
+        warehouseId = httpPath.substring(httpPath.lastIndexOf('/') + 1);
       } else {
         throw new IllegalArgumentException("Invalid httpPath " + httpPath);
       }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksDriver.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksDriver.java
@@ -1,75 +1,74 @@
 package com.databricks.jdbc.driver;
 
 import com.databricks.jdbc.core.DatabricksConnection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Databricks JDBC driver.
- * TODO: Add implementation to accept Urls in format: jdbc:databricks://host:port.
+ * Databricks JDBC driver. TODO: Add implementation to accept Urls in format:
+ * jdbc:databricks://host:port.
  */
 public class DatabricksDriver implements Driver {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksDriver.class);
-    private static final DatabricksDriver INSTANCE;
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksDriver.class);
+  private static final DatabricksDriver INSTANCE;
 
-    private static int majorVersion = 0;
-    private static int minorVersion = 0;
+  private static int majorVersion = 0;
+  private static int minorVersion = 0;
 
-    static {
-        try {
-            DriverManager.registerDriver(INSTANCE = new DatabricksDriver());
-            System.out.printf("Driver has been registered. instance = %s\n", INSTANCE);
-        } catch (SQLException e) {
-            throw new IllegalStateException("Unable to register " + DatabricksDriver.class, e);
-        }
+  static {
+    try {
+      DriverManager.registerDriver(INSTANCE = new DatabricksDriver());
+      System.out.printf("Driver has been registered. instance = %s\n", INSTANCE);
+    } catch (SQLException e) {
+      throw new IllegalStateException("Unable to register " + DatabricksDriver.class, e);
     }
+  }
 
-    @Override
-    public boolean acceptsURL(String url) {
-        return DatabricksConnectionContext.isValid(url);
-    }
+  @Override
+  public boolean acceptsURL(String url) {
+    return DatabricksConnectionContext.isValid(url);
+  }
 
-    @Override
-    public Connection connect(String url, Properties info) {
-        LOGGER.debug("public Connection connect(String url = {}, Properties info)", url);
-        IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(url, info);
-        return new DatabricksConnection(connectionContext);
-    }
+  @Override
+  public Connection connect(String url, Properties info) {
+    LOGGER.debug("public Connection connect(String url = {}, Properties info)", url);
+    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(url, info);
+    return new DatabricksConnection(connectionContext);
+  }
 
-    @Override
-    public int getMajorVersion() {
-        return majorVersion;
-    }
+  @Override
+  public int getMajorVersion() {
+    return majorVersion;
+  }
 
-    @Override
-    public int getMinorVersion() {
-        return minorVersion;
-    }
+  @Override
+  public int getMinorVersion() {
+    return minorVersion;
+  }
 
-    @Override
-    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
-    @Override
-    public boolean jdbcCompliant() {
-        return false;
-    }
+  @Override
+  public boolean jdbcCompliant() {
+    return false;
+  }
 
-    @Override
-    public java.util.logging.Logger getParentLogger() {
-        return null;
-    }
+  @Override
+  public java.util.logging.Logger getParentLogger() {
+    return null;
+  }
 
-    public static void main(String[] args) {
-        LOGGER.info("The driver {} has been initialized.", DatabricksDriver.class);
-    }
+  public static void main(String[] args) {
+    LOGGER.info("The driver {} has been initialized.", DatabricksDriver.class);
+  }
 }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
@@ -4,7 +4,8 @@ import java.util.regex.Pattern;
 
 public final class DatabricksJdbcConstants {
 
-  static final Pattern JDBC_URL_PATTERN = Pattern.compile("jdbc:databricks:\\/\\/([^/]*)(?::\\d+)?\\/(.*)");
+  static final Pattern JDBC_URL_PATTERN =
+      Pattern.compile("jdbc:databricks:\\/\\/([^/]*)(?::\\d+)?\\/(.*)");
   static final Pattern HTTP_PATH_PATTERN = Pattern.compile(".*\\/warehouses\\/(.*)");
   static final Pattern HTTP_PATH_SQL_PATTERN = Pattern.compile("sql\\/(.*)");
   static final String JDBC_SCHEMA = "jdbc:databricks://";

--- a/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
@@ -3,19 +3,23 @@ package com.databricks.jdbc.driver;
 public interface IDatabricksConnectionContext {
 
   /**
-   * Returns host-Url for Databricks server as parsed from JDBC connection in format https://server:port
+   * Returns host-Url for Databricks server as parsed from JDBC connection in format
+   * https://server:port
+   *
    * @return Databricks host-Url
    */
   String getHostUrl();
 
   /**
    * Returns warehouse-Id as parsed from JDBC connection Url
+   *
    * @return warehouse-Id
    */
   String getWarehouse();
 
   /**
    * Returns the auth token (personal access token/OAuth token etc)
+   *
    * @return auth token
    */
   String getToken();

--- a/src/main/java/com/databricks/jdbc/util/WildcardUtil.java
+++ b/src/main/java/com/databricks/jdbc/util/WildcardUtil.java
@@ -1,45 +1,46 @@
 package com.databricks.jdbc.util;
 
 /**
- * This class consists of utility functions with respect to wildcard strings that are required in building SQL queries
+ * This class consists of utility functions with respect to wildcard strings that are required in
+ * building SQL queries
  */
 public class WildcardUtil {
-    private static final String ASTERISK = "*";
+  private static final String ASTERISK = "*";
 
-    /**
-     * This function checks if the input string is a "match anything" string i.e. "*"
-     *
-     * @param s     the input string
-     * @return true if the input string is "*"
-     */
-    public static boolean isMatchAnything(String s) {
-        return ASTERISK.equals(s);
-    }
+  /**
+   * This function checks if the input string is a "match anything" string i.e. "*"
+   *
+   * @param s the input string
+   * @return true if the input string is "*"
+   */
+  public static boolean isMatchAnything(String s) {
+    return ASTERISK.equals(s);
+  }
 
-    /**
-     * This function checks if the input string is a wildcard string
-     *
-     * @param s     the input string
-     * @return true if the input string is wildcard
-     */
-    public static boolean isWildcard(String s) {
-        return s.contains(ASTERISK);
-    }
+  /**
+   * This function checks if the input string is a wildcard string
+   *
+   * @param s the input string
+   * @return true if the input string is wildcard
+   */
+  public static boolean isWildcard(String s) {
+    return s.contains(ASTERISK);
+  }
 
-    /**
-     * This function checks if the input string contains an emoji
-     *
-     * @param str   the input string
-     * @return true if the input string contains an emoji
-     */
-    public static boolean containsEmoji(String str) {
-        int length = str.length();
-        for (int i = 0; i < length; i++) {
-            int type = Character.getType(str.charAt(i));
-            if (type == Character.SURROGATE || type == Character.OTHER_SYMBOL) {
-                return true;
-            }
-        }
-        return false;
+  /**
+   * This function checks if the input string contains an emoji
+   *
+   * @param str the input string
+   * @return true if the input string contains an emoji
+   */
+  public static boolean containsEmoji(String str) {
+    int length = str.length();
+    for (int i = 0; i < length; i++) {
+      int type = Character.getType(str.charAt(i));
+      if (type == Character.SURROGATE || type == Character.OTHER_SYMBOL) {
+        return true;
+      }
     }
+    return false;
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/ArrowResultChunkTest.java
+++ b/src/test/java/com/databricks/jdbc/core/ArrowResultChunkTest.java
@@ -1,6 +1,16 @@
 package com.databricks.jdbc.core;
 
+import static java.lang.Math.min;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.databricks.sdk.service.sql.ChunkInfo;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
@@ -15,106 +25,101 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-import static java.lang.Math.min;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class ArrowResultChunkTest {
 
-    private static final String STATEMENT_ID = "statement_id";
-    private Random random = new Random();
-    private int rowsInRecordBatch = 20;
+  private static final String STATEMENT_ID = "statement_id";
+  private Random random = new Random();
+  private int rowsInRecordBatch = 20;
 
-    private long totalRows = 110;
+  private long totalRows = 110;
 
-    @Test
-    public void testGetArrowDataFromInputStream() throws Exception {
-        // Arrange
-        ChunkInfo chunkInfo = new ChunkInfo()
-                .setChunkIndex(0L)
-                .setByteCount(200L)
-                .setRowOffset(0L)
-                .setRowCount(totalRows);
-        ArrowResultChunk arrowResultChunk = new ArrowResultChunk(
-            chunkInfo, new RootAllocator(Integer.MAX_VALUE), STATEMENT_ID);
-        Schema schema = createTestSchema();
-        Object[][] testData = createTestData(schema, (int) totalRows);
-        File arrowFile = createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
+  @Test
+  public void testGetArrowDataFromInputStream() throws Exception {
+    // Arrange
+    ChunkInfo chunkInfo =
+        new ChunkInfo()
+            .setChunkIndex(0L)
+            .setByteCount(200L)
+            .setRowOffset(0L)
+            .setRowCount(totalRows);
+    ArrowResultChunk arrowResultChunk =
+        new ArrowResultChunk(chunkInfo, new RootAllocator(Integer.MAX_VALUE), STATEMENT_ID);
+    Schema schema = createTestSchema();
+    Object[][] testData = createTestData(schema, (int) totalRows);
+    File arrowFile =
+        createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
 
-        // Act
-        arrowResultChunk.getArrowDataFromInputStream(new FileInputStream(arrowFile));
+    // Act
+    arrowResultChunk.getArrowDataFromInputStream(new FileInputStream(arrowFile));
 
-        // Assert
-        int totalRecordBatches = (int) ((totalRows + rowsInRecordBatch)/rowsInRecordBatch);
-        assertEquals(arrowResultChunk.getRecordBatchCountInChunk(), totalRecordBatches);
-    }
+    // Assert
+    int totalRecordBatches = (int) ((totalRows + rowsInRecordBatch) / rowsInRecordBatch);
+    assertEquals(arrowResultChunk.getRecordBatchCountInChunk(), totalRecordBatches);
+  }
 
-    private File createTestArrowFile(String fileName, Schema schema, Object[][] testData, RootAllocator allocator) throws IOException {
-        File file = new File(fileName);
-        int cols = testData.length;
-        int rows = testData[0].length;
-        VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
-        ArrowWriter writer = new ArrowStreamWriter(vectorSchemaRoot, new DictionaryProvider.MapDictionaryProvider(), new FileOutputStream(file));
-        writer.start();
-        for(int j = 0; j < rows; j += rowsInRecordBatch) {
-            int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
-            vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
-            for(int i = 0; i < cols; i++) {
-                Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-                FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
-                if(type.equals(Types.MinorType.INT)) {
-                    IntVector intVector = (IntVector) fieldVector;
-                    intVector.setInitialCapacity(rowsToAddToRecordBatch);
-                    for(int k = 0; k < rowsToAddToRecordBatch; k++) {
-                        intVector.set(k, 1, (int) testData[i][j + k]);
-                    }
-                }
-                else if(type.equals(Types.MinorType.FLOAT8)) {
-                    Float8Vector float8Vector = (Float8Vector) fieldVector;
-                    float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
-                    for(int k = 0; k < rowsToAddToRecordBatch; k++) {
-                        float8Vector.set(k, 1, (double) testData[i][j + k]);
-                    }
-                }
-                fieldVector.setValueCount(rowsToAddToRecordBatch);
-            }
-            writer.writeBatch();
+  private File createTestArrowFile(
+      String fileName, Schema schema, Object[][] testData, RootAllocator allocator)
+      throws IOException {
+    File file = new File(fileName);
+    int cols = testData.length;
+    int rows = testData[0].length;
+    VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
+    ArrowWriter writer =
+        new ArrowStreamWriter(
+            vectorSchemaRoot,
+            new DictionaryProvider.MapDictionaryProvider(),
+            new FileOutputStream(file));
+    writer.start();
+    for (int j = 0; j < rows; j += rowsInRecordBatch) {
+      int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
+      vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
+      for (int i = 0; i < cols; i++) {
+        Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
+        FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
+        if (type.equals(Types.MinorType.INT)) {
+          IntVector intVector = (IntVector) fieldVector;
+          intVector.setInitialCapacity(rowsToAddToRecordBatch);
+          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
+            intVector.set(k, 1, (int) testData[i][j + k]);
+          }
+        } else if (type.equals(Types.MinorType.FLOAT8)) {
+          Float8Vector float8Vector = (Float8Vector) fieldVector;
+          float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
+          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
+            float8Vector.set(k, 1, (double) testData[i][j + k]);
+          }
         }
-        return file;
+        fieldVector.setValueCount(rowsToAddToRecordBatch);
+      }
+      writer.writeBatch();
     }
+    return file;
+  }
 
-    private Schema createTestSchema() {
-        List<Field> fieldList = new ArrayList<>();
-        FieldType fieldType1 = new FieldType(false, Types.MinorType.INT.getType(), null);
-        FieldType fieldType2 = new FieldType(false, Types.MinorType.FLOAT8.getType(), null);
-        fieldList.add(new Field("Field1", fieldType1, null));
-        fieldList.add(new Field("Field2", fieldType2, null));
-        return new Schema(fieldList);
-    }
+  private Schema createTestSchema() {
+    List<Field> fieldList = new ArrayList<>();
+    FieldType fieldType1 = new FieldType(false, Types.MinorType.INT.getType(), null);
+    FieldType fieldType2 = new FieldType(false, Types.MinorType.FLOAT8.getType(), null);
+    fieldList.add(new Field("Field1", fieldType1, null));
+    fieldList.add(new Field("Field2", fieldType2, null));
+    return new Schema(fieldList);
+  }
 
-    private Object[][] createTestData(Schema schema, int rows) {
-        int cols = schema.getFields().size();
-        Object[][] data = new Object[cols][rows];
-        for(int i = 0; i < cols; i++) {
-            Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-            if(type.equals(Types.MinorType.INT)) {
-                for(int j = 0; j < rows; j++) {
-                    data[i][j] = random.nextInt();
-                }
-            }
-            else if(type.equals(Types.MinorType.FLOAT8)) {
-                for(int j = 0; j < rows; j++) {
-                    data[i][j] = random.nextDouble();
-                }
-            }
+  private Object[][] createTestData(Schema schema, int rows) {
+    int cols = schema.getFields().size();
+    Object[][] data = new Object[cols][rows];
+    for (int i = 0; i < cols; i++) {
+      Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
+      if (type.equals(Types.MinorType.INT)) {
+        for (int j = 0; j < rows; j++) {
+          data[i][j] = random.nextInt();
         }
-        return data;
+      } else if (type.equals(Types.MinorType.FLOAT8)) {
+        for (int j = 0; j < rows; j++) {
+          data[i][j] = random.nextDouble();
+        }
+      }
     }
+    return data;
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/ArrowStreamResultTest.java
+++ b/src/test/java/com/databricks/jdbc/core/ArrowStreamResultTest.java
@@ -1,5 +1,11 @@
 package com.databricks.jdbc.core;
 
+import static java.lang.Math.min;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.IDatabricksHttpClient;
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.driver.DatabricksConnectionContext;
@@ -7,6 +13,12 @@ import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.*;
 import com.google.common.collect.ImmutableList;
+import java.io.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
@@ -26,248 +38,239 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockedConstruction;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
-
-import java.io.*;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-import java.util.concurrent.Executors;
-
-import static java.lang.Math.min;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ArrowStreamResultTest {
 
-    private ArrayList<ArrowResultChunk> resultChunks = new ArrayList<>();
+  private ArrayList<ArrowResultChunk> resultChunks = new ArrayList<>();
 
-    private List<ChunkInfo> chunkInfos = new ArrayList<>();
+  private List<ChunkInfo> chunkInfos = new ArrayList<>();
 
-    private int numberOfChunks = 10;
-    private Random random = new Random();
+  private int numberOfChunks = 10;
+  private Random random = new Random();
 
-    private long rowsInChunk = 110L;
+  private long rowsInChunk = 110L;
 
-    private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
-    private static final String CHUNK_URL_PREFIX = "chunk.databricks.com/";
-    private static final String STATEMENT_ID = "statement_id";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String CHUNK_URL_PREFIX = "chunk.databricks.com/";
+  private static final String STATEMENT_ID = "statement_id";
 
-    @Mock
-    StatementExecutionService statementExecutionService;
-    @Mock
-    ApiClient apiClient;
-    @Mock
-    IDatabricksHttpClient mockHttpClient;
-    @Mock
-    CloseableHttpResponse httpResponse;
-    @Mock
-    HttpEntity httpEntity;
+  @Mock StatementExecutionService statementExecutionService;
+  @Mock ApiClient apiClient;
+  @Mock IDatabricksHttpClient mockHttpClient;
+  @Mock CloseableHttpResponse httpResponse;
+  @Mock HttpEntity httpEntity;
 
-    @BeforeEach
-    public void setup() throws Exception {
-        setupChunks();
+  @BeforeEach
+  public void setup() throws Exception {
+    setupChunks();
+  }
+
+  @Test
+  public void testIteration() throws Exception {
+    // Arrange
+    ResultManifest resultManifest =
+        new ResultManifest()
+            .setTotalChunkCount((long) this.numberOfChunks)
+            .setTotalRowCount(this.numberOfChunks * 110L)
+            .setTotalByteCount(1000L)
+            .setChunks(this.chunkInfos)
+            .setSchema(new ResultSchema().setColumns(new ArrayList<>()));
+
+    ResultData resultData = new ResultData().setExternalLinks(getChunkLinks(0L, false));
+
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSession session =
+        new DatabricksSession(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+
+    setupMockLinks(1, false);
+    setupMockLinks(2, false);
+    setupMockLinks(3, false);
+    setupMockLinks(4, false);
+    setupMockLinks(5, false);
+    setupMockLinks(6, false);
+    setupMockLinks(7, false);
+    setupMockLinks(8, false);
+    setupMockLinks(9, true);
+
+    setupMockResponse();
+    when(mockHttpClient.execute(isA(HttpUriRequest.class))).thenReturn(httpResponse);
+
+    ArrowStreamResult result =
+        new ArrowStreamResult(resultManifest, resultData, STATEMENT_ID, session, mockHttpClient);
+
+    // Act & Assert
+    for (int i = 0; i < this.numberOfChunks; ++i) {
+      // Since the first row of the chunk is null
+      for (int j = 0; j < (this.rowsInChunk); ++j) {
+        assertTrue(result.hasNext());
+        assertTrue(result.next());
+      }
     }
+    assertFalse(result.hasNext());
+    assertFalse(result.next());
+    //      mocked.close();
+  }
 
-    @Test
-    public void testIteration() throws Exception {
-        // Arrange
-        ResultManifest resultManifest = new ResultManifest()
-                .setTotalChunkCount((long) this.numberOfChunks)
-                .setTotalRowCount(this.numberOfChunks * 110L)
-                .setTotalByteCount(1000L)
-                .setChunks(this.chunkInfos)
-                .setSchema(new ResultSchema().setColumns(new ArrayList<>()));
+  @Test
+  public void testGetObject() throws Exception {
+    // Arrange
+    ResultManifest resultManifest =
+        new ResultManifest()
+            .setTotalChunkCount((long) this.numberOfChunks)
+            .setTotalRowCount(this.numberOfChunks * 110L)
+            .setTotalByteCount(1000L)
+            .setChunks(this.chunkInfos)
+            .setSchema(
+                new ResultSchema()
+                    .setColumns(
+                        ImmutableList.of(
+                            new ColumnInfo().setTypeName(ColumnInfoTypeName.INT),
+                            new ColumnInfo().setTypeName(ColumnInfoTypeName.DOUBLE))));
 
-        ResultData resultData = new ResultData()
-                .setExternalLinks(getChunkLinks(0L, false));
+    ResultData resultData = new ResultData().setExternalLinks(getChunkLinks(0L, false));
 
-        IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-        DatabricksSession session = new DatabricksSession(connectionContext,
-                new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSession session =
+        new DatabricksSession(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, null));
 
-        setupMockLinks(1, false);
-        setupMockLinks(2, false);
-        setupMockLinks(3, false);
-        setupMockLinks(4, false);
-        setupMockLinks(5, false);
-        setupMockLinks(6, false);
-        setupMockLinks(7, false);
-        setupMockLinks(8, false);
-        setupMockLinks(9, true);
+    setupMockLinks(1, false);
+    setupMockLinks(2, false);
+    setupMockLinks(3, false);
 
-        setupMockResponse();
-        when(mockHttpClient.execute(isA(HttpUriRequest.class))).thenReturn(httpResponse);
+    setupMockResponse();
+    when(mockHttpClient.execute(isA(HttpUriRequest.class))).thenReturn(httpResponse);
 
-        ArrowStreamResult result = new ArrowStreamResult(resultManifest, resultData, STATEMENT_ID, session,
-            mockHttpClient);
+    ArrowStreamResult result =
+        new ArrowStreamResult(resultManifest, resultData, STATEMENT_ID, session, mockHttpClient);
 
-        // Act & Assert
-        for(int i = 0; i < this.numberOfChunks; ++i) {
-            // Since the first row of the chunk is null
-            for(int j = 0; j < (this.rowsInChunk); ++j) {
-                assertTrue(result.hasNext());
-                assertTrue(result.next());
-            }
-        }
-        assertFalse(result.hasNext());
-        assertFalse(result.next());
-  //      mocked.close();
-    }
+    result.next();
+    Object objectInFirstColumn = result.getObject(0);
+    Object objectInSecondColumn = result.getObject(1);
 
-    @Test
-    public void testGetObject() throws Exception {
-        // Arrange
-        ResultManifest resultManifest = new ResultManifest()
-                .setTotalChunkCount((long) this.numberOfChunks)
-                .setTotalRowCount(this.numberOfChunks * 110L)
-                .setTotalByteCount(1000L)
-                .setChunks(this.chunkInfos)
-                .setSchema(new ResultSchema().setColumns(ImmutableList.of(new ColumnInfo().setTypeName(ColumnInfoTypeName.INT), new ColumnInfo().setTypeName(ColumnInfoTypeName.DOUBLE))));
+    assertTrue(objectInFirstColumn instanceof Integer);
+    assertTrue(objectInSecondColumn instanceof Double);
+  }
 
-        ResultData resultData = new ResultData()
-                .setExternalLinks(getChunkLinks(0L, false));
+  private void setupMockLinks(long chunkIndex, boolean isLast) {
+    when(statementExecutionService.getStatementResultChunkN(getChunkNRequest(chunkIndex)))
+        .thenReturn(new ResultData().setExternalLinks(getChunkLinks(chunkIndex, isLast)));
+  }
 
-        IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-        DatabricksSession session = new DatabricksSession(connectionContext,
-                new DatabricksSdkClient(connectionContext, statementExecutionService, null));
-
-        setupMockLinks(1, false);
-        setupMockLinks(2, false);
-        setupMockLinks(3, false);
-
-        setupMockResponse();
-        when(mockHttpClient.execute(isA(HttpUriRequest.class))).thenReturn(httpResponse);
-
-        ArrowStreamResult result = new ArrowStreamResult(resultManifest, resultData, STATEMENT_ID, session,
-            mockHttpClient);
-
-        result.next();
-        Object objectInFirstColumn = result.getObject(0);
-        Object objectInSecondColumn = result.getObject(1);
-
-        assertTrue(objectInFirstColumn instanceof Integer);
-        assertTrue(objectInSecondColumn instanceof Double);
-
-    }
-
-    private void setupMockLinks(long chunkIndex, boolean isLast) {
-        when(statementExecutionService.getStatementResultChunkN(getChunkNRequest(chunkIndex)))
-            .thenReturn(new ResultData().setExternalLinks(getChunkLinks(chunkIndex, isLast)));
-    }
-
-    private List<ExternalLink> getChunkLinks(long chunkIndex, boolean isLast) {
-        List<ExternalLink> chunkLinks = new ArrayList<>();
-        ExternalLink chunkLink = new ExternalLink()
+  private List<ExternalLink> getChunkLinks(long chunkIndex, boolean isLast) {
+    List<ExternalLink> chunkLinks = new ArrayList<>();
+    ExternalLink chunkLink =
+        new ExternalLink()
             .setChunkIndex(chunkIndex)
             .setExternalLink(CHUNK_URL_PREFIX + chunkIndex)
             .setExpiration(Instant.now().plusSeconds(3600L).toString());
-        if (!isLast) {
-            chunkLink.setNextChunkIndex(chunkIndex + 1);
+    if (!isLast) {
+      chunkLink.setNextChunkIndex(chunkIndex + 1);
+    }
+    chunkLinks.add(chunkLink);
+    return chunkLinks;
+  }
+
+  private void setupChunks() throws Exception {
+    for (int i = 0; i < this.numberOfChunks; ++i) {
+      ChunkInfo chunkInfo =
+          new ChunkInfo()
+              .setChunkIndex((long) i)
+              .setByteCount(1000L)
+              .setRowOffset((long) (i * 110L))
+              .setRowCount(this.rowsInChunk);
+      this.chunkInfos.add(chunkInfo);
+    }
+  }
+
+  private void setupMockResponse() throws Exception {
+    Schema schema = createTestSchema();
+    Object[][] testData = createTestData(schema, (int) this.rowsInChunk);
+    File arrowFile =
+        createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
+
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenAnswer(invocation -> new FileInputStream(arrowFile));
+  }
+
+  private File createTestArrowFile(
+      String fileName, Schema schema, Object[][] testData, RootAllocator allocator)
+      throws IOException {
+    int rowsInRecordBatch = 20;
+    File file = new File(fileName);
+    int cols = testData.length;
+    int rows = testData[0].length;
+    VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
+    ArrowWriter writer =
+        new ArrowStreamWriter(
+            vectorSchemaRoot,
+            new DictionaryProvider.MapDictionaryProvider(),
+            new FileOutputStream(file));
+    writer.start();
+    for (int j = 0; j < rows; j += rowsInRecordBatch) {
+      int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
+      vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
+      for (int i = 0; i < cols; i++) {
+        Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
+        FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
+        if (type.equals(Types.MinorType.INT)) {
+          IntVector intVector = (IntVector) fieldVector;
+          intVector.setInitialCapacity(rowsToAddToRecordBatch);
+          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
+            intVector.set(k, 1, (int) testData[i][j + k]);
+          }
+        } else if (type.equals(Types.MinorType.FLOAT8)) {
+          Float8Vector float8Vector = (Float8Vector) fieldVector;
+          float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
+          for (int currentRow = 0; currentRow < rowsToAddToRecordBatch; currentRow++) {
+            float8Vector.set(currentRow, 1, (double) testData[i][j + currentRow]);
+          }
         }
-        chunkLinks.add(chunkLink);
-        return chunkLinks;
+        fieldVector.setValueCount(rowsToAddToRecordBatch);
+      }
+      writer.writeBatch();
     }
+    return file;
+  }
 
-    private void setupChunks() throws Exception {
-        for (int i = 0; i < this.numberOfChunks; ++i) {
-            ChunkInfo chunkInfo = new ChunkInfo()
-                    .setChunkIndex((long) i)
-                    .setByteCount(1000L)
-                    .setRowOffset((long) (i * 110L))
-                    .setRowCount(this.rowsInChunk);
-            this.chunkInfos.add(chunkInfo);
+  private Schema createTestSchema() {
+    List<Field> fieldList = new ArrayList<>();
+    FieldType fieldType1 = new FieldType(false, Types.MinorType.INT.getType(), null);
+    FieldType fieldType2 = new FieldType(false, Types.MinorType.FLOAT8.getType(), null);
+    fieldList.add(new Field("Field1", fieldType1, null));
+    fieldList.add(new Field("Field2", fieldType2, null));
+    return new Schema(fieldList);
+  }
+
+  private Object[][] createTestData(Schema schema, int rows) {
+    int cols = schema.getFields().size();
+    Object[][] data = new Object[cols][rows];
+    for (int i = 0; i < cols; i++) {
+      Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
+      if (type.equals(Types.MinorType.INT)) {
+        for (int j = 0; j < rows; j++) {
+          data[i][j] = random.nextInt();
         }
-    }
-
-    private void setupMockResponse() throws Exception {
-        Schema schema = createTestSchema();
-        Object[][] testData = createTestData(schema, (int) this.rowsInChunk);
-        File arrowFile = createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
-
-        when(httpResponse.getEntity()).thenReturn(httpEntity);
-        when(httpEntity.getContent()).thenAnswer(invocation -> new FileInputStream(arrowFile));
-    }
-
-    private File createTestArrowFile(String fileName, Schema schema, Object[][] testData, RootAllocator allocator) throws IOException {
-        int rowsInRecordBatch = 20;
-        File file = new File(fileName);
-        int cols = testData.length;
-        int rows = testData[0].length;
-        VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
-        ArrowWriter writer = new ArrowStreamWriter(vectorSchemaRoot, new DictionaryProvider.MapDictionaryProvider(), new FileOutputStream(file));
-        writer.start();
-        for(int j = 0; j < rows; j += rowsInRecordBatch) {
-            int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
-            vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
-            for(int i = 0; i < cols; i++) {
-                Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-                FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
-                if(type.equals(Types.MinorType.INT)) {
-                    IntVector intVector = (IntVector) fieldVector;
-                    intVector.setInitialCapacity(rowsToAddToRecordBatch);
-                    for(int k = 0; k < rowsToAddToRecordBatch; k++) {
-                        intVector.set(k, 1, (int) testData[i][j + k]);
-                    }
-                }
-                else if(type.equals(Types.MinorType.FLOAT8)) {
-                    Float8Vector float8Vector = (Float8Vector) fieldVector;
-                    float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
-                    for(int currentRow = 0; currentRow < rowsToAddToRecordBatch; currentRow++) {
-                        float8Vector.set(currentRow, 1, (double) testData[i][j + currentRow]);
-                    }
-                }
-                fieldVector.setValueCount(rowsToAddToRecordBatch);
-            }
-            writer.writeBatch();
+      } else if (type.equals(Types.MinorType.FLOAT8)) {
+        for (int j = 0; j < rows; j++) {
+          data[i][j] = random.nextDouble();
         }
-        return file;
+      }
     }
+    return data;
+  }
 
-    private Schema createTestSchema() {
-        List<Field> fieldList = new ArrayList<>();
-        FieldType fieldType1 = new FieldType(false, Types.MinorType.INT.getType(), null);
-        FieldType fieldType2 = new FieldType(false, Types.MinorType.FLOAT8.getType(), null);
-        fieldList.add(new Field("Field1", fieldType1, null));
-        fieldList.add(new Field("Field2", fieldType2, null));
-        return new Schema(fieldList);
-    }
-
-    private Object[][] createTestData(Schema schema, int rows) {
-        int cols = schema.getFields().size();
-        Object[][] data = new Object[cols][rows];
-        for(int i = 0; i < cols; i++) {
-            Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-            if(type.equals(Types.MinorType.INT)) {
-                for(int j = 0; j < rows; j++) {
-                    data[i][j] = random.nextInt();
-                }
-            }
-            else if(type.equals(Types.MinorType.FLOAT8)) {
-                for(int j = 0; j < rows; j++) {
-                    data[i][j] = random.nextDouble();
-                }
-            }
-        }
-        return data;
-    }
-
-    private GetStatementResultChunkNRequest getChunkNRequest(long chunkIndex) {
-        return new GetStatementResultChunkNRequest()
-                .setStatementId(STATEMENT_ID)
-                .setChunkIndex(chunkIndex);
-    }
-
-
-
+  private GetStatementResultChunkNRequest getChunkNRequest(long chunkIndex) {
+    return new GetStatementResultChunkNRequest()
+        .setStatementId(STATEMENT_ID)
+        .setChunkIndex(chunkIndex);
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/ArrowToJavaObjectConverterTest.java
@@ -1,224 +1,237 @@
 package com.databricks.jdbc.core;
 
-import com.databricks.sdk.service.sql.ColumnInfoTypeName;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.*;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.sdk.service.sql.ColumnInfoTypeName;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.*;
+import org.junit.jupiter.api.Test;
 
 public class ArrowToJavaObjectConverterTest {
-    private final BufferAllocator bufferAllocator;
+  private final BufferAllocator bufferAllocator;
 
-    ArrowToJavaObjectConverterTest() {
-        this.bufferAllocator = new RootAllocator();
-    }
+  ArrowToJavaObjectConverterTest() {
+    this.bufferAllocator = new RootAllocator();
+  }
 
-    @Test
-    public void testByteConversion() throws SQLException {
-        TinyIntVector tinyIntVector = new TinyIntVector("tinyIntVector", this.bufferAllocator);
-        tinyIntVector.allocateNew(1);
-        tinyIntVector.set(0, 65);
-        Object unconvertedObject = tinyIntVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.BYTE);
+  @Test
+  public void testByteConversion() throws SQLException {
+    TinyIntVector tinyIntVector = new TinyIntVector("tinyIntVector", this.bufferAllocator);
+    tinyIntVector.allocateNew(1);
+    tinyIntVector.set(0, 65);
+    Object unconvertedObject = tinyIntVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.BYTE);
 
-        assertTrue(convertedObject instanceof Byte);
-        assertEquals(convertedObject, (byte) 65);
-    }
+    assertTrue(convertedObject instanceof Byte);
+    assertEquals(convertedObject, (byte) 65);
+  }
 
-    @Test
-    public void testShortConversion() throws SQLException {
-        SmallIntVector smallIntVector = new SmallIntVector("smallIntVector", this.bufferAllocator);
-        smallIntVector.allocateNew(1);
-        smallIntVector.set(0, 4);
-        Object unconvertedObject = smallIntVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.SHORT);
+  @Test
+  public void testShortConversion() throws SQLException {
+    SmallIntVector smallIntVector = new SmallIntVector("smallIntVector", this.bufferAllocator);
+    smallIntVector.allocateNew(1);
+    smallIntVector.set(0, 4);
+    Object unconvertedObject = smallIntVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.SHORT);
 
-        assertTrue(convertedObject instanceof Short);
-        assertEquals(convertedObject, (short) 4);
-    }
+    assertTrue(convertedObject instanceof Short);
+    assertEquals(convertedObject, (short) 4);
+  }
 
-    @Test
-    public void testIntConversion() throws SQLException {
-        IntVector intVector = new IntVector("intVector", this.bufferAllocator);
-        intVector.allocateNew(1);
-        intVector.set(0, 1111111111);
-        Object unconvertedObject = intVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.INT);
+  @Test
+  public void testIntConversion() throws SQLException {
+    IntVector intVector = new IntVector("intVector", this.bufferAllocator);
+    intVector.allocateNew(1);
+    intVector.set(0, 1111111111);
+    Object unconvertedObject = intVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.INT);
 
-        assertTrue(convertedObject instanceof Integer);
-        assertEquals(convertedObject, 1111111111);
-    }
+    assertTrue(convertedObject instanceof Integer);
+    assertEquals(convertedObject, 1111111111);
+  }
 
-    @Test
-    public void testLongConversion() throws SQLException {
-        BigIntVector bigIntVector = new BigIntVector("bigIntVector", this.bufferAllocator);
-        bigIntVector.allocateNew(1);
-        bigIntVector.set(0, 1111111111111111111L);
-        Object unconvertedObject = bigIntVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.LONG);
+  @Test
+  public void testLongConversion() throws SQLException {
+    BigIntVector bigIntVector = new BigIntVector("bigIntVector", this.bufferAllocator);
+    bigIntVector.allocateNew(1);
+    bigIntVector.set(0, 1111111111111111111L);
+    Object unconvertedObject = bigIntVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.LONG);
 
-        assertTrue(convertedObject instanceof Long);
-        assertEquals(convertedObject, 1111111111111111111L);
-    }
+    assertTrue(convertedObject instanceof Long);
+    assertEquals(convertedObject, 1111111111111111111L);
+  }
 
-    @Test
-    public void testFloatConversion() throws SQLException {
-        Float4Vector float4Vector = new Float4Vector("float4Vector", this.bufferAllocator);
-        float4Vector.allocateNew(1);
-        float4Vector.set(0, 4.2f);
-        Object unconvertedObject = float4Vector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.FLOAT);
+  @Test
+  public void testFloatConversion() throws SQLException {
+    Float4Vector float4Vector = new Float4Vector("float4Vector", this.bufferAllocator);
+    float4Vector.allocateNew(1);
+    float4Vector.set(0, 4.2f);
+    Object unconvertedObject = float4Vector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.FLOAT);
 
-        assertTrue(convertedObject instanceof Float);
-        assertEquals(convertedObject, 4.2f);
-    }
+    assertTrue(convertedObject instanceof Float);
+    assertEquals(convertedObject, 4.2f);
+  }
 
-    @Test
-    public void testDoubleConversion() throws SQLException {
-        Float8Vector float8Vector = new Float8Vector("float8Vector", this.bufferAllocator);
-        float8Vector.allocateNew(1);
-        float8Vector.set(0, 4.11111111);
-        Object unconvertedObject = float8Vector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DOUBLE);
+  @Test
+  public void testDoubleConversion() throws SQLException {
+    Float8Vector float8Vector = new Float8Vector("float8Vector", this.bufferAllocator);
+    float8Vector.allocateNew(1);
+    float8Vector.set(0, 4.11111111);
+    Object unconvertedObject = float8Vector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DOUBLE);
 
-        assertTrue(convertedObject instanceof Double);
-        assertEquals(convertedObject, 4.11111111);
-    }
+    assertTrue(convertedObject instanceof Double);
+    assertEquals(convertedObject, 4.11111111);
+  }
 
-    @Test
-    public void testBigDecimalConversion() throws SQLException {
-        DecimalVector decimalVector = new DecimalVector("decimalVector", this.bufferAllocator, 30, 10);
-        decimalVector.allocateNew(1);
-        decimalVector.set(0, BigDecimal.valueOf(4.1111111111));
-        Object unconvertedObject = decimalVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DECIMAL);
+  @Test
+  public void testBigDecimalConversion() throws SQLException {
+    DecimalVector decimalVector = new DecimalVector("decimalVector", this.bufferAllocator, 30, 10);
+    decimalVector.allocateNew(1);
+    decimalVector.set(0, BigDecimal.valueOf(4.1111111111));
+    Object unconvertedObject = decimalVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DECIMAL);
 
-        assertTrue(convertedObject instanceof BigDecimal);
-        assertEquals(convertedObject, BigDecimal.valueOf(4.1111111111));
-    }
+    assertTrue(convertedObject instanceof BigDecimal);
+    assertEquals(convertedObject, BigDecimal.valueOf(4.1111111111));
+  }
 
-    @Test
-    public void testByteArrayConversion() throws SQLException {
-        VarBinaryVector varBinaryVector = new VarBinaryVector("varBinaryVector", this.bufferAllocator);
-        varBinaryVector.allocateNew(1);
-        varBinaryVector.set(0, new byte[]{65, 66, 67});
-        Object unconvertedObject = varBinaryVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.BINARY);
+  @Test
+  public void testByteArrayConversion() throws SQLException {
+    VarBinaryVector varBinaryVector = new VarBinaryVector("varBinaryVector", this.bufferAllocator);
+    varBinaryVector.allocateNew(1);
+    varBinaryVector.set(0, new byte[] {65, 66, 67});
+    Object unconvertedObject = varBinaryVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.BINARY);
 
-        assertTrue(convertedObject instanceof byte[]);
-        assertArrayEquals((byte[]) convertedObject, "ABC".getBytes());
-    }
+    assertTrue(convertedObject instanceof byte[]);
+    assertArrayEquals((byte[]) convertedObject, "ABC".getBytes());
+  }
 
-    @Test
-    public void testBooleanConversion() throws SQLException {
-        BitVector bitVector = new BitVector("bitVector", this.bufferAllocator);
-        bitVector.allocateNew(2);
-        bitVector.set(0, 0);
-        bitVector.set(1, 1);
-        Object unconvertedFalseObject = bitVector.getObject(0);
-        Object convertedFalseObject = ArrowToJavaObjectConverter.convert(unconvertedFalseObject,
-                ColumnInfoTypeName.BOOLEAN);
-        Object unconvertedTrueObject = bitVector.getObject(1);
-        Object convertedTrueObject = ArrowToJavaObjectConverter.convert(unconvertedTrueObject,
-                ColumnInfoTypeName.BOOLEAN);
+  @Test
+  public void testBooleanConversion() throws SQLException {
+    BitVector bitVector = new BitVector("bitVector", this.bufferAllocator);
+    bitVector.allocateNew(2);
+    bitVector.set(0, 0);
+    bitVector.set(1, 1);
+    Object unconvertedFalseObject = bitVector.getObject(0);
+    Object convertedFalseObject =
+        ArrowToJavaObjectConverter.convert(unconvertedFalseObject, ColumnInfoTypeName.BOOLEAN);
+    Object unconvertedTrueObject = bitVector.getObject(1);
+    Object convertedTrueObject =
+        ArrowToJavaObjectConverter.convert(unconvertedTrueObject, ColumnInfoTypeName.BOOLEAN);
 
-        assertTrue(unconvertedTrueObject instanceof Boolean);
-        assertTrue(unconvertedFalseObject instanceof Boolean);
-        assertEquals(convertedFalseObject, false);
-        assertEquals(convertedTrueObject, true);
-    }
+    assertTrue(unconvertedTrueObject instanceof Boolean);
+    assertTrue(unconvertedFalseObject instanceof Boolean);
+    assertEquals(convertedFalseObject, false);
+    assertEquals(convertedTrueObject, true);
+  }
 
-    @Test
-    public void testCharConversion() throws SQLException {
-        VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
-        varCharVector.allocateNew(1);
-        varCharVector.set(0, new byte[]{65});
-        Object unconvertedObject = varCharVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.CHAR);
+  @Test
+  public void testCharConversion() throws SQLException {
+    VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
+    varCharVector.allocateNew(1);
+    varCharVector.set(0, new byte[] {65});
+    Object unconvertedObject = varCharVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.CHAR);
 
-        assertTrue(convertedObject instanceof Character);
-        assertEquals(convertedObject, 'A');
-    }
+    assertTrue(convertedObject instanceof Character);
+    assertEquals(convertedObject, 'A');
+  }
 
-    @Test
-    public void testStringConversion() throws SQLException {
-        VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
-        varCharVector.allocateNew(1);
-        varCharVector.set(0, new byte[]{65, 66, 67});
-        Object unconvertedObject = varCharVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRING);
+  @Test
+  public void testStringConversion() throws SQLException {
+    VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
+    varCharVector.allocateNew(1);
+    varCharVector.set(0, new byte[] {65, 66, 67});
+    Object unconvertedObject = varCharVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRING);
 
-        assertTrue(convertedObject instanceof String);
-        assertEquals(convertedObject, "ABC");
-    }
+    assertTrue(convertedObject instanceof String);
+    assertEquals(convertedObject, "ABC");
+  }
 
-    @Test
-    public void testDateConversion() throws SQLException {
-        DateDayVector dateDayVector = new DateDayVector("dateDayVector", this.bufferAllocator);
-        dateDayVector.allocateNew(1);
-        dateDayVector.set(0, 19598); // 29th August 2023
-        Object unconvertedObject = dateDayVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DATE);
+  @Test
+  public void testDateConversion() throws SQLException {
+    DateDayVector dateDayVector = new DateDayVector("dateDayVector", this.bufferAllocator);
+    dateDayVector.allocateNew(1);
+    dateDayVector.set(0, 19598); // 29th August 2023
+    Object unconvertedObject = dateDayVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.DATE);
 
-        assertTrue(convertedObject instanceof Date);
-        assertEquals(convertedObject, Date.valueOf("2023-08-29"));
-    }
+    assertTrue(convertedObject instanceof Date);
+    assertEquals(convertedObject, Date.valueOf("2023-08-29"));
+  }
 
-    @Test
-    public void testTimestampConversion() throws SQLException {
-        IntVector intVector = new IntVector("intVector", this.bufferAllocator);
-        intVector.allocateNew(1);
-        intVector.set(0, 4);
-        Object unconvertedIntObject = intVector.getObject(0);
-        Object convertedFromIntObject = ArrowToJavaObjectConverter.convert(unconvertedIntObject,
-                ColumnInfoTypeName.TIMESTAMP);
-        BigIntVector bigIntVector = new BigIntVector("bigIntVector", this.bufferAllocator);
-        bigIntVector.allocateNew(1);
-        bigIntVector.set(0, 1693312639000L);
-        Object unconvertedBigIntObject = bigIntVector.getObject(0);
-        Object convertedFromBigIntObject = ArrowToJavaObjectConverter.convert(unconvertedBigIntObject,
-                ColumnInfoTypeName.TIMESTAMP);
+  @Test
+  public void testTimestampConversion() throws SQLException {
+    IntVector intVector = new IntVector("intVector", this.bufferAllocator);
+    intVector.allocateNew(1);
+    intVector.set(0, 4);
+    Object unconvertedIntObject = intVector.getObject(0);
+    Object convertedFromIntObject =
+        ArrowToJavaObjectConverter.convert(unconvertedIntObject, ColumnInfoTypeName.TIMESTAMP);
+    BigIntVector bigIntVector = new BigIntVector("bigIntVector", this.bufferAllocator);
+    bigIntVector.allocateNew(1);
+    bigIntVector.set(0, 1693312639000L);
+    Object unconvertedBigIntObject = bigIntVector.getObject(0);
+    Object convertedFromBigIntObject =
+        ArrowToJavaObjectConverter.convert(unconvertedBigIntObject, ColumnInfoTypeName.TIMESTAMP);
 
-        assertTrue(convertedFromIntObject instanceof Timestamp);
-        assertEquals(((Timestamp) convertedFromIntObject).toInstant(), Instant.ofEpochMilli(4));
-        assertTrue(convertedFromBigIntObject instanceof Timestamp);
-        assertEquals(((Timestamp) convertedFromBigIntObject).toInstant(), Instant.ofEpochMilli(1693312639000L));
-    }
+    assertTrue(convertedFromIntObject instanceof Timestamp);
+    assertEquals(((Timestamp) convertedFromIntObject).toInstant(), Instant.ofEpochMilli(4));
+    assertTrue(convertedFromBigIntObject instanceof Timestamp);
+    assertEquals(
+        ((Timestamp) convertedFromBigIntObject).toInstant(), Instant.ofEpochMilli(1693312639000L));
+  }
 
-    @Test
-    public void testStructConversion() throws SQLException {
-        Map<String, String> map = new HashMap<>();
-        map.put("key", "value");
-        VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
-        varCharVector.allocateNew(1);
-        varCharVector.set(0, map.toString().getBytes());
-        Object unconvertedObject = varCharVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRUCT);
-        assertTrue(convertedObject instanceof String);
-        assertEquals(convertedObject, "{key=value}");
-    }
+  @Test
+  public void testStructConversion() throws SQLException {
+    Map<String, String> map = new HashMap<>();
+    map.put("key", "value");
+    VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
+    varCharVector.allocateNew(1);
+    varCharVector.set(0, map.toString().getBytes());
+    Object unconvertedObject = varCharVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRUCT);
+    assertTrue(convertedObject instanceof String);
+    assertEquals(convertedObject, "{key=value}");
+  }
 
-    @Test
-    public void testArrayConversion() throws SQLException {
-        ArrayList<String> list = new ArrayList();
-        list.add("A");
-        list.add("B");
-        VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
-        varCharVector.allocateNew(1);
-        varCharVector.set(0, list.toString().getBytes());
-        Object unconvertedObject = varCharVector.getObject(0);
-        Object convertedObject = ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRUCT);
+  @Test
+  public void testArrayConversion() throws SQLException {
+    ArrayList<String> list = new ArrayList();
+    list.add("A");
+    list.add("B");
+    VarCharVector varCharVector = new VarCharVector("varCharVector", this.bufferAllocator);
+    varCharVector.allocateNew(1);
+    varCharVector.set(0, list.toString().getBytes());
+    Object unconvertedObject = varCharVector.getObject(0);
+    Object convertedObject =
+        ArrowToJavaObjectConverter.convert(unconvertedObject, ColumnInfoTypeName.STRUCT);
 
-        assertTrue(convertedObject instanceof String);
-        assertEquals(convertedObject, "[A, B]");
-    }
+    assertTrue(convertedObject instanceof String);
+    assertEquals(convertedObject, "[A, B]");
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/ChunkDownloaderTest.java
+++ b/src/test/java/com/databricks/jdbc/core/ChunkDownloaderTest.java
@@ -1,5 +1,12 @@
 package com.databricks.jdbc.core;
 
+import static java.lang.Math.min;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.IDatabricksHttpClient;
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.core.ArrowResultChunk.DownloadStatus;
@@ -7,6 +14,12 @@ import com.databricks.jdbc.driver.DatabricksConnectionContext;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.*;
+import java.io.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
@@ -22,24 +35,9 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.io.*;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-
-import static java.lang.Math.min;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ChunkDownloaderTest {
@@ -48,7 +46,8 @@ public class ChunkDownloaderTest {
   private static final String SESSION_ID = "session_id";
   private static final String STATEMENT_ID = "statement_id";
   private static final String STATEMENT = "select 1";
-  private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
   private static final String CHUNK_URL_PREFIX = "chunk.databricks.com/";
   private static final long TOTAL_CHUNKS = 5;
   private static final long TOTAL_ROWS = 90;
@@ -57,27 +56,25 @@ public class ChunkDownloaderTest {
   private int rowsInRecordBatch = 20;
   private Random random = new Random();
 
-  @Mock
-  StatementExecutionService statementExecutionService;
+  @Mock StatementExecutionService statementExecutionService;
 
-  @Mock
-  IDatabricksHttpClient mockHttpClient;
-  @Mock
-  CloseableHttpResponse httpResponse;
-  @Mock
-  HttpEntity httpEntity;
+  @Mock IDatabricksHttpClient mockHttpClient;
+  @Mock CloseableHttpResponse httpResponse;
+  @Mock HttpEntity httpEntity;
 
-  @Mock
-  ApiClient apiClient;
+  @Mock ApiClient apiClient;
 
- // @Test
+  // @Test
   public void testInitChunkDownloader() throws Exception {
     ResultManifest resultManifest = getResultManifest();
     ResultData resultData = getResultData();
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksSession session = new DatabricksSession(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSession session =
+        new DatabricksSession(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
 
     when(statementExecutionService.getStatementResultChunkN(getChunkNRequest(1L)))
         .thenReturn(new ResultData().setExternalLinks(getChunkLinks(1L, false)));
@@ -108,20 +105,19 @@ public class ChunkDownloaderTest {
   }
 
   private ResultData getResultData() {
-    return new ResultData()
-        .setExternalLinks(getChunkLinks(0L, false));
+    return new ResultData().setExternalLinks(getChunkLinks(0L, false));
   }
 
   private ResultManifest getResultManifest() {
     List<ChunkInfo> chunks = new ArrayList<>();
-    for (long chunkIndex =0; chunkIndex < TOTAL_CHUNKS; chunkIndex++) {
-      ChunkInfo chunkInfo = new ChunkInfo()
-          .setChunkIndex(chunkIndex)
-          .setByteCount(200L)
-          .setRowOffset(chunkIndex*20);
-      if (chunkIndex < TOTAL_CHUNKS -1) {
-        chunkInfo.setNextChunkIndex(chunkIndex +1)
-            .setRowCount(20L);
+    for (long chunkIndex = 0; chunkIndex < TOTAL_CHUNKS; chunkIndex++) {
+      ChunkInfo chunkInfo =
+          new ChunkInfo()
+              .setChunkIndex(chunkIndex)
+              .setByteCount(200L)
+              .setRowOffset(chunkIndex * 20);
+      if (chunkIndex < TOTAL_CHUNKS - 1) {
+        chunkInfo.setNextChunkIndex(chunkIndex + 1).setRowCount(20L);
       } else {
         chunkInfo.setRowCount(10L);
       }
@@ -138,7 +134,8 @@ public class ChunkDownloaderTest {
   private void setupMockResponse() throws Exception {
     Schema schema = createTestSchema();
     Object[][] testData = createTestData(schema, 20);
-    File arrowFile = createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
+    File arrowFile =
+        createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
 
     when(httpResponse.getEntity()).thenReturn(httpEntity);
     when(httpEntity.getContent()).thenAnswer(invocation -> new FileInputStream(arrowFile));
@@ -146,10 +143,11 @@ public class ChunkDownloaderTest {
 
   private List<ExternalLink> getChunkLinks(long chunkIndex, boolean isLast) {
     List<ExternalLink> chunkLinks = new ArrayList<>();
-    ExternalLink chunkLink = new ExternalLink()
-        .setChunkIndex(chunkIndex)
-        .setExternalLink(CHUNK_URL_PREFIX + chunkIndex)
-        .setExpiration(Instant.now().plusSeconds(3600L).toString());
+    ExternalLink chunkLink =
+        new ExternalLink()
+            .setChunkIndex(chunkIndex)
+            .setExternalLink(CHUNK_URL_PREFIX + chunkIndex)
+            .setExpiration(Instant.now().plusSeconds(3600L).toString());
     if (!isLast) {
       chunkLink.setNextChunkIndex(chunkIndex + 1);
     }
@@ -175,30 +173,35 @@ public class ChunkDownloaderTest {
     assertEquals(DownloadStatus.DOWNLOAD_SUCCEEDED, chunk.getStatus());
   }
 
-  private File createTestArrowFile(String fileName, Schema schema, Object[][] testData, RootAllocator allocator) throws IOException {
+  private File createTestArrowFile(
+      String fileName, Schema schema, Object[][] testData, RootAllocator allocator)
+      throws IOException {
     File file = new File(fileName);
     int cols = testData.length;
     int rows = testData[0].length;
     VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
-    ArrowWriter writer = new ArrowStreamWriter(vectorSchemaRoot, new DictionaryProvider.MapDictionaryProvider(), new FileOutputStream(file));
+    ArrowWriter writer =
+        new ArrowStreamWriter(
+            vectorSchemaRoot,
+            new DictionaryProvider.MapDictionaryProvider(),
+            new FileOutputStream(file));
     writer.start();
-    for(int j = 0; j < rows; j += rowsInRecordBatch) {
+    for (int j = 0; j < rows; j += rowsInRecordBatch) {
       int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
       vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
-      for(int i = 0; i < cols; i++) {
+      for (int i = 0; i < cols; i++) {
         Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
         FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
-        if(type.equals(Types.MinorType.INT)) {
+        if (type.equals(Types.MinorType.INT)) {
           IntVector intVector = (IntVector) fieldVector;
           intVector.setInitialCapacity(rowsToAddToRecordBatch);
-          for(int k = 0; k < rowsToAddToRecordBatch; k++) {
+          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
             intVector.set(k, 1, (int) testData[i][j + k]);
           }
-        }
-        else if(type.equals(Types.MinorType.FLOAT8)) {
+        } else if (type.equals(Types.MinorType.FLOAT8)) {
           Float8Vector float8Vector = (Float8Vector) fieldVector;
           float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
-          for(int k = 0; k < rowsToAddToRecordBatch; k++) {
+          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
             float8Vector.set(k, 1, (double) testData[i][j + k]);
           }
         }
@@ -221,20 +224,18 @@ public class ChunkDownloaderTest {
   private Object[][] createTestData(Schema schema, int rows) {
     int cols = schema.getFields().size();
     Object[][] data = new Object[cols][rows];
-    for(int i = 0; i < cols; i++) {
+    for (int i = 0; i < cols; i++) {
       Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-      if(type.equals(Types.MinorType.INT)) {
-        for(int j = 0; j < rows; j++) {
+      if (type.equals(Types.MinorType.INT)) {
+        for (int j = 0; j < rows; j++) {
           data[i][j] = random.nextInt();
         }
-      }
-      else if(type.equals(Types.MinorType.FLOAT8)) {
-        for(int j = 0; j < rows; j++) {
+      } else if (type.equals(Types.MinorType.FLOAT8)) {
+        for (int j = 0; j < rows; j++) {
           data[i][j] = random.nextDouble();
         }
       }
     }
     return data;
   }
-
 }

--- a/src/test/java/com/databricks/jdbc/core/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksConnectionTest.java
@@ -1,5 +1,9 @@
 package com.databricks.jdbc.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.client.sqlexec.CreateSessionRequest;
 import com.databricks.jdbc.client.sqlexec.Session;
@@ -7,44 +11,43 @@ import com.databricks.jdbc.driver.DatabricksConnectionContext;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.StatementExecutionService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 public class DatabricksConnectionTest {
 
-  private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
   private static final String WAREHOUSE_ID = "erg6767gg";
   private static final String SESSION_ID = "session_id";
 
-  @Mock
-  StatementExecutionService statementExecutionService;
+  @Mock StatementExecutionService statementExecutionService;
 
-  @Mock
-  ApiClient apiClient;
+  @Mock ApiClient apiClient;
 
   @Test
   public void testConnection() throws Exception {
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksConnection connection = new DatabricksConnection(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection =
+        new DatabricksConnection(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
 
     assertFalse(connection.isClosed());
     assertEquals(connection.getSession().getSessionId(), SESSION_ID);

--- a/src/test/java/com/databricks/jdbc/core/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksPreparedStatementTest.java
@@ -1,5 +1,9 @@
 package com.databricks.jdbc.core;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.client.sqlexec.CreateSessionRequest;
 import com.databricks.jdbc.client.sqlexec.ExecuteStatementRequestWithSession;
@@ -10,17 +14,12 @@ import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.*;
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DatabricksPreparedStatementTest {
@@ -28,65 +27,76 @@ public class DatabricksPreparedStatementTest {
   private static final String WAREHOUSE_ID = "erg6767gg";
   private static final String SESSION_ID = "session_id";
   private static final String STATEMENT_ID = "statement_id";
-  private static final String STATEMENT = "SELECT * FROM orders WHERE user_id = ? AND shard = ? AND region_code = ? AND namespace = ?";
-  private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String STATEMENT =
+      "SELECT * FROM orders WHERE user_id = ? AND shard = ? AND region_code = ? AND namespace = ?";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
 
-
-  @Mock
-  StatementExecutionService statementExecutionService;
-  @Mock
-  ApiClient apiClient;
+  @Mock StatementExecutionService statementExecutionService;
+  @Mock ApiClient apiClient;
 
   @Test
   public void testExecuteStatement() throws Exception {
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
     List<StatementParameterListItem> params = new ArrayList<>();
     params.add(getParam("BIGINT", "100", 1));
     params.add(getParam("SMALLINT", "10", 2));
     params.add(getParam("TINYINT", "15", 3));
     params.add(getParam("STRING", "value", 4));
-    ExecuteStatementRequestWithSession executeStatementRequest = (ExecuteStatementRequestWithSession)
-        new ExecuteStatementRequestWithSession()
-            .setSessionId(SESSION_ID)
-            .setWarehouseId(WAREHOUSE_ID)
-            .setStatement(STATEMENT)
-            .setDisposition(Disposition.EXTERNAL_LINKS)
-            .setFormat(Format.ARROW_STREAM)
-            .setWaitTimeout("10s")
-            .setOnWaitTimeout(TimeoutAction.CONTINUE)
-            .setParameters(params);
+    ExecuteStatementRequestWithSession executeStatementRequest =
+        (ExecuteStatementRequestWithSession)
+            new ExecuteStatementRequestWithSession()
+                .setSessionId(SESSION_ID)
+                .setWarehouseId(WAREHOUSE_ID)
+                .setStatement(STATEMENT)
+                .setDisposition(Disposition.EXTERNAL_LINKS)
+                .setFormat(Format.ARROW_STREAM)
+                .setWaitTimeout("10s")
+                .setOnWaitTimeout(TimeoutAction.CONTINUE)
+                .setParameters(params);
     when(statementExecutionService.executeStatement(executeStatementRequest))
-        .thenReturn(new ExecuteStatementResponse()
-            .setStatementId(STATEMENT_ID)
-            .setStatus(new StatementStatus().setState(StatementState.PENDING)));
+        .thenReturn(
+            new ExecuteStatementResponse()
+                .setStatementId(STATEMENT_ID)
+                .setStatus(new StatementStatus().setState(StatementState.PENDING)));
 
-    GetStatementResponse getResponsePending = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.PENDING));
-    GetStatementResponse getResponseSuccessful = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
-        .setManifest(new ResultManifest()
-            .setFormat(Format.ARROW_STREAM)
-            .setTotalRowCount(0L).setTotalChunkCount(0L)
-            .setChunks(new ArrayList<>())
-            .setSchema(new ResultSchema()
-                .setColumns(new ArrayList<>())))
-        .setResult(new ResultData().setExternalLinks(new ArrayList<>()));
-    GetStatementRequest getStatementRequest = new GetStatementRequest().setStatementId(STATEMENT_ID);
+    GetStatementResponse getResponsePending =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.PENDING));
+    GetStatementResponse getResponseSuccessful =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
+            .setManifest(
+                new ResultManifest()
+                    .setFormat(Format.ARROW_STREAM)
+                    .setTotalRowCount(0L)
+                    .setTotalChunkCount(0L)
+                    .setChunks(new ArrayList<>())
+                    .setSchema(new ResultSchema().setColumns(new ArrayList<>())))
+            .setResult(new ResultData().setExternalLinks(new ArrayList<>()));
+    GetStatementRequest getStatementRequest =
+        new GetStatementRequest().setStatementId(STATEMENT_ID);
     when(statementExecutionService.getStatement(getStatementRequest))
         .thenReturn(getResponsePending, getResponseSuccessful);
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksConnection connection = new DatabricksConnection(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
-    DatabricksPreparedStatement statement = (DatabricksPreparedStatement) connection.prepareStatement(STATEMENT);
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection =
+        new DatabricksConnection(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    DatabricksPreparedStatement statement =
+        (DatabricksPreparedStatement) connection.prepareStatement(STATEMENT);
     statement.setLong(1, 100);
     statement.setShort(2, (short) 10);
     statement.setByte(3, (byte) 15);
@@ -102,73 +112,84 @@ public class DatabricksPreparedStatementTest {
     assertTrue(resultSet.isClosed());
 
     // TODO: add more assertions
-    verify(statementExecutionService, Mockito.times(1))
-        .executeStatement(executeStatementRequest);
-    verify(statementExecutionService, Mockito.times(2))
-        .getStatement(getStatementRequest);
+    verify(statementExecutionService, Mockito.times(1)).executeStatement(executeStatementRequest);
+    verify(statementExecutionService, Mockito.times(2)).getStatement(getStatementRequest);
   }
 
   @Test
   public void testExecuteUpdateStatement() throws Exception {
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
     List<StatementParameterListItem> params = new ArrayList<>();
-    ExecuteStatementRequestWithSession executeStatementRequest = (ExecuteStatementRequestWithSession)
-        new ExecuteStatementRequestWithSession()
-            .setSessionId(SESSION_ID)
-            .setWarehouseId(WAREHOUSE_ID)
-            .setStatement(STATEMENT)
-            .setDisposition(Disposition.INLINE)
-            .setFormat(Format.JSON_ARRAY)
-            .setWaitTimeout("10s")
-            .setOnWaitTimeout(TimeoutAction.CONTINUE)
-            .setParameters(params);
+    ExecuteStatementRequestWithSession executeStatementRequest =
+        (ExecuteStatementRequestWithSession)
+            new ExecuteStatementRequestWithSession()
+                .setSessionId(SESSION_ID)
+                .setWarehouseId(WAREHOUSE_ID)
+                .setStatement(STATEMENT)
+                .setDisposition(Disposition.INLINE)
+                .setFormat(Format.JSON_ARRAY)
+                .setWaitTimeout("10s")
+                .setOnWaitTimeout(TimeoutAction.CONTINUE)
+                .setParameters(params);
     when(statementExecutionService.executeStatement(executeStatementRequest))
-        .thenReturn(new ExecuteStatementResponse()
-            .setStatementId(STATEMENT_ID)
-            .setStatus(new StatementStatus().setState(StatementState.PENDING)));
+        .thenReturn(
+            new ExecuteStatementResponse()
+                .setStatementId(STATEMENT_ID)
+                .setStatus(new StatementStatus().setState(StatementState.PENDING)));
 
-    GetStatementResponse getResponsePending = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.PENDING));
-    GetStatementResponse getResponseSuccessful = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
-        .setManifest(new ResultManifest()
-            .setFormat(Format.JSON_ARRAY)
-            .setTotalRowCount(1L).setTotalChunkCount(1L)
-            .setChunks(new ArrayList<>())
-            .setSchema(new ResultSchema()
-                .setColumns(ImmutableList.of(new ColumnInfo()
-                    .setName("num_affected_rows")
-                    .setTypeText("Long")
-                    .setTypeName(ColumnInfoTypeName.LONG)
-                    .setPosition(0L)))))
-        .setResult(new ResultData()
-            .setDataArray(ImmutableList.of(ImmutableList.of("2"))));
-    GetStatementRequest getStatementRequest = new GetStatementRequest().setStatementId(STATEMENT_ID);
+    GetStatementResponse getResponsePending =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.PENDING));
+    GetStatementResponse getResponseSuccessful =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
+            .setManifest(
+                new ResultManifest()
+                    .setFormat(Format.JSON_ARRAY)
+                    .setTotalRowCount(1L)
+                    .setTotalChunkCount(1L)
+                    .setChunks(new ArrayList<>())
+                    .setSchema(
+                        new ResultSchema()
+                            .setColumns(
+                                ImmutableList.of(
+                                    new ColumnInfo()
+                                        .setName("num_affected_rows")
+                                        .setTypeText("Long")
+                                        .setTypeName(ColumnInfoTypeName.LONG)
+                                        .setPosition(0L)))))
+            .setResult(new ResultData().setDataArray(ImmutableList.of(ImmutableList.of("2"))));
+    GetStatementRequest getStatementRequest =
+        new GetStatementRequest().setStatementId(STATEMENT_ID);
     when(statementExecutionService.getStatement(getStatementRequest))
         .thenReturn(getResponsePending, getResponseSuccessful);
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksConnection connection = new DatabricksConnection(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
-    DatabricksPreparedStatement statement = (DatabricksPreparedStatement) connection.prepareStatement(STATEMENT);
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection =
+        new DatabricksConnection(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    DatabricksPreparedStatement statement =
+        (DatabricksPreparedStatement) connection.prepareStatement(STATEMENT);
     int updateCount = statement.executeUpdate();
 
     assertEquals(2, updateCount);
     assertTrue(statement.resultSet.hasUpdateCount());
     assertFalse(statement.isClosed());
     // TODO: add more assertions
-    verify(statementExecutionService, Mockito.times(1))
-        .executeStatement(executeStatementRequest);
-    verify(statementExecutionService, Mockito.times(2))
-        .getStatement(getStatementRequest);
+    verify(statementExecutionService, Mockito.times(1)).executeStatement(executeStatementRequest);
+    verify(statementExecutionService, Mockito.times(2)).getStatement(getStatementRequest);
 
     // close the statement
     statement.close();

--- a/src/test/java/com/databricks/jdbc/core/DatabricksSessionTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksSessionTest.java
@@ -1,5 +1,8 @@
 package com.databricks.jdbc.core;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.client.sqlexec.CreateSessionRequest;
 import com.databricks.jdbc.client.sqlexec.Session;
@@ -7,44 +10,45 @@ import com.databricks.jdbc.driver.DatabricksConnectionContext;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.StatementExecutionService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 public class DatabricksSessionTest {
 
-  private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
-  private static final String JDBC_URL_INVALID = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehou/erg6767gg;";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String JDBC_URL_INVALID =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehou/erg6767gg;";
   private static final String WAREHOUSE_ID = "erg6767gg";
   private static final String SESSION_ID = "session_id";
 
-  @Mock
-  StatementExecutionService statementExecutionService;
+  @Mock StatementExecutionService statementExecutionService;
 
-  @Mock
-  ApiClient apiClient;
+  @Mock ApiClient apiClient;
 
   @Test
   public void testOpenSession() {
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksSession session = new DatabricksSession(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSession session =
+        new DatabricksSession(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
 
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
     assertFalse(session.isOpen());
     session.open();
@@ -58,8 +62,10 @@ public class DatabricksSessionTest {
 
   @Test
   public void testOpenSession_invalidWarehouseUrl() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new DatabricksSession(DatabricksConnectionContext.parse(JDBC_URL_INVALID, new Properties()),
-            null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new DatabricksSession(
+                DatabricksConnectionContext.parse(JDBC_URL_INVALID, new Properties()), null));
   }
 }

--- a/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
@@ -1,5 +1,9 @@
 package com.databricks.jdbc.core;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.databricks.jdbc.client.impl.DatabricksSdkClient;
 import com.databricks.jdbc.client.sqlexec.CreateSessionRequest;
 import com.databricks.jdbc.client.sqlexec.ExecuteStatementRequestWithSession;
@@ -9,17 +13,12 @@ import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.service.sql.*;
 import com.google.common.collect.ImmutableList;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DatabricksStatementTest {
@@ -28,59 +27,68 @@ public class DatabricksStatementTest {
   private static final String SESSION_ID = "session_id";
   private static final String STATEMENT_ID = "statement_id";
   private static final String STATEMENT = "select 1";
-  private static final String JDBC_URL = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String JDBC_URL =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
 
-
-  @Mock
-  StatementExecutionService statementExecutionService;
-  @Mock
-  ApiClient apiClient;
+  @Mock StatementExecutionService statementExecutionService;
+  @Mock ApiClient apiClient;
 
   @Test
   public void testExecuteStatement() throws Exception {
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
     List<StatementParameterListItem> params = new ArrayList<>();
-    ExecuteStatementRequestWithSession executeStatementRequest = (ExecuteStatementRequestWithSession)
-        new ExecuteStatementRequestWithSession()
-            .setSessionId(SESSION_ID)
-            .setWarehouseId(WAREHOUSE_ID)
-            .setStatement(STATEMENT)
-            .setDisposition(Disposition.EXTERNAL_LINKS)
-            .setFormat(Format.ARROW_STREAM)
-            .setWaitTimeout("10s")
-            .setOnWaitTimeout(TimeoutAction.CONTINUE)
-            .setParameters(params);
+    ExecuteStatementRequestWithSession executeStatementRequest =
+        (ExecuteStatementRequestWithSession)
+            new ExecuteStatementRequestWithSession()
+                .setSessionId(SESSION_ID)
+                .setWarehouseId(WAREHOUSE_ID)
+                .setStatement(STATEMENT)
+                .setDisposition(Disposition.EXTERNAL_LINKS)
+                .setFormat(Format.ARROW_STREAM)
+                .setWaitTimeout("10s")
+                .setOnWaitTimeout(TimeoutAction.CONTINUE)
+                .setParameters(params);
     when(statementExecutionService.executeStatement(executeStatementRequest))
-        .thenReturn(new ExecuteStatementResponse()
-            .setStatementId(STATEMENT_ID)
-            .setStatus(new StatementStatus().setState(StatementState.PENDING)));
+        .thenReturn(
+            new ExecuteStatementResponse()
+                .setStatementId(STATEMENT_ID)
+                .setStatus(new StatementStatus().setState(StatementState.PENDING)));
 
-    GetStatementResponse getResponsePending = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.PENDING));
-    GetStatementResponse getResponseSuccessful = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
-        .setManifest(new ResultManifest()
-            .setFormat(Format.ARROW_STREAM)
-            .setTotalRowCount(0L).setTotalChunkCount(0L)
-            .setChunks(new ArrayList<>())
-            .setSchema(new ResultSchema()
-                .setColumns(new ArrayList<>())))
-        .setResult(new ResultData().setExternalLinks(new ArrayList<>()));
-    GetStatementRequest getStatementRequest = new GetStatementRequest().setStatementId(STATEMENT_ID);
+    GetStatementResponse getResponsePending =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.PENDING));
+    GetStatementResponse getResponseSuccessful =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
+            .setManifest(
+                new ResultManifest()
+                    .setFormat(Format.ARROW_STREAM)
+                    .setTotalRowCount(0L)
+                    .setTotalChunkCount(0L)
+                    .setChunks(new ArrayList<>())
+                    .setSchema(new ResultSchema().setColumns(new ArrayList<>())))
+            .setResult(new ResultData().setExternalLinks(new ArrayList<>()));
+    GetStatementRequest getStatementRequest =
+        new GetStatementRequest().setStatementId(STATEMENT_ID);
     when(statementExecutionService.getStatement(getStatementRequest))
         .thenReturn(getResponsePending, getResponseSuccessful);
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksConnection connection = new DatabricksConnection(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection =
+        new DatabricksConnection(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
     DatabricksStatement statement = (DatabricksStatement) connection.createStatement();
     DatabricksResultSet resultSet = (DatabricksResultSet) statement.executeQuery(STATEMENT);
     assertFalse(resultSet.hasUpdateCount());
@@ -92,62 +100,74 @@ public class DatabricksStatementTest {
     assertTrue(resultSet.isClosed());
 
     // TODO: add more assertions
-    verify(statementExecutionService, Mockito.times(1))
-        .executeStatement(executeStatementRequest);
-    verify(statementExecutionService, Mockito.times(2))
-        .getStatement(getStatementRequest);
+    verify(statementExecutionService, Mockito.times(1)).executeStatement(executeStatementRequest);
+    verify(statementExecutionService, Mockito.times(2)).getStatement(getStatementRequest);
   }
 
   @Test
   public void testExecuteUpdateStatement() throws Exception {
-    CreateSessionRequest createSessionRequest = new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
+    CreateSessionRequest createSessionRequest =
+        new CreateSessionRequest().setWarehouseId(WAREHOUSE_ID);
     Map<String, String> headers = new HashMap<>();
     headers.put("Accept", "application/json");
     headers.put("Content-Type", "application/json");
-    when(apiClient.POST("/api/2.0/sql/statements/sessions", createSessionRequest,
-        Session.class, headers)).thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
+    when(apiClient.POST(
+            "/api/2.0/sql/statements/sessions", createSessionRequest, Session.class, headers))
+        .thenReturn(new Session().setWarehouseId(WAREHOUSE_ID).setSessionId(SESSION_ID));
 
     List<StatementParameterListItem> params = new ArrayList<>();
-    ExecuteStatementRequestWithSession executeStatementRequest = (ExecuteStatementRequestWithSession)
-        new ExecuteStatementRequestWithSession()
-            .setSessionId(SESSION_ID)
-            .setWarehouseId(WAREHOUSE_ID)
-            .setStatement(STATEMENT)
-            .setDisposition(Disposition.INLINE)
-            .setFormat(Format.JSON_ARRAY)
-            .setWaitTimeout("10s")
-            .setOnWaitTimeout(TimeoutAction.CONTINUE)
-            .setParameters(params);
+    ExecuteStatementRequestWithSession executeStatementRequest =
+        (ExecuteStatementRequestWithSession)
+            new ExecuteStatementRequestWithSession()
+                .setSessionId(SESSION_ID)
+                .setWarehouseId(WAREHOUSE_ID)
+                .setStatement(STATEMENT)
+                .setDisposition(Disposition.INLINE)
+                .setFormat(Format.JSON_ARRAY)
+                .setWaitTimeout("10s")
+                .setOnWaitTimeout(TimeoutAction.CONTINUE)
+                .setParameters(params);
     when(statementExecutionService.executeStatement(executeStatementRequest))
-        .thenReturn(new ExecuteStatementResponse()
-            .setStatementId(STATEMENT_ID)
-            .setStatus(new StatementStatus().setState(StatementState.PENDING)));
+        .thenReturn(
+            new ExecuteStatementResponse()
+                .setStatementId(STATEMENT_ID)
+                .setStatus(new StatementStatus().setState(StatementState.PENDING)));
 
-    GetStatementResponse getResponsePending = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.PENDING));
-    GetStatementResponse getResponseSuccessful = new GetStatementResponse()
-        .setStatementId(STATEMENT_ID)
-        .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
-        .setManifest(new ResultManifest()
-            .setFormat(Format.JSON_ARRAY)
-            .setTotalRowCount(1L).setTotalChunkCount(1L)
-            .setChunks(new ArrayList<>())
-            .setSchema(new ResultSchema()
-                .setColumns(ImmutableList.of(new ColumnInfo()
-                    .setName("num_affected_rows")
-                        .setTypeText("Long")
-                    .setTypeName(ColumnInfoTypeName.LONG)
-                    .setPosition(0L)))))
-        .setResult(new ResultData()
-            .setDataArray(ImmutableList.of(ImmutableList.of("2"))));
-    GetStatementRequest getStatementRequest = new GetStatementRequest().setStatementId(STATEMENT_ID);
+    GetStatementResponse getResponsePending =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.PENDING));
+    GetStatementResponse getResponseSuccessful =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID)
+            .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED))
+            .setManifest(
+                new ResultManifest()
+                    .setFormat(Format.JSON_ARRAY)
+                    .setTotalRowCount(1L)
+                    .setTotalChunkCount(1L)
+                    .setChunks(new ArrayList<>())
+                    .setSchema(
+                        new ResultSchema()
+                            .setColumns(
+                                ImmutableList.of(
+                                    new ColumnInfo()
+                                        .setName("num_affected_rows")
+                                        .setTypeText("Long")
+                                        .setTypeName(ColumnInfoTypeName.LONG)
+                                        .setPosition(0L)))))
+            .setResult(new ResultData().setDataArray(ImmutableList.of(ImmutableList.of("2"))));
+    GetStatementRequest getStatementRequest =
+        new GetStatementRequest().setStatementId(STATEMENT_ID);
     when(statementExecutionService.getStatement(getStatementRequest))
         .thenReturn(getResponsePending, getResponseSuccessful);
 
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
-    DatabricksConnection connection = new DatabricksConnection(connectionContext,
-        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection =
+        new DatabricksConnection(
+            connectionContext,
+            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
     DatabricksStatement statement = (DatabricksStatement) connection.createStatement();
     int updateCount = statement.executeUpdate(STATEMENT);
 
@@ -155,10 +175,8 @@ public class DatabricksStatementTest {
     assertTrue(statement.resultSet.hasUpdateCount());
     assertFalse(statement.isClosed());
     // TODO: add more assertions
-    verify(statementExecutionService, Mockito.times(1))
-        .executeStatement(executeStatementRequest);
-    verify(statementExecutionService, Mockito.times(2))
-        .getStatement(getStatementRequest);
+    verify(statementExecutionService, Mockito.times(1)).executeStatement(executeStatementRequest);
+    verify(statementExecutionService, Mockito.times(2)).getStatement(getStatementRequest);
 
     // close the statement
     statement.close();

--- a/src/test/java/com/databricks/jdbc/core/converters/BigDecimalConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/BigDecimalConverterTest.java
@@ -1,118 +1,136 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class BigDecimalConverterTest {
 
-    private BigDecimal NON_ZERO_OBJECT = BigDecimal.valueOf(10.2);
-    private BigDecimal ZERO_OBJECT = BigDecimal.valueOf(0);
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  private BigDecimal NON_ZERO_OBJECT = BigDecimal.valueOf(10.2);
+  private BigDecimal ZERO_OBJECT = BigDecimal.valueOf(0);
 
-        BigDecimal bigDecimalThatDoesNotFitInByte = BigDecimal.valueOf(257.1);
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+    BigDecimal bigDecimalThatDoesNotFitInByte = BigDecimal.valueOf(257.1);
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToShort(), (short) 0);
 
-        BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(32768.1);
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(32768.1);
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToInt(), (int) 0);
 
-        BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(2147483648.1);
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToInt());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(2147483648.1);
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToInt());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToLong(), 0L);
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToLong(), 0L);
 
-        BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(9223372036854775808.1);
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToLong());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    BigDecimal bigDecimalThatDoesNotFitInInt = BigDecimal.valueOf(9223372036854775808.1);
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(bigDecimalThatDoesNotFitInInt).convertToLong());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10.2));
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(
+        new BigDecimalConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10.2));
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToByteArray(),
-               BigDecimal.valueOf(10.2).toBigInteger().toByteArray()));
-        assertTrue(Arrays.equals(new BigDecimalConverter(ZERO_OBJECT).convertToByteArray(),
-                BigDecimal.valueOf(0).toBigInteger().toByteArray()));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new BigDecimalConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            BigDecimal.valueOf(10.2).toBigInteger().toByteArray()));
+    assertTrue(
+        Arrays.equals(
+            new BigDecimalConverter(ZERO_OBJECT).convertToByteArray(),
+            BigDecimal.valueOf(0).toBigInteger().toByteArray()));
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
-        assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToString(), "0");
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new BigDecimalConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
+    assertEquals(new BigDecimalConverter(ZERO_OBJECT).convertToString(), "0");
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BigDecimalConverter(NON_ZERO_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/BooleanConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/BooleanConverterTest.java
@@ -1,94 +1,99 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class BooleanConverterTest {
 
-    private boolean TRUE_OBJECT = true;
-    private boolean FALSE_OBJECT = false;
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToByte(), (byte) 1);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToByte(), (byte) 0);
-    }
+  private boolean TRUE_OBJECT = true;
+  private boolean FALSE_OBJECT = false;
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToShort(), (short) 1);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToShort(), (short) 0);
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToByte(), (byte) 1);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToByte(), (byte) 0);
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToInt(), (int) 1);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToInt(), (int) 0);
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToShort(), (short) 1);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToShort(), (short) 0);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToLong(), 1L);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToLong(), 0L);
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToInt(), (int) 1);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToInt(), (int) 0);
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToFloat(), 1f);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToLong(), 1L);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToLong(), 0L);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToDouble(), (double) 1);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToFloat(), 1f);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(1));
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToDouble(), (double) 1);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToBoolean(), true);
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(1));
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new BooleanConverter(TRUE_OBJECT).convertToByteArray(), new byte[]{1}));
-        assertTrue(Arrays.equals(new BooleanConverter(FALSE_OBJECT).convertToByteArray(), new byte[]{0}));
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToBoolean(), true);
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToChar(), '1');
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToChar(), '0');
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(new BooleanConverter(TRUE_OBJECT).convertToByteArray(), new byte[] {1}));
+    assertTrue(
+        Arrays.equals(new BooleanConverter(FALSE_OBJECT).convertToByteArray(), new byte[] {0}));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new BooleanConverter(TRUE_OBJECT).convertToString(), "true");
-        assertEquals(new BooleanConverter(FALSE_OBJECT).convertToString(), "false");
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToChar(), '1');
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToChar(), '0');
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BooleanConverter(TRUE_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new BooleanConverter(TRUE_OBJECT).convertToString(), "true");
+    assertEquals(new BooleanConverter(FALSE_OBJECT).convertToString(), "false");
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new BooleanConverter(TRUE_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new BooleanConverter(TRUE_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
+
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class, () -> new BooleanConverter(TRUE_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/ByteConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/ByteConverterTest.java
@@ -1,94 +1,99 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ByteConverterTest {
 
-    private byte NON_ZERO_OBJECT = 65;
-    private byte ZERO_OBJECT = 0;
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 65);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
-    }
+  private byte NON_ZERO_OBJECT = 65;
+  private byte ZERO_OBJECT = 0;
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToShort(), (short) 65);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToShort(), (short) 0);
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 65);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToInt(), (int) 65);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToInt(), (int) 0);
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToShort(), (short) 65);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToLong(), 65L);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToLong(), 0L);
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToInt(), (int) 65);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToFloat(), 65f);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToLong(), 65L);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToLong(), 0L);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 65);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToFloat(), 65f);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(65));
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 65);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new ByteConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(65));
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new ByteConverter(NON_ZERO_OBJECT).convertToByteArray(), new byte[]{65}));
-        assertTrue(Arrays.equals(new ByteConverter(ZERO_OBJECT).convertToByteArray(), new byte[]{0}));
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new ByteConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ByteConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(new ByteConverter(NON_ZERO_OBJECT).convertToByteArray(), new byte[] {65}));
+    assertTrue(Arrays.equals(new ByteConverter(ZERO_OBJECT).convertToByteArray(), new byte[] {0}));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToString(), "A");
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class, () -> new ByteConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ByteConverter(NON_ZERO_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new ByteConverter(NON_ZERO_OBJECT).convertToString(), "A");
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ByteConverter(NON_ZERO_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new ByteConverter(NON_ZERO_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
+
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class, () -> new ByteConverter(NON_ZERO_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/DateConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/DateConverterTest.java
@@ -1,45 +1,46 @@
 package com.databricks.jdbc.core.converters;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
-
-
 import java.sql.Date;
 import java.sql.Timestamp;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class DateConverterTest {
 
-    private Date DATE = Date.valueOf("2023-09-10");
+  private Date DATE = Date.valueOf("2023-09-10");
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new DateConverter(DATE).convertToShort(), 19610);
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new DateConverter(DATE).convertToShort(), 19610);
 
-        Date dateDoesNotFitInShort = Date.valueOf("5050-12-31");
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DateConverter(dateDoesNotFitInShort).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    Date dateDoesNotFitInShort = Date.valueOf("5050-12-31");
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DateConverter(dateDoesNotFitInShort).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new DateConverter(DATE).convertToInt(), 19610);
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new DateConverter(DATE).convertToInt(), 19610);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new DateConverter(DATE).convertToLong(), 19610L);
-    }
-    //
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new DateConverter(DATE).convertToString(), "2023-09-10");
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new DateConverter(DATE).convertToLong(), 19610L);
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        assertEquals(new DateConverter(DATE).convertToDate(), Timestamp.valueOf("2023-09-10 00:00:00"));
-    }
+  //
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new DateConverter(DATE).convertToString(), "2023-09-10");
+  }
+
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    assertEquals(new DateConverter(DATE).convertToDate(), Timestamp.valueOf("2023-09-10 00:00:00"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/DoubleConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/DoubleConverterTest.java
@@ -1,123 +1,146 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class DoubleConverterTest {
 
-    private double NON_ZERO_OBJECT = 10.2;
-    private double ZERO_OBJECT = 0;
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  private double NON_ZERO_OBJECT = 10.2;
+  private double ZERO_OBJECT = 0;
 
-        double doubleThatDoesNotFitInByte = 128.5;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(doubleThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+    double doubleThatDoesNotFitInByte = 128.5;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(doubleThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        double doubleThatDoesNotFitInShort = 32768.1;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(doubleThatDoesNotFitInShort).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToShort(), (short) 0);
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+    double doubleThatDoesNotFitInShort = 32768.1;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(doubleThatDoesNotFitInShort).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        double doubleThatDoesNotFitInInt = 2147483648.5;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(doubleThatDoesNotFitInInt).convertToInt());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToInt(), (int) 0);
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToLong(), 0L);
+    double doubleThatDoesNotFitInInt = 2147483648.5;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(doubleThatDoesNotFitInInt).convertToInt());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        double doubleThatDoesNotFitInLong = 1.5E20;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(doubleThatDoesNotFitInLong).convertToLong());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToLong(), 0L);
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToFloat(), 0f);
+    double doubleThatDoesNotFitInLong = 1.5E20;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(doubleThatDoesNotFitInLong).convertToLong());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        double doubleThatDoesNotFitInFloat = 1.5E40;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(doubleThatDoesNotFitInFloat).convertToFloat());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToFloat(), 0f);
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+    double doubleThatDoesNotFitInFloat = 1.5E40;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(doubleThatDoesNotFitInFloat).convertToFloat());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Double.toString(10.2)));
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Double.toString(0)));
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(
+        new DoubleConverter(NON_ZERO_OBJECT).convertToBigDecimal(),
+        new BigDecimal(Double.toString(10.2)));
+    assertEquals(
+        new DoubleConverter(ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Double.toString(0)));
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new DoubleConverter(NON_ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(8).putDouble(10.2).array()));
-        assertTrue(Arrays.equals(new DoubleConverter(ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(8).putDouble(0).array()));
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new DoubleConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(8).putDouble(10.2).array()));
+    assertTrue(
+        Arrays.equals(
+            new DoubleConverter(ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(8).putDouble(0).array()));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
-        assertEquals(new DoubleConverter(ZERO_OBJECT).convertToString(), "0.0");
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(NON_ZERO_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new DoubleConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
+    assertEquals(new DoubleConverter(ZERO_OBJECT).convertToString(), "0.0");
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new DoubleConverter(NON_ZERO_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(NON_ZERO_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
+
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new DoubleConverter(NON_ZERO_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/FloatConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/FloatConverterTest.java
@@ -1,118 +1,139 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class FloatConverterTest {
 
-    private float NON_ZERO_OBJECT = 10.2f;
-    private float ZERO_OBJECT = 0f;
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  private float NON_ZERO_OBJECT = 10.2f;
+  private float ZERO_OBJECT = 0f;
 
-        float floatThatDoesNotFitInByte = 128.5f;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(floatThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+    float floatThatDoesNotFitInByte = 128.5f;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(floatThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        float floatThatDoesNotFitInShort = 32768.1f;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(floatThatDoesNotFitInShort).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToShort(), (short) 0);
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+    float floatThatDoesNotFitInShort = 32768.1f;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(floatThatDoesNotFitInShort).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        float floatThatDoesNotFitInInt = 2147483648.5f;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(floatThatDoesNotFitInInt).convertToInt());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToInt(), (int) 0);
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToLong(), 0L);
+    float floatThatDoesNotFitInInt = 2147483648.5f;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(floatThatDoesNotFitInInt).convertToInt());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-        float floatThatDoesNotFitInLong = 1.5E20f;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(floatThatDoesNotFitInLong).convertToLong());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToLong(), 0L);
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+    float floatThatDoesNotFitInLong = 1.5E20f;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(floatThatDoesNotFitInLong).convertToLong());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2f);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToFloat(), 10.2f);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Float.toString(10.2f)));
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Float.toString(0f)));
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10.2f);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(
+        new FloatConverter(NON_ZERO_OBJECT).convertToBigDecimal(),
+        new BigDecimal(Float.toString(10.2f)));
+    assertEquals(
+        new FloatConverter(ZERO_OBJECT).convertToBigDecimal(), new BigDecimal(Float.toString(0f)));
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new FloatConverter(NON_ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(4).putFloat(10.2f).array()));
-        assertTrue(Arrays.equals(new FloatConverter(ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(4).putFloat(0f).array()));
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new FloatConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(4).putFloat(10.2f).array()));
+    assertTrue(
+        Arrays.equals(
+            new FloatConverter(ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(4).putFloat(0f).array()));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
-        assertEquals(new FloatConverter(ZERO_OBJECT).convertToString(), "0.0");
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(NON_ZERO_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new FloatConverter(NON_ZERO_OBJECT).convertToString(), "10.2");
+    assertEquals(new FloatConverter(ZERO_OBJECT).convertToString(), "0.0");
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new FloatConverter(NON_ZERO_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(NON_ZERO_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
+
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new FloatConverter(NON_ZERO_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/IntConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/IntConverterTest.java
@@ -1,109 +1,121 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class IntConverterTest {
 
-    private int NON_ZERO_OBJECT = 10;
-    private int ZERO_OBJECT = 0;
+  private int NON_ZERO_OBJECT = 10;
+  private int ZERO_OBJECT = 0;
 
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-        int intThatDoesNotFitInByte = 257;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new IntConverter(intThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    int intThatDoesNotFitInByte = 257;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new IntConverter(intThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToShort(), (short) 0);
 
-        int intThatDoesNotFitInShort = 32768;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new IntConverter(intThatDoesNotFitInShort).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    int intThatDoesNotFitInShort = 32768;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new IntConverter(intThatDoesNotFitInShort).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToInt(), (int) 0);
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToLong(), 0L);
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToLong(), 0L);
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new IntConverter(NON_ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(4).putInt(10).array()));
-        assertTrue(Arrays.equals(new IntConverter(ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(4).putInt(0).array()));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new IntConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(4).putInt(10).array()));
+    assertTrue(
+        Arrays.equals(
+            new IntConverter(ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(4).putInt(0).array()));
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new IntConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class, () -> new IntConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToString(), "10");
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToString(), "0");
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToString(), "10");
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToString(), "0");
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToTimestamp(), Timestamp.valueOf("1970-01-01 05:30:00.01"));
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToTimestamp(), Timestamp.valueOf("1970-01-01 05:30:00"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    assertEquals(
+        new IntConverter(NON_ZERO_OBJECT).convertToTimestamp(),
+        Timestamp.valueOf("1970-01-01 05:30:00.01"));
+    assertEquals(
+        new IntConverter(ZERO_OBJECT).convertToTimestamp(),
+        Timestamp.valueOf("1970-01-01 05:30:00"));
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-11"));
-        assertEquals(new IntConverter(ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-01"));
-    }
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    assertEquals(new IntConverter(NON_ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-11"));
+    assertEquals(new IntConverter(ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-01"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/LongConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/LongConverterTest.java
@@ -1,114 +1,128 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class LongConverterTest {
 
-    private long NON_ZERO_OBJECT = 10L;
-    private long ZERO_OBJECT = 0;
+  private long NON_ZERO_OBJECT = 10L;
+  private long ZERO_OBJECT = 0;
 
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-        long longThatDoesNotFitInByte = 257L;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new LongConverter(longThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    long longThatDoesNotFitInByte = 257L;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new LongConverter(longThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToShort(), (short) 0);
 
-        long longThatDoesNotFitInShort = 32768L;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new LongConverter(longThatDoesNotFitInShort).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    long longThatDoesNotFitInShort = 32768L;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new LongConverter(longThatDoesNotFitInShort).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToInt(), (int) 0);
 
-        long longThatDoesNotFitInInt = 2147483648L;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new LongConverter(longThatDoesNotFitInInt).convertToShort());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    long longThatDoesNotFitInInt = 2147483648L;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new LongConverter(longThatDoesNotFitInInt).convertToShort());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToLong(), 0L);
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToLong(), 0L);
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new LongConverter(NON_ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(8).putLong(10L).array()));
-        assertTrue(Arrays.equals(new LongConverter(ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(8).putLong(0).array()));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new LongConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(8).putLong(10L).array()));
+    assertTrue(
+        Arrays.equals(
+            new LongConverter(ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(8).putLong(0).array()));
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new LongConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class, () -> new LongConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToString(), "10");
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToString(), "0");
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToString(), "10");
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToString(), "0");
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToTimestamp(), Timestamp.valueOf("1970-01-01 05:30:00.01"));
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToTimestamp(), Timestamp.valueOf("1970-01-01 05:30:00"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    assertEquals(
+        new LongConverter(NON_ZERO_OBJECT).convertToTimestamp(),
+        Timestamp.valueOf("1970-01-01 05:30:00.01"));
+    assertEquals(
+        new LongConverter(ZERO_OBJECT).convertToTimestamp(),
+        Timestamp.valueOf("1970-01-01 05:30:00"));
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-11"));
-        assertEquals(new LongConverter(ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-01"));
-    }
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    assertEquals(new LongConverter(NON_ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-11"));
+    assertEquals(new LongConverter(ZERO_OBJECT).convertToDate(), Date.valueOf("1970-01-01"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/ShortConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/ShortConverterTest.java
@@ -1,104 +1,115 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ShortConverterTest {
 
-    private short NON_ZERO_OBJECT = 10;
-    private short ZERO_OBJECT = 0;
+  private short NON_ZERO_OBJECT = 10;
+  private short ZERO_OBJECT = 0;
 
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToByte(), (byte) 10);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToByte(), (byte) 0);
 
-        short shortThatDoesNotFitInByte = 257;
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ShortConverter(shortThatDoesNotFitInByte).convertToByte());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+    short shortThatDoesNotFitInByte = 257;
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new ShortConverter(shortThatDoesNotFitInByte).convertToByte());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToShort(), (short) 0);
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToShort(), (short) 10);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToShort(), (short) 0);
+  }
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToInt(), (int) 0);
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToInt(), (int) 10);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToInt(), (int) 0);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToLong(), 0L);
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToLong(), 10L);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToLong(), 0L);
+  }
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToFloat(), 0f);
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToFloat(), 10f);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToFloat(), 0f);
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToDouble(), (double) 10);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToDouble(), (double) 0);
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
-    }
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(10));
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToBigDecimal(), BigDecimal.valueOf(0));
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToBoolean(), false);
-    }
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToBoolean(), true);
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToBoolean(), false);
+  }
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new ShortConverter(NON_ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(2).putShort((short) 10).array()));
-        assertTrue(Arrays.equals(new ShortConverter(ZERO_OBJECT).convertToByteArray(),
-                ByteBuffer.allocate(2).putShort((short) 0).array()));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new ShortConverter(NON_ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(2).putShort((short) 10).array()));
+    assertTrue(
+        Arrays.equals(
+            new ShortConverter(ZERO_OBJECT).convertToByteArray(),
+            ByteBuffer.allocate(2).putShort((short) 0).array()));
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ShortConverter(NON_ZERO_OBJECT).convertToChar());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new ShortConverter(NON_ZERO_OBJECT).convertToChar());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToString(), "10");
-        assertEquals(new ShortConverter(ZERO_OBJECT).convertToString(), "0");
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new ShortConverter(NON_ZERO_OBJECT).convertToString(), "10");
+    assertEquals(new ShortConverter(ZERO_OBJECT).convertToString(), "0");
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ShortConverter(NON_ZERO_OBJECT).convertToTimestamp());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new ShortConverter(NON_ZERO_OBJECT).convertToTimestamp());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new ShortConverter(NON_ZERO_OBJECT).convertToDate());
-        assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
-    }
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new ShortConverter(NON_ZERO_OBJECT).convertToDate());
+    assertTrue(exception.getMessage().contains("Unsupported conversion operation"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/StringConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/StringConverterTest.java
@@ -1,149 +1,187 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class StringConverterTest {
 
-    private String NUMERICAL_STRING = "10";
-    private String NUMBERICAL_ZERO_STRING = "0";
+  private String NUMERICAL_STRING = "10";
+  private String NUMBERICAL_ZERO_STRING = "0";
 
-    private String CHARACTER_STRING = "ABC";
+  private String CHARACTER_STRING = "ABC";
 
-    private String TIME_STAMP_STRING = "2023-09-10 00:00:00";
+  private String TIME_STAMP_STRING = "2023-09-10 00:00:00";
 
-    private String DATE_STRING = "2023-09-10";
-    @Test
-    public void testConvertToByte() throws DatabricksSQLException {
-        String singleCharacterString = "A";
-        assertEquals(new StringConverter(singleCharacterString).convertToByte(), (byte) 'A');
+  private String DATE_STRING = "2023-09-10";
 
-        DatabricksSQLException tooManyCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToByte());
-        assertTrue(tooManyCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToByte() throws DatabricksSQLException {
+    String singleCharacterString = "A";
+    assertEquals(new StringConverter(singleCharacterString).convertToByte(), (byte) 'A');
 
-    @Test
-    public void testConvertToShort() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToShort(), (short) 10);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToShort(), (short) 0);
+    DatabricksSQLException tooManyCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToByte());
+    assertTrue(tooManyCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-        String stringThatDoesNotFitInShort = "32768";
-        DatabricksSQLException outOfRangeException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(stringThatDoesNotFitInShort).convertToShort());
-        assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToShort());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToShort() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToShort(), (short) 10);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToShort(), (short) 0);
 
-    @Test
-    public void testConvertToInt() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToInt(), (int) 10);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToInt(), (int) 0);
+    String stringThatDoesNotFitInShort = "32768";
+    DatabricksSQLException outOfRangeException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(stringThatDoesNotFitInShort).convertToShort());
+    assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToShort());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-        String stringThatDoesNotFitInInt = "2147483648";
-        DatabricksSQLException outOfRangeException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(stringThatDoesNotFitInInt).convertToInt());
-        assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToInt());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToInt() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToInt(), (int) 10);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToInt(), (int) 0);
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToLong(), (long) 10);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToLong(), (long) 0);
+    String stringThatDoesNotFitInInt = "2147483648";
+    DatabricksSQLException outOfRangeException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(stringThatDoesNotFitInInt).convertToInt());
+    assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToInt());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-        String stringThatDoesNotFitInLong = "9223372036854775808";
-        DatabricksSQLException outOfRangeException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(stringThatDoesNotFitInLong).convertToLong());
-        assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToLong());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToLong(), (long) 10);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToLong(), (long) 0);
 
-    @Test
-    public void testConvertToFloat() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToFloat(), 10f);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToFloat(), 0f);
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToLong());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+    String stringThatDoesNotFitInLong = "9223372036854775808";
+    DatabricksSQLException outOfRangeException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(stringThatDoesNotFitInLong).convertToLong());
+    assertTrue(outOfRangeException.getMessage().contains("Invalid conversion"));
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToLong());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToDouble() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToDouble(), (double) 10);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToDouble(), (double) 0);
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToLong());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToFloat() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToFloat(), 10f);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToFloat(), 0f);
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToLong());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToBigDecimal() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToBigDecimal(), new BigDecimal("10"));
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToBigDecimal(), new BigDecimal("0"));
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToLong());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToDouble() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToDouble(), (double) 10);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToDouble(), (double) 0);
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToLong());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToBoolean() throws DatabricksSQLException {
-        assertEquals(new StringConverter("1").convertToBoolean(), true);
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToBoolean(), false);
-        assertEquals(new StringConverter("true").convertToBoolean(), true);
-        assertEquals(new StringConverter("false").convertToBoolean(), false);
+  @Test
+  public void testConvertToBigDecimal() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToBigDecimal(), new BigDecimal("10"));
+    assertEquals(
+        new StringConverter(NUMBERICAL_ZERO_STRING).convertToBigDecimal(), new BigDecimal("0"));
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToLong());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  }
 
-        DatabricksSQLException invalidCharactersException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(CHARACTER_STRING).convertToBoolean());
-        assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
+  @Test
+  public void testConvertToBoolean() throws DatabricksSQLException {
+    assertEquals(new StringConverter("1").convertToBoolean(), true);
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToBoolean(), false);
+    assertEquals(new StringConverter("true").convertToBoolean(), true);
+    assertEquals(new StringConverter("false").convertToBoolean(), false);
 
-        DatabricksSQLException invalidNumberException =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(NUMERICAL_STRING).convertToBoolean());
-        assertTrue(invalidNumberException.getMessage().contains("Invalid conversion"));
-    }
+    DatabricksSQLException invalidCharactersException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(CHARACTER_STRING).convertToBoolean());
+    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
 
-    @Test
-    public void testConvertToByteArray() throws DatabricksSQLException {
-        assertTrue(Arrays.equals(new StringConverter(NUMERICAL_STRING).convertToByteArray(), NUMERICAL_STRING.getBytes()));
-        assertTrue(Arrays.equals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToByteArray(), NUMBERICAL_ZERO_STRING.getBytes()));
-        assertTrue(Arrays.equals(new StringConverter(CHARACTER_STRING).convertToByteArray(), CHARACTER_STRING.getBytes()));
-    }
+    DatabricksSQLException invalidNumberException =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(NUMERICAL_STRING).convertToBoolean());
+    assertTrue(invalidNumberException.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToChar() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToChar(), '0');
-        DatabricksSQLException exception =
-                assertThrows(DatabricksSQLException.class, () -> new StringConverter(NUMERICAL_STRING).convertToChar());
-        assertTrue(exception.getMessage().contains("Invalid conversion"));
-    }
+  @Test
+  public void testConvertToByteArray() throws DatabricksSQLException {
+    assertTrue(
+        Arrays.equals(
+            new StringConverter(NUMERICAL_STRING).convertToByteArray(),
+            NUMERICAL_STRING.getBytes()));
+    assertTrue(
+        Arrays.equals(
+            new StringConverter(NUMBERICAL_ZERO_STRING).convertToByteArray(),
+            NUMBERICAL_ZERO_STRING.getBytes()));
+    assertTrue(
+        Arrays.equals(
+            new StringConverter(CHARACTER_STRING).convertToByteArray(),
+            CHARACTER_STRING.getBytes()));
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new StringConverter(NUMERICAL_STRING).convertToString(), "10");
-        assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToString(), "0");
-        assertEquals(new StringConverter(CHARACTER_STRING).convertToString(), "ABC");
-    }
+  @Test
+  public void testConvertToChar() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToChar(), '0');
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StringConverter(NUMERICAL_STRING).convertToChar());
+    assertTrue(exception.getMessage().contains("Invalid conversion"));
+  }
 
-    @Test
-    public void testConvertToTimestamp() throws DatabricksSQLException {
-        assertEquals(new StringConverter(TIME_STAMP_STRING).convertToTimestamp(), Timestamp.valueOf(TIME_STAMP_STRING));
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new StringConverter(NUMERICAL_STRING).convertToString(), "10");
+    assertEquals(new StringConverter(NUMBERICAL_ZERO_STRING).convertToString(), "0");
+    assertEquals(new StringConverter(CHARACTER_STRING).convertToString(), "ABC");
+  }
 
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        assertEquals(new StringConverter(DATE_STRING).convertToDate(), Date.valueOf(DATE_STRING));
-    }
+  @Test
+  public void testConvertToTimestamp() throws DatabricksSQLException {
+    assertEquals(
+        new StringConverter(TIME_STAMP_STRING).convertToTimestamp(),
+        Timestamp.valueOf(TIME_STAMP_STRING));
+  }
+
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    assertEquals(new StringConverter(DATE_STRING).convertToDate(), Date.valueOf(DATE_STRING));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/core/converters/TimestampConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/core/converters/TimestampConverterTest.java
@@ -1,33 +1,28 @@
 package com.databricks.jdbc.core.converters;
 
-import com.databricks.jdbc.core.DatabricksSQLException;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
+import com.databricks.jdbc.core.DatabricksSQLException;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class TimestampConverterTest {
 
-    private Timestamp TIMESTAMP = Timestamp.valueOf("2023-09-10 20:45:00");
+  private Timestamp TIMESTAMP = Timestamp.valueOf("2023-09-10 20:45:00");
 
+  @Test
+  public void testConvertToLong() throws DatabricksSQLException {
+    assertEquals(new TimestampConverter(TIMESTAMP).convertToLong(), 1694358900000L);
+  }
 
-    @Test
-    public void testConvertToLong() throws DatabricksSQLException {
-        assertEquals(new TimestampConverter(TIMESTAMP).convertToLong(), 1694358900000L);
-    }
+  @Test
+  public void testConvertToString() throws DatabricksSQLException {
+    assertEquals(new TimestampConverter(TIMESTAMP).convertToString(), "2023-09-10 20:45:00.0");
+  }
 
-    @Test
-    public void testConvertToString() throws DatabricksSQLException {
-        assertEquals(new TimestampConverter(TIMESTAMP).convertToString(), "2023-09-10 20:45:00.0");
-    }
-
-    @Test
-    public void testConvertToDate() throws DatabricksSQLException {
-        assertEquals(new TimestampConverter(TIMESTAMP).convertToDate(), Date.valueOf("2023-09-10"));
-    }
+  @Test
+  public void testConvertToDate() throws DatabricksSQLException {
+    assertEquals(new TimestampConverter(TIMESTAMP).convertToDate(), Date.valueOf("2023-09-10"));
+  }
 }

--- a/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
@@ -3,15 +3,19 @@ package com.databricks.jdbc.driver;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Properties;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 class DatabricksConnectionContestTest {
 
-  private static final String VALID_URL_1 = "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
-  private static final String VALID_URL_2 = "jdbc:databricks://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
-  private static final String INVALID_URL_1 = "jdbc:oracle://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
-  private static final String INVALID_URL_2 = "http:databricks://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
+  private static final String VALID_URL_1 =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;";
+  private static final String VALID_URL_2 =
+      "jdbc:databricks://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
+  private static final String INVALID_URL_1 =
+      "jdbc:oracle://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
+  private static final String INVALID_URL_2 =
+      "http:databricks://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
 
   private static Properties properties = new Properties();
 
@@ -30,8 +34,12 @@ class DatabricksConnectionContestTest {
 
   @Test
   public void testParseInvalid() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> DatabricksConnectionContext.parse(INVALID_URL_1, properties));
-    assertThrows(IllegalArgumentException.class, () -> DatabricksConnectionContext.parse(INVALID_URL_2, properties));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DatabricksConnectionContext.parse(INVALID_URL_1, properties));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DatabricksConnectionContext.parse(INVALID_URL_2, properties));
   }
 
   @Test
@@ -39,13 +47,15 @@ class DatabricksConnectionContestTest {
     // test provided port
     DatabricksConnectionContext connectionContext =
         (DatabricksConnectionContext) DatabricksConnectionContext.parse(VALID_URL_1, properties);
-    assertEquals("https://adb-565757575.18.azuredatabricks.net:4423", connectionContext.getHostUrl());
+    assertEquals(
+        "https://adb-565757575.18.azuredatabricks.net:4423", connectionContext.getHostUrl());
     assertEquals("/sql/1.0/warehouses/erg6767gg", connectionContext.getHttpPath());
     assertEquals("passwd", connectionContext.getToken());
     assertEquals(5, connectionContext.parameters.size());
 
     // test default port
-    connectionContext = (DatabricksConnectionContext) DatabricksConnectionContext.parse(VALID_URL_2, properties);
+    connectionContext =
+        (DatabricksConnectionContext) DatabricksConnectionContext.parse(VALID_URL_2, properties);
     assertEquals("https://azuredatabricks.net:443", connectionContext.getHostUrl());
     assertEquals("/sql/1.0/warehouses/fgff575757", connectionContext.getHttpPath());
     assertEquals("passwd", connectionContext.getToken());

--- a/src/test/java/com/databricks/jdbc/local/DriverTester.java
+++ b/src/test/java/com/databricks/jdbc/local/DriverTester.java
@@ -1,77 +1,76 @@
 package com.databricks.jdbc.local;
 
+import java.sql.*;
 import org.junit.jupiter.api.Test;
 
-import java.sql.*;
-
 public class DriverTester {
-    public void printResultSet(ResultSet resultSet) throws SQLException {
-        ResultSetMetaData rsmd = resultSet.getMetaData();
-        int columnsNumber = rsmd.getColumnCount();
-        for (int i = 1; i <= columnsNumber; i++)
-            System.out.print(rsmd.getColumnName(i) + "\t");
-        System.out.println();
-        for (int i = 1; i <= columnsNumber; i++)
-            System.out.print(rsmd.getColumnTypeName(i) + "\t\t");
-        System.out.println();
-        for (int i = 1; i <= columnsNumber; i++)
-            System.out.print(rsmd.getColumnType(i) + "\t\t\t");
-        System.out.println();
-        for (int i = 1; i <= columnsNumber; i++)
-            System.out.print(rsmd.getPrecision(i) + "\t\t\t");
-        System.out.println();
-        while (resultSet.next()) {
-            for (int i = 1; i <= columnsNumber; i++) {
-                Object columnValue = resultSet.getObject(i);
-                System.out.print(columnValue + "\t\t");
-            }
-            System.out.println();
-        }
+  public void printResultSet(ResultSet resultSet) throws SQLException {
+    ResultSetMetaData rsmd = resultSet.getMetaData();
+    int columnsNumber = rsmd.getColumnCount();
+    for (int i = 1; i <= columnsNumber; i++) System.out.print(rsmd.getColumnName(i) + "\t");
+    System.out.println();
+    for (int i = 1; i <= columnsNumber; i++) System.out.print(rsmd.getColumnTypeName(i) + "\t\t");
+    System.out.println();
+    for (int i = 1; i <= columnsNumber; i++) System.out.print(rsmd.getColumnType(i) + "\t\t\t");
+    System.out.println();
+    for (int i = 1; i <= columnsNumber; i++) System.out.print(rsmd.getPrecision(i) + "\t\t\t");
+    System.out.println();
+    while (resultSet.next()) {
+      for (int i = 1; i <= columnsNumber; i++) {
+        Object columnValue = resultSet.getObject(i);
+        System.out.print(columnValue + "\t\t");
+      }
+      System.out.println();
     }
-    @Test
-    void testGetTablesOSS() throws Exception {
-        DriverManager.registerDriver(new com.databricks.jdbc.driver.DatabricksDriver());
-        DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
-        //Getting the connection
-        String jdbcUrl = "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
-        Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
-        System.out.println("Connection established......");
-        //Retrieving the meta data object
-        DatabaseMetaData metaData = con.getMetaData();
-        //Retrieving the columns in the database
-        ResultSet resultSet = metaData.getTables("samples", "tpch", null, null);
-        printResultSet(resultSet);
-    }
+  }
 
-    @Test
-    void testGetTablesSimba() throws Exception {
-        DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
-        //Getting the connection
-        String jdbcUrl = "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
-        Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
-        System.out.println("Connection established......");
-        //Retrieving the meta data object
-        DatabaseMetaData metaData = con.getMetaData();
-        System.out.println(con.getAutoCommit());
-        ResultSet rs = metaData.getSchemas();
-        printResultSet(rs);
-        con.close();
-    }
+  @Test
+  void testGetTablesOSS() throws Exception {
+    DriverManager.registerDriver(new com.databricks.jdbc.driver.DatabricksDriver());
+    DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
+    // Getting the connection
+    String jdbcUrl =
+        "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
+    Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
+    System.out.println("Connection established......");
+    // Retrieving the meta data object
+    DatabaseMetaData metaData = con.getMetaData();
+    // Retrieving the columns in the database
+    ResultSet resultSet = metaData.getTables("samples", "tpch", null, null);
+    printResultSet(resultSet);
+  }
 
-    @Test
-    void testStatementSimba() throws Exception {
-        DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
-        //Getting the connection
-        String jdbcUrl = "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
-        Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
-        System.out.println("Connection established......");
-        //Retrieving the meta data object
-        Statement statement = con.createStatement();
-        statement.setMaxRows(10);
-        ResultSet rs = statement.executeQuery("select * from samples.tpch.lineitem limit 1");
-        printResultSet(rs);
-        rs.close();
-        statement.close();
-        con.close();
-    }
+  @Test
+  void testGetTablesSimba() throws Exception {
+    DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
+    // Getting the connection
+    String jdbcUrl =
+        "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
+    Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
+    System.out.println("Connection established......");
+    // Retrieving the meta data object
+    DatabaseMetaData metaData = con.getMetaData();
+    System.out.println(con.getAutoCommit());
+    ResultSet rs = metaData.getSchemas();
+    printResultSet(rs);
+    con.close();
+  }
+
+  @Test
+  void testStatementSimba() throws Exception {
+    DriverManager.drivers().forEach(driver -> System.out.println(driver.getClass()));
+    // Getting the connection
+    String jdbcUrl =
+        "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/791ba2a31c7fd70a;";
+    Connection con = DriverManager.getConnection(jdbcUrl, "madhav.sainanee@databricks.com", "##");
+    System.out.println("Connection established......");
+    // Retrieving the meta data object
+    Statement statement = con.createStatement();
+    statement.setMaxRows(10);
+    ResultSet rs = statement.executeQuery("select * from samples.tpch.lineitem limit 1");
+    printResultSet(rs);
+    rs.close();
+    statement.close();
+    con.close();
+  }
 }


### PR DESCRIPTION
Change log :
1. Added google java formatter using spotless to automatically format code during code compile itself.
2. Added a line in pom.xml to fix the error Caused by: java.lang.IllegalArgumentException: Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java 20 (64) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
3. Updated version of databricks-sdk version. 

[Note to reviewer : Only view the pom.xml file. Rest are formatting changes.]
