### PR TITLE
Fix rowCount method for Thrift client

### DIFF
--- a/src/main/java/com/databricks/jdbc/core/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksResultSet.java
@@ -1,7 +1,6 @@
 package com.databricks.jdbc.core;
 
-import static com.databricks.jdbc.client.impl.thrift.commons.DatabricksThriftHelper.SUCCESS_STATUS_LIST;
-import static com.databricks.jdbc.client.impl.thrift.commons.DatabricksThriftHelper.getRowCount;
+import static com.databricks.jdbc.client.impl.thrift.commons.DatabricksThriftHelper.*;
 import static com.databricks.jdbc.core.converters.ConverterHelper.getConvertedObject;
 import static com.databricks.jdbc.core.converters.ConverterHelper.getObjectConverter;
 
@@ -99,7 +98,7 @@ public class DatabricksResultSet implements ResultSet, IDatabricksResultSet {
     this.statementId = statementId;
     this.executionResult =
         ExecutionResultFactory.getResultSet(resultData, resultManifest, statementId, session);
-    int rowSize = getRowCount(resultData);
+    long rowSize = getRowCount(resultData);
     this.resultSetMetaData =
         new DatabricksResultSetMetaData(
             statementId, resultManifest, rowSize, resultData.getResultLinksSize());

--- a/src/main/java/com/databricks/jdbc/core/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksResultSetMetaData.java
@@ -85,7 +85,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
   }
 
   public DatabricksResultSetMetaData(
-      String statementId, TGetResultSetMetadataResp resultManifest, int rows, long chunkCount) {
+      String statementId, TGetResultSetMetadataResp resultManifest, long rows, long chunkCount) {
     this.statementId = statementId;
     Map<String, Integer> columnNameToIndexMap = new HashMap<>();
     ImmutableList.Builder<ImmutableDatabricksColumn> columnsBuilder = ImmutableList.builder();

--- a/src/test/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelperTest.java
@@ -45,9 +45,17 @@ public class DatabricksThriftHelperTest {
   }
 
   private static Stream<Arguments> resultDataTypes() {
+    // Create a test row set with chunk links
+    TSparkArrowResultLink sampleResultLink = new TSparkArrowResultLink().setRowCount(10);
+    sampleResultLink.setRowCountIsSet(true);
+    TRowSet resultChunkRowSet =
+        new TRowSet().setResultLinks(Collections.singletonList(sampleResultLink));
+    resultChunkRowSet.setResultLinksIsSet(true);
+
     return Stream.of(
         Arguments.of(new TRowSet(), 0),
         Arguments.of(new TRowSet().setColumns(Collections.emptyList()), 0),
+        Arguments.of(resultChunkRowSet, 10),
         Arguments.of(boolRowSet, 4),
         Arguments.of(byteRowSet, 1),
         Arguments.of(doubleRowSet, 6),


### PR DESCRIPTION
## Description
SQL-Gateway can return DBFS links (hybrid results). This commit adds handling of DBFS links in row count method.

## Testing
Added unit test.

