### PR TITLE
[PECO-1575] Make use of updated version to make a single call

### DIFF
--- a/src/main/java/com/databricks/jdbc/commons/EnvironmentVariables.java
+++ b/src/main/java/com/databricks/jdbc/commons/EnvironmentVariables.java
@@ -12,5 +12,5 @@ public final class EnvironmentVariables {
       false; // By default, we should not process the sql
 
   public static final TProtocolVersion JDBC_THRIFT_VERSION =
-      TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10;
+      TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9;
 }

--- a/src/test/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -36,7 +36,7 @@ public class DatabricksThriftServiceClientTest {
             .setInitialNamespace(getNamespace(CATALOG, SCHEMA))
             .setConfiguration(EMPTY_MAP)
             .setCanUseMultipleCatalogs(true)
-            .setClient_protocol(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10);
+            .setClient_protocol(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9);
     TOpenSessionResp openSessionResp =
         new TOpenSessionResp()
             .setSessionHandle(SESSION_HANDLE)


### PR DESCRIPTION
## Description
- Direct results didn't seem to work earlier. Upon discussion with Sander, this is a thrift version issue. We will have to bump up version from HIVE latest to SPARK latest and make use of direct results. 
-  When direct results are enabled and the execution  request can be a single round trip RPC if the Spark execution time is <5s and the result is sufficiently small. In those cases, to optimize performance, the SQL Gateway doesn’t even record the statement ID in it’s database.

## Testing
- tested using driver tester
- added unit tests

## Additional Notes to the Reviewer
- cloud fetch is a follow up and not a part of this PR https://databricks.atlassian.net/browse/PECO-1256

