### PR TITLE
Fix queryTimeout=0 to adhere to JDBC spec

### DIFF
--- a/src/main/java/com/databricks/jdbc/commons/util/ValidationUtil.java
+++ b/src/main/java/com/databricks/jdbc/commons/util/ValidationUtil.java
@@ -11,7 +11,8 @@ import org.apache.logging.log4j.Logger;
 public class ValidationUtil {
   private static final Logger LOGGER = LogManager.getLogger(ValidationUtil.class);
 
-  public static void checkIfPositive(int number, String fieldName) throws DatabricksSQLException {
+  public static void checkIfNonNegative(int number, String fieldName)
+      throws DatabricksSQLException {
     // Todo : Add appropriate exception
     if (number < 0) {
       throw new DatabricksSQLException(

--- a/src/main/java/com/databricks/jdbc/core/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksConnection.java
@@ -386,7 +386,7 @@ public class DatabricksConnection implements IDatabricksConnection, Connection {
   @Override
   public boolean isValid(int timeout) throws SQLException {
     LOGGER.debug("public boolean isValid(int timeout = {})", timeout);
-    ValidationUtil.checkIfPositive(timeout, "timeout");
+    ValidationUtil.checkIfNonNegative(timeout, "timeout");
     try {
       DatabricksStatement statement = new DatabricksStatement(this);
       statement.setQueryTimeout(timeout);

--- a/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
@@ -105,7 +105,7 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   public void setMaxRows(int max) throws SQLException {
     LOGGER.debug("public void setMaxRows(int max = {})", max);
     checkIfClosed();
-    ValidationUtil.checkIfPositive(max, "maxRows");
+    ValidationUtil.checkIfNonNegative(max, "maxRows");
     this.maxRows = max;
   }
 
@@ -126,6 +126,7 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   public void setQueryTimeout(int seconds) throws SQLException {
     LOGGER.debug("public void setQueryTimeout(int seconds = {})", seconds);
     checkIfClosed();
+    ValidationUtil.checkIfNonNegative(seconds, "queryTimeout");
     this.timeoutInSeconds = seconds;
   }
 
@@ -410,7 +411,10 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
     CompletableFuture<DatabricksResultSet> futureResultSet =
         getFutureResult(sql, params, statementType);
     try {
-      resultSet = futureResultSet.get(timeoutInSeconds, TimeUnit.SECONDS);
+      resultSet =
+          timeoutInSeconds == 0
+              ? futureResultSet.get() // Wait indefinitely when timeout is 0
+              : futureResultSet.get(timeoutInSeconds, TimeUnit.SECONDS);
     } catch (TimeoutException e) {
       this.close(); // Close the statement
       futureResultSet.cancel(true); // Cancel execution run

--- a/src/test/java/com/databricks/jdbc/commons/ValidationUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/commons/ValidationUtilTest.java
@@ -21,9 +21,9 @@ class ValidationUtilTest {
 
   @Test
   void testCheckIfPositive() {
-    assertDoesNotThrow(() -> ValidationUtil.checkIfPositive(10, "testField"));
+    assertDoesNotThrow(() -> ValidationUtil.checkIfNonNegative(10, "testField"));
     assertThrows(
-        DatabricksSQLException.class, () -> validationUtil.checkIfPositive(-10, "testField"));
+        DatabricksSQLException.class, () -> validationUtil.checkIfNonNegative(-10, "testField"));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
@@ -3,8 +3,7 @@ package com.databricks.jdbc.core;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.databricks.jdbc.client.StatementType;
 import com.databricks.jdbc.client.impl.sdk.DatabricksSdkClient;
@@ -18,6 +17,8 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -238,5 +239,28 @@ public class DatabricksStatementTest {
     assertEquals(ResultSet.CONCUR_READ_ONLY, statement.getResultSetConcurrency());
     assertEquals(ResultSet.TYPE_FORWARD_ONLY, statement.getResultSetType());
     assertEquals(ResultSet.FETCH_FORWARD, statement.getFetchDirection());
+  }
+
+  @Test
+  public void testExecuteInternalWithZeroTimeout() throws Exception {
+    DatabricksConnection mockConnection = mock(DatabricksConnection.class);
+    DatabricksStatement statement = new DatabricksStatement(mockConnection);
+
+    // Set timeout to 0 for infinite wait
+    statement.setQueryTimeout(0);
+
+    CompletableFuture<DatabricksResultSet> mockFuture = mock(CompletableFuture.class);
+
+    when(mockFuture.get()).thenReturn(resultSet);
+
+    DatabricksStatement spyStatement = spy(statement);
+    doReturn(mockFuture).when(spyStatement).getFutureResult(anyString(), anyMap(), any());
+
+    // Execute query using statement
+    spyStatement.executeInternal("SELECT * FROM table", new HashMap<>(), StatementType.QUERY);
+
+    // Verify that get() is called instead of get(long, TimeUnit) for infinite wait
+    verify(mockFuture, times(1)).get();
+    verify(mockFuture, never()).get(anyLong(), any(TimeUnit.class));
   }
 }


### PR DESCRIPTION
## Description
queryTimeout=0 signifies there is no limit.

https://github.com/databricks/runtime/blob/e849a7b3911df4b5413aaa189a3b118d9a7fcd4d/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala#L120

https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setQueryTimeout-int-

## Testing
Unit testing

## Additional Notes to the Reviewer
Because of this few runtime tests are failing as well.

