### PR TITLE
Add connection tests for thrift client

### DIFF
--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -50,7 +50,7 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Run Integration Tests
-        run: mvn -B test -Dtest=*IntegrationTests
+        run: mvn -B test -Dtest=*IntegrationTests -DexcludedTests=**/thrifttests/**
         env:
           DATABRICKS_HOST: ${{ env.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ env.DATABRICKS_TOKEN }}

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConnectionIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ConnectionIntegrationTests.java
@@ -16,9 +16,10 @@ public class ConnectionIntegrationTests extends AbstractFakeServiceIntegrationTe
   @Test
   void testSuccessfulConnection() throws SQLException {
     Connection conn = getValidJDBCConnection();
-    assert ((conn != null) && !conn.isClosed());
+    assert !conn.isClosed();
 
     conn.close();
+    assert conn.isClosed();
   }
 
   @Test
@@ -29,19 +30,23 @@ public class ConnectionIntegrationTests extends AbstractFakeServiceIntegrationTe
             DatabricksSQLException.class,
             () -> DriverManager.getConnection(url, getDatabricksUser(), "bad_token"));
 
-    assert e.getMessage().contains("Invalid or unknown token or hostname provided");
+    assert e.getMessage().contains(getUnsuccessfulConnectionMessage());
   }
 
   @Test
   void testIncorrectCredentialsForOAuth() {
     String template =
-        "jdbc:databricks://%s/default;transportMode=http;ssl=1;AuthMech=11;AuthFlow=0;httpPath=%s";
+        "jdbc:databricks://%s/default;transportMode=http;ssl=0;AuthMech=11;AuthFlow=0;httpPath=%s";
     String url = String.format(template, getDatabricksHost(), getDatabricksHTTPPath());
     DatabricksSQLException e =
         assertThrows(
             DatabricksSQLException.class,
             () -> DriverManager.getConnection(url, getDatabricksUser(), "bad_token"));
 
-    assert e.getMessage().contains("Invalid or unknown token or hostname provided");
+    assert e.getMessage().contains(getUnsuccessfulConnectionMessage());
+  }
+
+  protected String getUnsuccessfulConnectionMessage() {
+    return "Invalid or unknown token or hostname provided";
   }
 }

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/thrifttests/ConnectionIntegrationThriftTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/thrifttests/ConnectionIntegrationThriftTests.java
@@ -1,0 +1,17 @@
+package com.databricks.jdbc.integration.fakeservice.thrifttests;
+
+import com.databricks.jdbc.integration.fakeservice.tests.ConnectionIntegrationTests;
+import org.junit.jupiter.api.BeforeAll;
+
+public class ConnectionIntegrationThriftTests extends ConnectionIntegrationTests {
+
+  @BeforeAll
+  static void beforeAll() {
+    setSqlExecApiTargetUrl("https://e2-dogfood.staging.cloud.databricks.com");
+  }
+
+  @Override
+  protected String getUnsuccessfulConnectionMessage() {
+    return "Error while receiving response from Thrift server";
+  }
+}

--- a/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testincorrectcredentialsforoauth/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-2ba235b4-57ec-408f-bed6-bf38b21581e9.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testincorrectcredentialsforoauth/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-2ba235b4-57ec-408f-bed6-bf38b21581e9.json
@@ -1,0 +1,29 @@
+{
+  "id" : "2ba235b4-57ec-408f-bed6-bf38b21581e9",
+  "name" : "sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv",
+  "request" : {
+    "url" : "/sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "gAEAAQAAAAtPcGVuU2Vzc2lvbgAAAAEMAAEIAAEAAKUJDQAECwsAAAAADAUECwABAAAABVNQQVJLCwACAAAAB2RlZmF1bHQAAgUFAQAA"
+    } ]
+  },
+  "response" : {
+    "status" : 401,
+    "body" : "{\"error_code\":401,\"message\":\"Credential was not sent or was of an unsupported type for this API.\"}",
+    "headers" : {
+      "date" : "Mon, 03 Jun 2024 15:01:46 GMT",
+      "server" : "databricks",
+      "x-databricks-popp-request-id" : "80c953ba-0e51-4198-bf74-c8c11f8c5141",
+      "x-databricks-shard-debug" : "oregon-staging",
+      "vary" : "Accept-Encoding",
+      "x-databricks-popp-shadow-routing-reason" : "deployment-name",
+      "www-authenticate" : "Bearer realm=\"DatabricksRealm\"",
+      "x-databricks-popp-routing-reason" : "deployment-name",
+      "content-type" : "application/json; charset=utf-8",
+      "x-databricks-reason-phrase" : "Credential was not sent or was of an unsupported type for this API."
+    }
+  },
+  "uuid" : "2ba235b4-57ec-408f-bed6-bf38b21581e9",
+  "insertionIndex" : 1
+}

--- a/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testincorrectcredentialsforpat/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-2dd02426-d85e-466f-9bb2-dfc161641401.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testincorrectcredentialsforpat/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-2dd02426-d85e-466f-9bb2-dfc161641401.json
@@ -1,0 +1,29 @@
+{
+  "id" : "2dd02426-d85e-466f-9bb2-dfc161641401",
+  "name" : "sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv",
+  "request" : {
+    "url" : "/sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "gAEAAQAAAAtPcGVuU2Vzc2lvbgAAAAEMAAEIAAEAAKUJDQAECwsAAAAADAUECwABAAAABVNQQVJLCwACAAAAB2RlZmF1bHQAAgUFAQAA"
+    } ]
+  },
+  "response" : {
+    "status" : 401,
+    "body" : "{\"error_code\":401,\"message\":\"Credential was not sent or was of an unsupported type for this API.\"}",
+    "headers" : {
+      "date" : "Mon, 03 Jun 2024 15:01:47 GMT",
+      "server" : "databricks",
+      "x-databricks-popp-request-id" : "4eb1e772-84a0-4f85-99d9-dd6a09f4c01a",
+      "x-databricks-shard-debug" : "oregon-staging",
+      "vary" : "Accept-Encoding",
+      "x-databricks-popp-shadow-routing-reason" : "deployment-name",
+      "www-authenticate" : "Bearer realm=\"DatabricksRealm\"",
+      "x-databricks-popp-routing-reason" : "deployment-name",
+      "content-type" : "application/json; charset=utf-8",
+      "x-databricks-reason-phrase" : "Credential was not sent or was of an unsupported type for this API."
+    }
+  },
+  "uuid" : "2dd02426-d85e-466f-9bb2-dfc161641401",
+  "insertionIndex" : 3
+}

--- a/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testsuccessfulconnection/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-450c750f-a3ed-432a-a419-d6b95dda0a6e.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testsuccessfulconnection/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-450c750f-a3ed-432a-a419-d6b95dda0a6e.json
@@ -1,0 +1,31 @@
+{
+  "id" : "450c750f-a3ed-432a-a419-d6b95dda0a6e",
+  "name" : "sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv",
+  "request" : {
+    "url" : "/sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "gAEAAQAAAAxDbG9zZVNlc3Npb24AAAACDAABDAABDAABCwABAAAAEMJNcE4IrkV5mUxQfU2fFKcLAAIAAAAQhzRGYX2/TDO5yFg5JSw/IQAAAAA="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "gAEAAgAAAAxDbG9zZVNlc3Npb24AAAACDAAADAABCAABAAAAAAAAAA==",
+    "headers" : {
+      "date" : "Mon, 03 Jun 2024 15:01:50 GMT,Mon, 03 Jun 2024 15:01:50 GMT",
+      "server" : "databricks",
+      "x-databricks-popp-request-id" : "85d14460-83af-42f3-885f-d3a0e3741f4b",
+      "x-content-type-options" : [ "nosniff", "nosniff" ],
+      "x-xss-protection" : "1; mode=block",
+      "x-databricks-shard-debug" : "oregon-staging",
+      "x-frame-options" : "SAMEORIGIN",
+      "x-databricks-popp-shadow-routing-reason" : "deployment-name",
+      "x-databricks-org-id" : "6051921418418893",
+      "x-databricks-popp-routing-reason" : "deployment-name",
+      "content-type" : "application/x-thrift",
+      "strict-transport-security" : [ "max-age=31536000; includeSubDomains; preload", "max-age=31536000; includeSubDomains; preload" ]
+    }
+  },
+  "uuid" : "450c750f-a3ed-432a-a419-d6b95dda0a6e",
+  "insertionIndex" : 5
+}

--- a/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testsuccessfulconnection/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-7f50f7cf-3b93-4dcc-b924-b7abaf323d44.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationthrifttests/testsuccessfulconnection/mappings/sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv-7f50f7cf-3b93-4dcc-b924-b7abaf323d44.json
@@ -1,0 +1,31 @@
+{
+  "id" : "7f50f7cf-3b93-4dcc-b924-b7abaf323d44",
+  "name" : "sql_protocolv1_o_6051921418418893_1115-130834-ms4m0yv",
+  "request" : {
+    "url" : "/sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "gAEAAQAAAAtPcGVuU2Vzc2lvbgAAAAEMAAEIAAEAAKUJDQAECwsAAAAADAUECwABAAAABVNQQVJLCwACAAAAB2RlZmF1bHQAAgUFAQAA"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "gAEAAgAAAAtPcGVuU2Vzc2lvbgAAAAEMAAAMAAEIAAEAAAAAAAgAAgAApQIMAAMMAAELAAEAAAAQwk1wTgiuRXmZTFB9TZ8UpwsAAgAAABCHNEZhfb9MM7nIWDklLD8hBg0BAAAACA0BAAClAgANAAQLCwAAAAAAAA==",
+    "headers" : {
+      "date" : "Mon, 03 Jun 2024 15:01:49 GMT,Mon, 03 Jun 2024 15:01:49 GMT",
+      "server" : "databricks",
+      "x-databricks-popp-request-id" : "a007ce12-22fd-467b-a482-09b82b2833f8",
+      "x-content-type-options" : [ "nosniff", "nosniff" ],
+      "x-xss-protection" : "1; mode=block",
+      "x-databricks-shard-debug" : "oregon-staging",
+      "x-frame-options" : "SAMEORIGIN",
+      "x-databricks-popp-shadow-routing-reason" : "deployment-name",
+      "x-databricks-org-id" : "6051921418418893",
+      "x-databricks-popp-routing-reason" : "deployment-name",
+      "content-type" : "application/x-thrift",
+      "strict-transport-security" : [ "max-age=31536000; includeSubDomains; preload", "max-age=31536000; includeSubDomains; preload" ]
+    }
+  },
+  "uuid" : "7f50f7cf-3b93-4dcc-b924-b7abaf323d44",
+  "insertionIndex" : 6
+}


### PR DESCRIPTION
## Description
This commit adds connection integration tests (and corresponding stubbings) for Thrift client.

## Testing
Ran tests in RECORD and REPLAY mode.

## Additional Notes to the Reviewer
Currently, I have disabled these tests in GitHub's integration tests workflow because of the absence of appropriate environment. This will be addressed in https://github.com/databricks/databricks-jdbc/pull/174.

