### PR TITLE
Run UTs and upload codeCov on main branch too

### DIFF
--- a/.github/workflows/prCheck.yml
+++ b/.github/workflows/prCheck.yml
@@ -2,6 +2,8 @@
 name: Build
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
## Description
-  Currently, codecov doesn't show the main branch, this is to fix this.
- We also need to run UT on main branch to be able to do so.

