### PR TITLE
Fixes connection pool running out of connections due to unclosed http responses in Thrift Flow

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftAccessor.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftAccessor.java
@@ -71,6 +71,8 @@ public class DatabricksThriftAccessor {
         request.toString(),
         commandName.name());
     refreshHeadersIfRequired();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
     try {
       switch (commandName) {
         case OPEN_SESSION:
@@ -108,6 +110,9 @@ public class DatabricksThriftAccessor {
               request.toString(), e.toString());
       LOGGER.error(errorMessage);
       throw new DatabricksSQLException(errorMessage, e);
+    } finally {
+      // Ensure resources are closed after use
+      transport.close();
     }
   }
 
@@ -134,6 +139,8 @@ public class DatabricksThriftAccessor {
             .setMaxRows(maxRows)
             .setMaxBytes(DEFAULT_BYTE_LIMIT);
     TFetchResultsResp response = null;
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
     try {
       response = getThriftClient().FetchResults(request);
       if (fetchMetadata) {
@@ -146,6 +153,8 @@ public class DatabricksThriftAccessor {
               request.toString(), e.toString());
       LOGGER.error(errorMessage);
       throw new DatabricksHttpException(errorMessage, e);
+    } finally {
+      transport.close();
     }
     verifySuccessStatus(
         response.getStatus().getStatusCode(),
@@ -163,15 +172,21 @@ public class DatabricksThriftAccessor {
             .setGetProgressUpdate(false);
     TGetOperationStatusResp response;
     TStatusCode statusCode;
-    do {
-      response = getThriftClient().GetOperationStatus(request);
-      statusCode = response.getStatus().getStatusCode();
-      if (statusCode == TStatusCode.STILL_EXECUTING_STATUS) {
-        Thread.sleep(DEFAULT_SLEEP_DELAY);
-      }
-    } while (statusCode == TStatusCode.STILL_EXECUTING_STATUS);
-    verifySuccessStatus(
-        statusCode, String.format("Request {%s}, Response {%s}", request, response));
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      do {
+        response = getThriftClient().GetOperationStatus(request);
+        statusCode = response.getStatus().getStatusCode();
+        if (statusCode == TStatusCode.STILL_EXECUTING_STATUS) {
+          Thread.sleep(DEFAULT_SLEEP_DELAY);
+        }
+      } while (statusCode == TStatusCode.STILL_EXECUTING_STATUS);
+      verifySuccessStatus(
+          statusCode, String.format("Request {%s}, Response {%s}", request, response));
+    } finally {
+      transport.close();
+    }
   }
 
   public DatabricksResultSet execute(
@@ -189,6 +204,8 @@ public class DatabricksThriftAccessor {
     }
     TExecuteStatementResp response = null;
     TFetchResultsResp resultSet = null;
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
     try {
       response = getThriftClient().ExecuteStatement(request);
       if (response.isSetDirectResults()) {
@@ -212,6 +229,8 @@ public class DatabricksThriftAccessor {
               request.toString(), e.toString());
       LOGGER.error(errorMessage);
       throw new DatabricksHttpException(errorMessage, e);
+    } finally {
+      transport.close();
     }
     return new DatabricksResultSet(
         response.getStatus(),
@@ -227,128 +246,176 @@ public class DatabricksThriftAccessor {
       throws DatabricksHttpException, TException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetFunctionsResp response = getThriftClient().GetFunctions(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp listPrimaryKeys(TGetPrimaryKeysReq request)
       throws DatabricksHttpException, TException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetPrimaryKeysResp response = getThriftClient().GetPrimaryKeys(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp getTables(TGetTablesReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetTablesResp response = getThriftClient().GetTables(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp getTableTypes(TGetTableTypesReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetTableTypesResp response = getThriftClient().GetTableTypes(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp getCatalogs(TGetCatalogsReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetCatalogsResp response = getThriftClient().GetCatalogs(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp listSchemas(TGetSchemasReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetSchemasResp response = getThriftClient().GetSchemas(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TFetchResultsResp getTypeInfo(TGetTypeInfoReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetTypeInfoResp response = getThriftClient().GetTypeInfo(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          true);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        true);
   }
 
   private TFetchResultsResp listColumns(TGetColumnsReq request)
       throws TException, DatabricksHttpException {
     if (enableDirectResults) request.setGetDirectResults(DEFAULT_DIRECT_RESULTS);
     TGetColumnsResp response = getThriftClient().GetColumns(request);
-    if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
-      return response.getDirectResults().getResultSet();
+    DatabricksHttpTTransport transport =
+        (DatabricksHttpTTransport) getThriftClient().getInputProtocol().getTransport();
+    try {
+      if (response.isSetDirectResults()) {
+        checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+        return response.getDirectResults().getResultSet();
+      }
+      return getResultSetResp(
+          response.getStatus().getStatusCode(),
+          response.getOperationHandle(),
+          response.toString(),
+          DEFAULT_ROW_LIMIT,
+          false);
+    } finally {
+      transport.close();
     }
-    return getResultSetResp(
-        response.getStatus().getStatusCode(),
-        response.getOperationHandle(),
-        response.toString(),
-        DEFAULT_ROW_LIMIT,
-        false);
   }
 
   private TGetResultSetMetadataResp getResultSetMetadata(TOperationHandle operationHandle)


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Currently, when running a lot of queries across multiple jdbc connections, we were running out of http connections that the connection pool could provide. This was occurring due to the responses of the clients not being closed after being consumed. This PR fixes that issue, by making sure responses are closed in due time.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

