### PR TITLE
Closes expired and idle connections in Thrift Flow

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksHttpTTransport.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksHttpTTransport.java
@@ -33,6 +33,7 @@ public class DatabricksHttpTTransport extends TTransport {
 
   public DatabricksHttpTTransport(DatabricksHttpClient httpClient, String url) {
     this.httpClient = httpClient;
+    this.httpClient.closeExpiredAndIdleConnections();
     this.url = url;
     this.requestBuffer = new ByteArrayOutputStream();
   }
@@ -50,6 +51,7 @@ public class DatabricksHttpTTransport extends TTransport {
 
   @Override
   public void close() {
+    this.httpClient.closeExpiredAndIdleConnections();
     if (inputStream != null) {
       try {
         inputStream.close();
@@ -136,6 +138,8 @@ public class DatabricksHttpTTransport extends TTransport {
         }
         cause = cause.getCause();
       }
+      httpClient.closeExpiredAndIdleConnections();
+
       String errorMessage = "Failed to flush data to server: " + e.getMessage();
       LOGGER.error(errorMessage);
       throw new TTransportException(TTransportException.UNKNOWN, errorMessage);


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

Uses the idleHttpConnectionExpiry JDBC Connection Parameter to close idle and expired connections from the connection pool manager.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

