### PR TITLE
Skipped flushing of metrics when session is closed for integration tests

### DIFF
--- a/src/main/java/com/databricks/jdbc/core/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksSession.java
@@ -155,7 +155,9 @@ public class DatabricksSession implements IDatabricksSession {
         databricksClient.deleteSession(this, computeResource);
         this.sessionInfo = null;
         this.isSessionOpen = false;
-        this.connectionContext.getMetricsExporter().close();
+        if (!connectionContext.isFakeServiceTest()) {
+          this.connectionContext.getMetricsExporter().close();
+        }
       }
     }
   }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
@@ -539,4 +539,12 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   public boolean supportManyParameters() {
     return getParameter(SUPPORT_MANY_PARAMETERS, "0").equals("1");
   }
+
+  /** Returns whether the current test is a fake service test. */
+  // TODO: (Bhuvan) This is a temporary solution to enable fake service tests by disabling flushing
+  // of metrics when session is closed. We should remove this
+  @Override
+  public boolean isFakeServiceTest() {
+    return Boolean.parseBoolean(System.getProperty(IS_FAKE_SERVICE_TEST_PROP));
+  }
 }

--- a/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
@@ -147,4 +147,6 @@ public interface IDatabricksConnectionContext {
   int getIdleHttpConnectionExpiry();
 
   boolean supportManyParameters();
+
+  boolean isFakeServiceTest();
 }


### PR DESCRIPTION
## Description
Disabling flushing of metrics when integration tests are run