### PR TITLE
Modify multi-chunk test to extend AbstractFakeServiceIntegrationTests

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/AbstractFakeServiceIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/AbstractFakeServiceIntegrationTests.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * com.databricks.jdbc.driver.DatabricksJdbcConstants.FakeServiceType#SQL_EXEC} and {@link
  * com.databricks.jdbc.driver.DatabricksJdbcConstants.FakeServiceType#CLOUD_FETCH}.
  */
-public abstract class BaseFakeServiceIntegrationTests {
+public abstract class AbstractFakeServiceIntegrationTests {
 
   /**
    * {@link FakeServiceExtension} for {@link DatabricksJdbcConstants.FakeServiceType#SQL_EXEC}.
@@ -40,11 +40,22 @@ public abstract class BaseFakeServiceIntegrationTests {
           DatabricksJdbcConstants.FakeServiceType.CLOUD_FETCH,
           "https://dbstoragepzjc6kojqibtg.blob.core.windows.net");
 
-  /** Resets the possible mutations for the extensions after all tests have run. */
+  /**
+   * Resets the potential mutations (e.g., URLs set by {@link #setSqlExecApiTargetUrl}, {@link
+   * #setCloudFetchApiTargetUrl}) to meaningful defaults, after all tests have completed.
+   */
   @AfterAll
-  protected static void resetPossibleMutations() {
+  static void resetPossibleMutations() {
     sqlExecApiExtension.setTargetBaseUrl("https://" + System.getenv("DATABRICKS_HOST"));
     cloudFetchApiExtension.setTargetBaseUrl("https://dbstoragepzjc6kojqibtg.blob.core.windows.net");
+  }
+
+  protected static void setSqlExecApiTargetUrl(final String sqlExecApiTargetUrl) {
+    sqlExecApiExtension.setTargetBaseUrl(sqlExecApiTargetUrl);
+  }
+
+  protected static void setCloudFetchApiTargetUrl(final String cloudFetchApiTargetUrl) {
+    cloudFetchApiExtension.setTargetBaseUrl(cloudFetchApiTargetUrl);
   }
 
   protected FakeServiceExtension getSqlExecApiExtension() {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceExtension.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceExtension.java
@@ -104,6 +104,9 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
   /** Fake service to manage. */
   private final FakeServiceType fakeServiceType;
 
+  /** HTTP port of the WireMock server. */
+  private int wireMockServerHttpPort;
+
   /** Base URL of the target production service. */
   private String targetBaseUrl;
 
@@ -145,8 +148,9 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
         fakeServiceModeValue != null
             ? FakeServiceMode.valueOf(fakeServiceModeValue.toUpperCase())
             : FakeServiceMode.REPLAY;
+    wireMockServerHttpPort = wireMockRuntimeInfo.getHttpPort();
 
-    setFakeServiceProperties(wireMockRuntimeInfo);
+    setFakeServiceProperties(wireMockServerHttpPort);
     IntegrationTestUtil.resetJDBCConnection();
     DatabricksHttpClient.resetInstance();
   }
@@ -190,6 +194,9 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
   /** Sets the base URL of the target production service to be tracked. */
   protected void setTargetBaseUrl(String targetBaseUrl) {
     this.targetBaseUrl = targetBaseUrl;
+
+    // Refresh the fake service properties
+    setFakeServiceProperties(wireMockServerHttpPort);
   }
 
   /** Gets the stubbing directory for the current test class and method. */
@@ -254,13 +261,12 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
     new JsonFileMappingsSource(new SingleRootFileSource(stubbingDir), null).save(stubMappingList);
   }
 
-  private void setFakeServiceProperties(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  private void setFakeServiceProperties(int wireMockServerHttpPort) {
     System.setProperty(IS_FAKE_SERVICE_TEST_PROP, "true");
     System.setProperty(
         fakeServiceType.name().toLowerCase() + TARGET_URI_PROP_SUFFIX, targetBaseUrl);
     System.setProperty(
-        targetBaseUrl + FAKE_SERVICE_URI_PROP_SUFFIX,
-        "http://localhost:" + wireMockRuntimeInfo.getHttpPort());
+        targetBaseUrl + FAKE_SERVICE_URI_PROP_SUFFIX, "http://localhost:" + wireMockServerHttpPort);
   }
 
   private void clearFakeServiceProperties() {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConcurrencyIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConcurrencyIntegrationTests.java
@@ -4,7 +4,7 @@ import static com.databricks.jdbc.integration.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for concurrent operations on a table. */
-public class ConcurrencyIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class ConcurrencyIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   private Connection connection;
 

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConnectionIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConnectionIntegrationTests.java
@@ -4,14 +4,14 @@ import static com.databricks.jdbc.integration.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.databricks.jdbc.core.DatabricksSQLException;
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for connection to Databricks service. */
-public class ConnectionIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class ConnectionIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   @Test
   void testSuccessfulConnection() throws SQLException {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ErrorHandlingIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ErrorHandlingIntegrationTests.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.databricks.jdbc.core.DatabricksParsingException;
 import com.databricks.jdbc.core.DatabricksSQLException;
 import com.databricks.jdbc.core.DatabricksSQLFeatureNotSupportedException;
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import java.sql.*;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for error handling scenarios. */
-public class ErrorHandlingIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class ErrorHandlingIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   @Test
   void testFailureToLoadDriver() {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ExecutionIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ExecutionIntegrationTests.java
@@ -7,14 +7,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for SQL statement execution. */
-public class ExecutionIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class ExecutionIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   @Test
   void testInsertStatement() throws SQLException {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/MetadataIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/MetadataIntegrationTests.java
@@ -7,7 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import java.sql.*;
 import org.junit.jupiter.api.AfterEach;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for metadata retrieval. */
-public class MetadataIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class MetadataIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   private Connection connection;
 

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/PreparedStatementIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/PreparedStatementIntegrationTests.java
@@ -4,7 +4,7 @@ import static com.databricks.jdbc.integration.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for PreparedStatement operations. */
-public class PreparedStatementIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class PreparedStatementIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   private Connection connection;
 

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ResultSetIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ResultSetIntegrationTests.java
@@ -3,7 +3,7 @@ package com.databricks.jdbc.integration.fakeservice.tests;
 import static com.databricks.jdbc.integration.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.databricks.jdbc.integration.fakeservice.BaseFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.ResultSet;
@@ -12,7 +12,7 @@ import java.sql.Timestamp;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for ResultSet operations. */
-public class ResultSetIntegrationTests extends BaseFakeServiceIntegrationTests {
+public class ResultSetIntegrationTests extends AbstractFakeServiceIntegrationTests {
 
   @Test
   void testRetrievalOfBasicDataTypes() throws SQLException {


### PR DESCRIPTION
## Description
AbstractFakeServiceIntegrationTests abstracts out the injection of fake services for _sql-exec_ and _cloud-fetch_. Integration tests using the production _sql-exec_ and _cloud-fetch_ services can extend the abstract class to automatically use fake services (RECORD or REPLAY mode based on environment `FAKE_SERVICE_TEST_MODE`). The abstract class also provides hooks to configure the target URL of _sql-exec_ and _cloud-fetch_ (used in RECORD mode to capture requests hitting target URL).

## Testing
Ran tests in REPLAY mode.