### PR TITLE
[Temporary Bug Fix] Execute multi-chunk and connection in thrift tests

### DIFF
--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -19,7 +19,7 @@ jobs:
           - test-command: mvn -B compile test -Dtest=*IntegrationTests
             token-secret: DATABRICKS_TOKEN
             use-thrift-client: 'false'
-          - test-command: mvn -B compile test -Dtest=**/fakeservice/tests/*.java,!**/fakeservice/tests/ConcurrencyIntegrationTests.java,!**/fakeservice/tests/PreparedStatementIntegrationTests.java,!**/fakeservice/tests/UCVolumeIntegrationTests.java
+          - test-command: mvn -B compile test -Dtest=**/fakeservice/tests/MultiChunkExecutionIntegrationTests.java,**/fakeservice/tests/ConnectionIntegrationTests.java
             token-secret: THRIFT_DATABRICKS_TOKEN
             use-thrift-client: 'true'
     steps:


### PR DESCRIPTION
## Description
This commit limits the thrift integration tests workflow to run multi-chunk and connection tests.

Other test classes like `ResultSetIntegrationTests` record a relatively large number of stub mappings pointing to the same thrift URL `/sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv`. The embedded Jetty server, therefore relies on the request body for differentiating between stub mappings. For each stub mapping, it has to decode binary body and deduce relevance to the original request. Consequently, the client's connection with the embedded Jetty server times out indeterminately.

Note that the issue surfaces only in slow CI/CD instances and is not reproducible yet locally. There are few open issues related to this: https://github.com/wiremock/wiremock/issues/2108, https://github.com/wiremock/wiremock/issues/97

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

