### PR TITLE
Add DRY mode to fake service tests for manual testing

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceExtension.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceExtension.java
@@ -88,6 +88,7 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
    *       persisted.
    *   <li>{@link FakeServiceMode#REPLAY}: Saved responses are replayed instead of sending requests
    *       to production service.
+   *   <li>{@link FakeServiceMode#DRY}: Requests are sent to production service but not persisted.
    * </ul>
    */
   public static final String FAKE_SERVICE_TEST_MODE_ENV = "FAKE_SERVICE_TEST_MODE";
@@ -126,7 +127,8 @@ public class FakeServiceExtension extends DatabricksWireMockExtension {
 
   public enum FakeServiceMode {
     RECORD,
-    REPLAY
+    REPLAY,
+    DRY
   }
 
   public FakeServiceExtension(


### PR DESCRIPTION
## Description
In DRY mode, it does not load or save stub mappings. The embedded server acts like a pass-through proxy that tracks metadata like number of calls to an API, etc.

This is mainly added to assist in manual testing or authoring tests.

## Testing
Ran existing tests in DRY mode.
