### PR TITLE
Don't add scopes for azure use-case

### DIFF
--- a/src/main/java/com/databricks/jdbc/core/OAuthAuthenticator.java
+++ b/src/main/java/com/databricks/jdbc/core/OAuthAuthenticator.java
@@ -40,8 +40,11 @@ public class OAuthAuthenticator {
             .setHost(this.connectionContext.getHostForOAuth())
             .setClientId(this.connectionContext.getClientId())
             .setClientSecret(this.connectionContext.getClientSecret())
-            .setScopes(this.connectionContext.getOAuthScopesForU2M())
             .setOAuthRedirectUrl(DatabricksJdbcConstants.U2M_AUTH_REDIRECT_URL);
+    if (!config.isAzure()) {
+      // Default scope is already being set for Azure in databricks-sdk.
+      config.setScopes(this.connectionContext.getOAuthScopesForU2M());
+    }
     return new WorkspaceClient(config);
   }
 

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
@@ -157,10 +157,8 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
     if (getCloud().equals("AWS")) {
       return Arrays.asList(
           DatabricksJdbcConstants.SQL_SCOPE, DatabricksJdbcConstants.OFFLINE_ACCESS_SCOPE);
-    } else if (getCloud().equals("AAD")) {
-      return Arrays.asList(
-          DatabricksJdbcConstants.AAD_SQL_SCOPE, DatabricksJdbcConstants.OFFLINE_ACCESS_SCOPE);
     } else {
+      // Default scope is already being set for Azure in databricks-sdk.
       return null;
     }
   }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
@@ -52,9 +52,6 @@ public final class DatabricksJdbcConstants {
 
   public static final String SQL_SCOPE = "sql";
   public static final String OFFLINE_ACCESS_SCOPE = "offline_access";
-  public static final String AAD_SQL_SCOPE =
-      "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/user_impersonation";
-
   public static final String FULL_STOP = ".";
   public static final String EMPTY_STRING = "";
   public static final String IDENTIFIER_QUOTE_STRING = "`";

--- a/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
@@ -2,16 +2,20 @@ package com.databricks.jdbc.driver;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class DatabricksConnectionContestTest {
+class DatabricksConnectionContextTest {
 
   private static final String VALID_URL_1 =
       "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=test1/application.log;";
   private static final String VALID_URL_2 =
       "jdbc:databricks://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;LogLevel=invalid;";
+  private static final String VALID_URL_3 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;";
+
   private static final String INVALID_URL_1 =
       "jdbc:oracle://azuredatabricks.net/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
   private static final String INVALID_URL_2 =
@@ -56,6 +60,7 @@ class DatabricksConnectionContestTest {
     assertEquals(7, connectionContext.parameters.size());
     assertEquals("DEBUG", connectionContext.getLogLevelString());
     assertEquals("test1/application.log", connectionContext.getLogPathString());
+    assertNull(connectionContext.getOAuthScopesForU2M());
 
     // test default port
     connectionContext =
@@ -67,5 +72,18 @@ class DatabricksConnectionContestTest {
     assertEquals("INFO", connectionContext.getLogLevelString());
     assertNull(connectionContext.getLogPathString());
     assertEquals("3", connectionContext.parameters.get("authmech"));
+    assertNull(connectionContext.getOAuthScopesForU2M());
+
+    // test aws port
+    connectionContext =
+        (DatabricksConnectionContext) DatabricksConnectionContext.parse(VALID_URL_3, properties);
+    List<String> expected_scopes = List.of("sql", "offline_access");
+    assertEquals(
+        "https://e2-dogfood.staging.cloud.databricks.com:443", connectionContext.getHostUrl());
+    assertEquals("/sql/1.0/warehouses/5c89f447c476a5a8", connectionContext.getHttpPath());
+    assertEquals("passwd", connectionContext.getToken());
+    assertEquals(5, connectionContext.parameters.size());
+    assertEquals("INFO", connectionContext.getLogLevelString());
+    assertEquals(connectionContext.getOAuthScopesForU2M(), expected_scopes);
   }
 }


### PR DESCRIPTION
## Description
- This is part of making Azure U2M work. 

## Testing details 

- Tested using squirrel client using url `jdbc:databricks://adb-2548836972759138.18.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=2;httpPath=/sql/1.0/warehouses/071969b1ec9a91ca;`
- Added unit tests
