### PR TITLE
Sanitize requests before logging

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/http/RequestSanitizer.java
+++ b/src/main/java/com/databricks/jdbc/client/http/RequestSanitizer.java
@@ -1,10 +1,54 @@
 package com.databricks.jdbc.client.http;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
 import org.apache.http.client.methods.HttpUriRequest;
 
 public class RequestSanitizer {
+  private static final List<String> SENSITIVE_QUERY_PARAMS =
+      List.of("X-Amz-Security-Token", "X-Amz-Signature", "X-Amz-Credential");
+
   public static String sanitizeRequest(HttpUriRequest request) {
-    // TODO: sanitize in better way
-    return request.getURI().toString();
+    try {
+      URI uri = new URI(request.getURI().toString());
+      String sanitizedQuery = sanitizeQuery(uri.getRawQuery());
+      URI sanitizedUri =
+          new URI(
+              uri.getScheme(),
+              uri.getAuthority(),
+              uri.getPath(),
+              sanitizedQuery,
+              uri.getFragment());
+      return sanitizedUri.toString();
+    } catch (URISyntaxException e) {
+      return "Error sanitizing URI: " + e.getMessage();
+    }
+  }
+
+  private static String sanitizeQuery(String query) {
+    if (query == null) {
+      return null;
+    }
+
+    StringBuilder sanitizedQuery = new StringBuilder();
+    String[] pairs = query.split("&");
+    for (String pair : pairs) {
+      int idx = pair.indexOf("=");
+      String key = (idx > 0) ? pair.substring(0, idx) : pair;
+      if (SENSITIVE_QUERY_PARAMS.contains(key)) {
+        sanitizedQuery.append(key).append("=REDACTED");
+      } else {
+        sanitizedQuery.append(pair);
+      }
+      sanitizedQuery.append("&");
+    }
+
+    // Remove the trailing '&' if present
+    if (sanitizedQuery.length() > 0) {
+      sanitizedQuery.setLength(sanitizedQuery.length() - 1);
+    }
+
+    return sanitizedQuery.toString();
   }
 }

--- a/src/test/java/com/databricks/jdbc/client/http/RequestSanitizerTest.java
+++ b/src/test/java/com/databricks/jdbc/client/http/RequestSanitizerTest.java
@@ -1,0 +1,72 @@
+package com.databricks.jdbc.client.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.Test;
+
+public class RequestSanitizerTest {
+
+  @Test
+  public void testSanitizeRequest_withSensitiveParams() {
+    String originalUri =
+        "https://example.com/api?X-Amz-Security-Token=token123&X-Amz-Signature=signature123&X-Amz-Credential=credential123";
+    HttpUriRequest request = new HttpGet(originalUri);
+
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(request);
+
+    String expectedUri =
+        "https://example.com/api?X-Amz-Security-Token=REDACTED&X-Amz-Signature=REDACTED&X-Amz-Credential=REDACTED";
+    assertEquals(expectedUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withNoSensitiveParams() {
+    String originalUri = "https://example.com/api?param1=value1&param2=value2";
+    HttpUriRequest request = new HttpGet(originalUri);
+
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(request);
+
+    assertEquals(originalUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withMixedParams() {
+    String originalUri =
+        "https://example.com/api?param1=value1&X-Amz-Security-Token=token123&param2=value2&X-Amz-Signature=signature123";
+    HttpUriRequest request = new HttpGet(originalUri);
+
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(request);
+
+    String expectedUri =
+        "https://example.com/api?param1=value1&X-Amz-Security-Token=REDACTED&param2=value2&X-Amz-Signature=REDACTED";
+    assertEquals(expectedUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withEmptyQuery() {
+    String originalUri = "https://example.com/api";
+    HttpUriRequest request = new HttpGet(originalUri);
+
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(request);
+
+    assertEquals(originalUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withErrorInUri() {
+    HttpUriRequest mockRequest = mock(HttpUriRequest.class);
+    URI mockUri = mock(URI.class);
+
+    when(mockRequest.getURI()).thenReturn(mockUri);
+    when(mockUri.toString()).thenReturn("https://example.com/path with spaces");
+
+    String result = RequestSanitizer.sanitizeRequest(mockRequest);
+    assertTrue(result.startsWith("Error sanitizing URI:"));
+  }
+}


### PR DESCRIPTION
## Description
This commit removes sensitive info from requests before logging like AWS secrets, etc.
It will replace sensitive info with the string `REDACTED`.

For example:
```
2024-07-17 12:50:40 DEBUG databricks-jdbc - Executing HTTP request [{https://e2-dogfood-core.s3.us-west-2.amazonaws.com/oregon-staging/6051921418418893.jobs/sql/extended/results_2024-07-18T08:20:34Z_29b1ead1-84b2-471c-abf7-fd1ceacda97d?X-Amz-Security-Token=REDACTED&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240717T072040Z&X-Amz-SignedHeaders=host&X-Amz-Expires=899&X-Amz-Credential=REDACTED&X-Amz-Signature=REDACTED}]
```

## Testing
Added unit tests.

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

