### PR TITLE
Update codecoverage percentage checks

### DIFF
--- a/.github/workflows/prCheck.yml
+++ b/.github/workflows/prCheck.yml
@@ -67,7 +67,7 @@ jobs:
         run: mvn test
 
       - name: Install xmllint
-        if: runner.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: JaCoCo report


### PR DESCRIPTION
## Description
All codeCov checks are failing on mainline. This is because we don't have a paid codecov version. This adds basic percentage check using jacoco.
`Upload limit has been reached
This org is currently on the Developer plan; which includes 250 free uploads monthly. This month's limit has been reached and the reports will not generate. To resolve this, upgrade plan and you'll have unlimited uploads.`

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

