### PR TITLE
[PECO-1490] Fixed a bug in chunk downloader due to which connections were not returned to the pool

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/IDatabricksHttpClient.java
+++ b/src/main/java/com/databricks/jdbc/client/IDatabricksHttpClient.java
@@ -1,6 +1,6 @@
 package com.databricks.jdbc.client;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /** Http client interface for executing http requests. */
@@ -12,7 +12,7 @@ public interface IDatabricksHttpClient {
    * @param request underlying http request
    * @return http response
    */
-  HttpResponse execute(HttpUriRequest request) throws DatabricksHttpException;
+  CloseableHttpResponse execute(HttpUriRequest request) throws DatabricksHttpException;
 
   void closeExpiredAndIdleConnections();
 }

--- a/src/main/java/com/databricks/jdbc/client/http/DatabricksHttpClient.java
+++ b/src/main/java/com/databricks/jdbc/client/http/DatabricksHttpClient.java
@@ -11,6 +11,7 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -123,7 +124,7 @@ public class DatabricksHttpClient implements IDatabricksHttpClient {
   }
 
   @Override
-  public HttpResponse execute(HttpUriRequest request) throws DatabricksHttpException {
+  public CloseableHttpResponse execute(HttpUriRequest request) throws DatabricksHttpException {
     LOGGER.debug("Executing HTTP request [{}]", RequestSanitizer.sanitizeRequest(request));
     // TODO: add retries and error handling
     try {

--- a/src/main/java/com/databricks/jdbc/core/SingleChunkDownloader.java
+++ b/src/main/java/com/databricks/jdbc/core/SingleChunkDownloader.java
@@ -2,11 +2,15 @@ package com.databricks.jdbc.core;
 
 import com.databricks.jdbc.client.DatabricksHttpException;
 import com.databricks.jdbc.client.IDatabricksHttpClient;
+import java.io.IOException;
 import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Task class to manage download for a single chunk. */
 class SingleChunkDownloader implements Callable<Void> {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SingleChunkDownloader.class);
   private final ArrowResultChunk chunk;
   private final IDatabricksHttpClient httpClient;
   private final ChunkDownloader chunkDownloader;
@@ -27,6 +31,8 @@ class SingleChunkDownloader implements Callable<Void> {
       chunk.downloadData(httpClient);
     } catch (DatabricksHttpException | DatabricksParsingException e) {
       // TODO: handle retries
+    } catch (IOException e) {
+      LOGGER.warn("Unable to close response, there might be a connection leak", e);
     } finally {
       chunkDownloader.downloadProcessed(chunk.getChunkIndex());
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
During SLT workflow, we observed that select statements were timing out due to unavailability of connections in the pool. Based [this article](https://www.baeldung.com/httpclient-connection-management#multiple), response entity must be consumed to return the connection to the pool. Which essentially means that the inputStream must be closed which was missing.

## Testing
<!-- Describe how the changes have been tested-->
Tested locally by setting the pool size to 3 and observed ConnectionPoolTimeoutException after 3 select queries were run. Post this change, 100s of select queries went through with the pool size at 3

