### PR TITLE
Fix driver pattern for executeQuery

### DIFF
--- a/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/core/DatabricksStatement.java
@@ -618,7 +618,6 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
     trimmedQuery = trimmedQuery.replaceAll("/\\*.*?\\*/", "");
     trimmedQuery = trimmedQuery.replaceAll("\\s+", " ").trim();
 
-
     // Check if the query matches any of the patterns that return a ResultSet
     if (SELECT_PATTERN.matcher(trimmedQuery).find()
         || SHOW_PATTERN.matcher(trimmedQuery).find()

--- a/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/core/DatabricksStatementTest.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -458,7 +458,8 @@ public class DatabricksStatementTest {
 
   @Test
   public void testShouldReturnResultSet_CommentSurroundingQuery() {
-    String query = "-- Single-line comment\n/* Multi-line comment */ SELECT * FROM table; /* Another comment */ -- End comment";
+    String query =
+        "-- Single-line comment\n/* Multi-line comment */ SELECT * FROM table; /* Another comment */ -- End comment";
     assertTrue(DatabricksStatement.shouldReturnResultSet(query));
   }
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

Currently, if a query has multiple single line comments at the start, our regex is not able to catch it. This fixes that issue, and introduces comprehensive testing.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

