### PR TITLE
Default HTTP client with SSL disabled to send metrics

### DIFF
--- a/src/main/java/com/databricks/jdbc/commons/util/DefaultHttpClientUtil.java
+++ b/src/main/java/com/databricks/jdbc/commons/util/DefaultHttpClientUtil.java
@@ -1,0 +1,38 @@
+package com.databricks.jdbc.commons.util;
+
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+public class DefaultHttpClientUtil {
+  public static DefaultHttpClient getDefaultHttpClient() throws Exception {
+    DefaultHttpClient httpClient = new DefaultHttpClient();
+    SSLContext ssl_ctx = SSLContext.getInstance("TLS");
+    TrustManager[] certs =
+        new TrustManager[] {
+          new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+              return null;
+            }
+
+            public void checkClientTrusted(X509Certificate[] certs, String t) {}
+
+            public void checkServerTrusted(X509Certificate[] certs, String t) {}
+          }
+        };
+    ssl_ctx.init(null, certs, new SecureRandom());
+    SSLSocketFactory ssf =
+        new SSLSocketFactory(ssl_ctx, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+    ClientConnectionManager ccm = httpClient.getConnectionManager();
+    SchemeRegistry sr = ccm.getSchemeRegistry();
+    sr.register(new Scheme("https", 443, ssf));
+    return new DefaultHttpClient(ccm, httpClient.getParams());
+  }
+}

--- a/src/main/java/com/databricks/jdbc/telemetry/DatabricksMetrics.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/DatabricksMetrics.java
@@ -1,7 +1,7 @@
 package com.databricks.jdbc.telemetry;
 
 import com.databricks.jdbc.client.DatabricksHttpException;
-import com.databricks.jdbc.client.http.DatabricksHttpClient;
+import com.databricks.jdbc.commons.util.DefaultHttpClientUtil;
 import com.databricks.jdbc.core.DatabricksSQLException;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,6 +15,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 
 // TODO (Bhuvan) Flush out metrics once the driver connection is closed
@@ -30,7 +31,7 @@ public class DatabricksMetrics {
   private final String METRICS_TYPE = "metrics_type";
   private Boolean hasInitialExportOccurred = false;
   private String workspaceId = null;
-  private DatabricksHttpClient telemetryClient = null;
+  private DefaultHttpClient telemetryClient = null;
 
   private void setWorkspaceId(String workspaceId) {
     this.workspaceId = workspaceId;
@@ -67,7 +68,13 @@ public class DatabricksMetrics {
     }
     String resourceId = context.getComputeResource().getWorkspaceId();
     setWorkspaceId(resourceId);
-    telemetryClient = DatabricksHttpClient.getInstance(context);
+    // TODO: Bhuvan: Replace telemetry client with DatabricksHttpClient when non-SSL variation is
+    // implemented
+    try {
+      telemetryClient = DefaultHttpClientUtil.getDefaultHttpClient();
+    } catch (Exception e) {
+      throw new DatabricksSQLException("Failed to create telemetry client");
+    }
     scheduleExportMetrics();
   }
 


### PR DESCRIPTION
### Description
Replaced `DatabricksHttpClient` with `DefaultHttpClient` (ssl disabled) to execute API calls for exporting metrics.

### Testing
Manually using Driver Tester

### TODO
Implement Non SSL version of `DatabricksHttpClient`