### PR TITLE
Fix handling of null type for thrift inline flow

### DIFF
--- a/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelper.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/thrift/commons/DatabricksThriftHelper.java
@@ -194,7 +194,8 @@ public class DatabricksThriftHelper {
     if (column.isSetStringVal())
       return getColumnValuesWithNulls(
           column.getStringVal().getValues(), column.getStringVal().getNulls());
-    return null; // Return null if no valid value set
+    return getColumnValuesWithNulls(
+        column.getStringVal().getValues(), column.getStringVal().getNulls()); // default to string
   }
 
   private static <T> List<T> getColumnValuesWithNulls(List<T> values, byte[] nulls) {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

Currently when we try to run queries like `SELECT cast(NULL as DOUBLE)` and get the object from the resultSet, we get a value of `0.0` instead of the expected output of `null`. This fixes this issue.

## Testing
<!-- Describe how the changes have been tested-->

Tested using driver tester

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

