### PR TITLE
Change Metadata benchmarking test to use Dogfood environment

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/benchmarking/MetadataBenchmarkingTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/benchmarking/MetadataBenchmarkingTests.java
@@ -106,7 +106,8 @@ public class MetadataBenchmarkingTests {
 
     switch (mode) {
       case "SEA":
-        connection = DriverManager.getConnection(getDogfoodJDBCUrl(), "token", getDatabricksDogfoodToken());
+        connection =
+            DriverManager.getConnection(getDogfoodJDBCUrl(), "token", getDatabricksDogfoodToken());
         break;
       case "THRIFT":
         connection =


### PR DESCRIPTION
## Description
Change Metadata benchmarking test to use Dogfood environment since current test warehouse doesn't support new metadata commands.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

