### PR TITLE
[PECO-1755] TINYINT SQL type should be mapped to BYTE Java type

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelper.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelper.java
@@ -129,6 +129,7 @@ public class DatabricksThriftHelper {
       case BOOLEAN_TYPE:
         return ColumnInfoTypeName.BOOLEAN;
       case TINYINT_TYPE:
+        return ColumnInfoTypeName.BYTE;
       case SMALLINT_TYPE:
         return ColumnInfoTypeName.SHORT;
       case INT_TYPE:

--- a/src/test/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelperTest.java
@@ -93,7 +93,7 @@ public class DatabricksThriftHelperTest {
   private static Stream<Arguments> typeIdAndColumnInfoType() {
     return Stream.of(
         Arguments.of(TTypeId.BOOLEAN_TYPE, ColumnInfoTypeName.BOOLEAN),
-        Arguments.of(TTypeId.TINYINT_TYPE, ColumnInfoTypeName.SHORT),
+        Arguments.of(TTypeId.TINYINT_TYPE, ColumnInfoTypeName.BYTE),
         Arguments.of(TTypeId.SMALLINT_TYPE, ColumnInfoTypeName.SHORT),
         Arguments.of(TTypeId.INT_TYPE, ColumnInfoTypeName.INT),
         Arguments.of(TTypeId.BIGINT_TYPE, ColumnInfoTypeName.LONG),


### PR DESCRIPTION
## Description
Reference: https://learn.microsoft.com/en-us/sql/language-extensions/how-to/java-to-sql-data-types?view=sql-server-ver16

## Testing
- Unit tests
- Runtime tests

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

