### PR TITLE
Fix oAuth tests

### DIFF
--- a/.github/workflows/bugCatcher.yml
+++ b/.github/workflows/bugCatcher.yml
@@ -1,10 +1,6 @@
 name: Weekly bug catcher
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - main
   schedule:
     # Runs at 00:00 on every Monday
     - cron: '0 0 * * 1'


### PR DESCRIPTION
## Description
- Bug catcher test on github catches if there are any oAuth regressions (to avoid the regression we had - that was caught in brickReady testing)
- This will also test any regressions from SDK side if we update versions. 

## Testing
- Manually tested (Added PR push schedule first and reverted back to weekly once it passed.)

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

