### PR TITLE
[Thrift Tests] Add Getter for connection initialised during the test

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/IntegrationTestUtil.java
+++ b/src/test/java/com/databricks/jdbc/integration/IntegrationTestUtil.java
@@ -269,4 +269,13 @@ public class IntegrationTestUtil {
             + " (id, col1, col2) VALUES (1, 'value1', 'value2')";
     executeSQL(insertSQL);
   }
+
+  /** Get the JDBC connection if it is already initialized in the test suite. */
+  public static Connection getJDBCConnectionIfInitialized() {
+    if (JDBCConnection == null) {
+      throw new IllegalStateException("JDBC connection is not initialized for the test");
+    }
+
+    return JDBCConnection;
+  }
 }


### PR DESCRIPTION
## Description
This will help provide a handle on connection and corresponding context during test runtime.
