### PR TITLE
Revert "Add flag for async (#258)"

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClient.java
@@ -134,8 +134,7 @@ public class DatabricksThriftServiceClient implements DatabricksClient, Databric
             .setStatement(sql)
             .setSessionHandle(session.getSessionInfo().sessionHandle())
             .setCanReadArrowResult(this.connectionContext.shouldEnableArrow())
-            .setCanDownloadResult(true)
-            .setRunAsync(true);
+            .setCanDownloadResult(true);
     DatabricksResultSet resultSet =
         thriftAccessor.execute(request, parentStatement, session, statementType);
     DatabricksMetrics.record(

--- a/src/test/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/client/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -82,8 +82,7 @@ public class DatabricksThriftServiceClientTest {
             .setStatement(TEST_STRING)
             .setSessionHandle(SESSION_HANDLE)
             .setCanReadArrowResult(true)
-            .setCanDownloadResult(true)
-            .setRunAsync(true);
+            .setCanDownloadResult(true);
     when(thriftAccessor.execute(executeStatementReq, null, session, StatementType.SQL))
         .thenReturn(resultSet);
     DatabricksResultSet actualResultSet =


### PR DESCRIPTION
## Description
This reverts commit 959fa9a1fe11260f74d558b5af5dfbaf06668232.

When async is set to true, DBR (in most cases) expects clients to poll results (RUNNING status) even if direct results are enabled on the request. Thrift response handling needs to be improved to poll based on the operation status.

## Testing
Sanity on existing tests.

## Additional Notes to the Reviewer
I will log a JIRA ticket for permanent fix and corresponding testing.