### PR TITLE
Fix U2M in Thrift

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftAccessor.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftAccessor.java
@@ -33,6 +33,7 @@ public class DatabricksThriftAccessor {
       throws DatabricksParsingException {
     enableDirectResults = connectionContext.getDirectResultMode();
     this.databricksConfig = new OAuthAuthenticator(connectionContext).getDatabricksConfig();
+    this.databricksConfig.resolve();
     Map<String, String> authHeaders = databricksConfig.authenticate();
     String endPointUrl = connectionContext.getEndpointURL();
     // Create a new thrift client for each thread as client state is not thread safe. Note that the


### PR DESCRIPTION
## Description
- The HTTPClient was marked as null - if we don't resolve it. This caused U2M in thrift to fail

## Testing
- Manual testing using driver tester

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

