### PR TITLE
Make DatabricksConnectionContext package-private

### DIFF
--- a/src/main/java/com/databricks/client/jdbc/Driver.java
+++ b/src/main/java/com/databricks/client/jdbc/Driver.java
@@ -5,13 +5,10 @@ import static com.databricks.jdbc.driver.DatabricksJdbcConstants.*;
 import com.databricks.jdbc.client.DatabricksClientType;
 import com.databricks.jdbc.commons.ErrorTypes;
 import com.databricks.jdbc.commons.LogLevel;
-import com.databricks.jdbc.commons.util.DeviceInfoLogUtil;
-import com.databricks.jdbc.commons.util.DriverUtil;
-import com.databricks.jdbc.commons.util.ErrorCodes;
-import com.databricks.jdbc.commons.util.LoggingUtil;
+import com.databricks.jdbc.commons.util.*;
 import com.databricks.jdbc.core.DatabricksConnection;
 import com.databricks.jdbc.core.DatabricksSQLException;
-import com.databricks.jdbc.driver.DatabricksConnectionContext;
+import com.databricks.jdbc.driver.DatabricksConnectionContextFactory;
 import com.databricks.jdbc.driver.DatabricksJdbcConstants;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.UserAgent;
@@ -19,16 +16,17 @@ import java.sql.*;
 import java.util.Properties;
 
 /**
- * Databricks JDBC driver. TODO: Add implementation to accept Urls in format:
- * jdbc:databricks://host:port.
+ * Databricks JDBC driver.
+ *
+ * <p>TODO: Add implementation to accept Urls in format, jdbc:databricks://host:port.
  */
 public class Driver implements java.sql.Driver {
+
   private static final Driver INSTANCE;
 
   static {
     try {
       DriverManager.registerDriver(INSTANCE = new Driver());
-      System.out.printf("Driver has been registered. instance = %s\n", INSTANCE);
     } catch (SQLException e) {
       throw new IllegalStateException("Unable to register " + Driver.class, e);
     }
@@ -36,12 +34,13 @@ public class Driver implements java.sql.Driver {
 
   @Override
   public boolean acceptsURL(String url) {
-    return DatabricksConnectionContext.isValid(url);
+    return ValidationUtil.isValidJdbcUrl(url);
   }
 
   @Override
   public Connection connect(String url, Properties info) throws DatabricksSQLException {
-    IDatabricksConnectionContext connectionContext = DatabricksConnectionContext.parse(url, info);
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContextFactory.create(url, info);
     LoggingUtil.setupLogger(
         connectionContext.getLogPathString(),
         connectionContext.getLogFileSize(),
@@ -87,40 +86,6 @@ public class Driver implements java.sql.Driver {
     }
   }
 
-  private void setMetadataClient(
-      DatabricksConnection connection, IDatabricksConnectionContext connectionContext) {
-    if (connectionContext.getUseLegacyMetadata().equals(true)) {
-      LoggingUtil.log(
-          LogLevel.DEBUG,
-          "The new metadata commands are enabled, but the legacy metadata commands are being used due to connection parameter useLegacyMetadata");
-      connection.setMetadataClient(true);
-    } else {
-      connection.setMetadataClient(false);
-    }
-  }
-
-  private boolean checkSupportForNewMetadata(String dbsqlVersion) {
-    try {
-      int majorVersion = Integer.parseInt(dbsqlVersion.split("\\.")[0]);
-      int minorVersion = Integer.parseInt(dbsqlVersion.split("\\.")[1]);
-
-      if (majorVersion > DBSQL_MIN_MAJOR_VERSION_FOR_NEW_METADATA) {
-        return true;
-      } else if (majorVersion == DBSQL_MIN_MAJOR_VERSION_FOR_NEW_METADATA) {
-        return minorVersion >= DBSQL_MIN_MINOR_VERSION_FOR_NEW_METADATA;
-      } else {
-        return false;
-      }
-    } catch (Exception e) {
-      LoggingUtil.log(
-          LogLevel.DEBUG,
-          String.format(
-              "Unable to parse the DBSQL version {%s}. Falling back to legacy metadata commands.",
-              dbsqlVersion));
-      return false;
-    }
-  }
-
   @Override
   public int getMajorVersion() {
     return DriverUtil.getMajorVersion();
@@ -157,5 +122,39 @@ public class Driver implements java.sql.Driver {
   public static void setUserAgent(IDatabricksConnectionContext connectionContext) {
     UserAgent.withProduct(DatabricksJdbcConstants.DEFAULT_USER_AGENT, DriverUtil.getVersion());
     UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, connectionContext.getClientUserAgent());
+  }
+
+  private void setMetadataClient(
+      DatabricksConnection connection, IDatabricksConnectionContext connectionContext) {
+    if (connectionContext.getUseLegacyMetadata().equals(true)) {
+      LoggingUtil.log(
+          LogLevel.DEBUG,
+          "The new metadata commands are enabled, but the legacy metadata commands are being used due to connection parameter useLegacyMetadata");
+      connection.setMetadataClient(true);
+    } else {
+      connection.setMetadataClient(false);
+    }
+  }
+
+  private boolean checkSupportForNewMetadata(String dbsqlVersion) {
+    try {
+      int majorVersion = Integer.parseInt(dbsqlVersion.split("\\.")[0]);
+      int minorVersion = Integer.parseInt(dbsqlVersion.split("\\.")[1]);
+
+      if (majorVersion > DBSQL_MIN_MAJOR_VERSION_FOR_NEW_METADATA) {
+        return true;
+      } else if (majorVersion == DBSQL_MIN_MAJOR_VERSION_FOR_NEW_METADATA) {
+        return minorVersion >= DBSQL_MIN_MINOR_VERSION_FOR_NEW_METADATA;
+      } else {
+        return false;
+      }
+    } catch (Exception e) {
+      LoggingUtil.log(
+          LogLevel.DEBUG,
+          String.format(
+              "Unable to parse the DBSQL version {%s}. Falling back to legacy metadata commands.",
+              dbsqlVersion));
+      return false;
+    }
   }
 }

--- a/src/main/java/com/databricks/jdbc/commons/util/ValidationUtil.java
+++ b/src/main/java/com/databricks/jdbc/commons/util/ValidationUtil.java
@@ -1,10 +1,14 @@
 package com.databricks.jdbc.commons.util;
 
+import static com.databricks.jdbc.driver.DatabricksJdbcConstants.*;
+
 import com.databricks.jdbc.client.DatabricksHttpException;
 import com.databricks.jdbc.commons.LogLevel;
 import com.databricks.jdbc.core.DatabricksSQLException;
 import com.databricks.jdbc.core.DatabricksValidationException;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.http.HttpResponse;
 
 public class ValidationUtil {
@@ -48,5 +52,28 @@ public class ValidationUtil {
         String.format("HTTP request failed by code: %d, status line: %s", statusCode, statusLine);
     throw new DatabricksHttpException(
         "Unable to fetch HTTP response successfully. " + errorMessage);
+  }
+
+  /**
+   * Validates the JDBC URL.
+   *
+   * @param url JDBC URL
+   * @return true if the URL is valid, false otherwise
+   */
+  public static boolean isValidJdbcUrl(String url) {
+    final List<Pattern> PATH_PATTERNS =
+        List.of(
+            HTTP_CLUSTER_PATH_PATTERN,
+            HTTP_WAREHOUSE_PATH_PATTERN,
+            HTTP_ENDPOINT_PATH_PATTERN,
+            TEST_PATH_PATTERN,
+            BASE_PATTERN,
+            HTTP_CLI_PATTERN);
+
+    if (!JDBC_URL_PATTERN.matcher(url).matches()) {
+      return false;
+    }
+
+    return PATH_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(url).matches());
   }
 }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContextFactory.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContextFactory.java
@@ -1,0 +1,21 @@
+package com.databricks.jdbc.driver;
+
+import com.databricks.jdbc.core.DatabricksSQLException;
+import java.util.Properties;
+
+/** Factory class for creating instances of {@link IDatabricksConnectionContext}. */
+public class DatabricksConnectionContextFactory {
+
+  /**
+   * Creates an instance of {@link IDatabricksConnectionContext} from the given URL and properties.
+   *
+   * @param url JDBC URL
+   * @param properties JDBC connection properties
+   * @return an instance of {@link IDatabricksConnectionContext}
+   * @throws DatabricksSQLException if the URL or properties are invalid
+   */
+  public static IDatabricksConnectionContext create(String url, Properties properties)
+      throws DatabricksSQLException {
+    return DatabricksConnectionContext.parse(url, properties);
+  }
+}

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
@@ -156,7 +156,9 @@ public final class DatabricksJdbcConstants {
   public static final String TABLE = "table";
 
   public static final String USER_NAME = "User";
+
   public static final String PORT = "port";
+
   public static final int DEFAULT_PORT = 443;
 
   /** Adding this for backward compatibility only */
@@ -216,54 +218,85 @@ public final class DatabricksJdbcConstants {
   public static final String USE_LEGACY_METADATA = "uselegacymetadata";
 
   static final String TEMPORARILY_UNAVAILABLE_RETRY = "TemporarilyUnavailableRetry";
+
   static final String TEMPORARILY_UNAVAILABLE_RETRY_TIMEOUT = "TemporarilyUnavailableRetryTimeout";
+
   public static final String DEFAULT_TEMPORARILY_UNAVAILABLE_RETRY_TIMEOUT = "900";
+
   static final String RATE_LIMIT_RETRY = "RateLimitRetry";
+
   static final String RATE_LIMIT_RETRY_TIMEOUT = "RateLimitRetryTimeout";
+
   public static final String DEFAULT_RATE_LIMIT_RETRY_TIMEOUT = "120";
+
   static final String IDLE_HTTP_CONNECTION_EXPIRY = "IdleHttpConnectionExpiry";
+
   static final String SUPPORT_MANY_PARAMETERS = "supportManyParameters";
+
   public static final String DEFAULT_IDLE_HTTP_CONNECTION_EXPIRY = "60";
+
   public static final String CLOUD_FETCH_THREAD_POOL_SIZE = "cloudFetchThreadPoolSize";
+
   public static final int CLOUD_FETCH_THREAD_POOL_SIZE_DEFAULT = 16;
+
   public static final String ENABLE_TELEMETRY = "enableTelemetry";
+
   public static final Pattern SELECT_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*SELECT", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern SHOW_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*SHOW", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern DESCRIBE_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*DESCRIBE", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern EXPLAIN_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*EXPLAIN", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern WITH_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*WITH", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern SET_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*SET", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern MAP_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*MAP", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern FROM_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*FROM\\s*\\(", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern VALUES_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*VALUES", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern UNION_PATTERN =
       Pattern.compile("\\s+UNION\\s+", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern INTERSECT_PATTERN =
       Pattern.compile("\\s+INTERSECT\\s+", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern EXCEPT_PATTERN =
       Pattern.compile("\\s+EXCEPT\\s+", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern DECLARE_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*DECLARE", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern PUT_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*GET", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern GET_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*PUT", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern REMOVE_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*REMOVE", Pattern.CASE_INSENSITIVE);
+
   public static final Pattern LIST_PATTERN =
       Pattern.compile("^(\\s*\\()*\\s*LIST", Pattern.CASE_INSENSITIVE);
+
   public static final int DBSQL_MIN_MAJOR_VERSION_FOR_NEW_METADATA = 2024;
+
   public static final int DBSQL_MIN_MINOR_VERSION_FOR_NEW_METADATA = 30;
 
   public static final int DEFAULT_RETRY_COUNT = 5;
+
   public static final LogLevel TELEMETRY_LOG_LEVEL = LogLevel.OFF;
 }

--- a/src/test/java/com/databricks/jdbc/TestConstants.java
+++ b/src/test/java/com/databricks/jdbc/TestConstants.java
@@ -10,12 +10,49 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/*All the common test constants should be placed here */
+/** TestConstants class contains all the constants that are used in the test classes. */
 public class TestConstants {
+  public static final String VALID_URL_1 =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2";
+  public static final String VALID_URL_2 =
+      "jdbc:databricks://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;LogLevel=invalid;EnableQueryResultLZ4Compression=1;UseThriftClient=0";
+  public static final String VALID_URL_3 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=0;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;EnableQueryResultLZ4Compression=0;UseThriftClient=1;LogLevel=1234";
+  public static final String VALID_URL_4 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1;EnableDirectResults=1;";
+  public static final String VALID_URL_5 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473;ssl=0;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1;EnableDirectResults=0";
+  public static final String VALID_URL_6 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473/schemaName;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;ConnCatalog=catalogName;QueryResultCompressionType=1";
+  public static final String VALID_URL_7 =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
+  public static final String VALID_URL_8 =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;port=123;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
+  public static final String VALID_URL_WITH_INVALID_COMPRESSION_TYPE =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=234";
+  public static final String INVALID_URL_1 =
+      "jdbc:oracle://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
+  public static final String INVALID_URL_2 =
+      "http:databricks://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
+  public static final String INVALID_URL_3 =
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;port=alphabetical;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
+  public static final String VALID_JDBC_TEST_URL = "jdbc:databricks://test";
+  public static final String VALID_CLUSTER_URL =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;httpPath=sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv;AuthMech=3;loglevel=3";
+  public static final String INVALID_CLUSTER_URL =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;httpPath=sql/protocolv1/oo/6051921418418893/1115-130834-ms4m0yv;AuthMech=3";
+  public static final String VALID_BASE_URL_1 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;";
+  public static final String VALID_BASE_URL_2 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default";
+  public static final String VALID_BASE_URL_3 =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443";
+  public static final String VALID_URL_WITH_PROXY =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;UseProxy=1;ProxyHost=127.0.0.1;ProxyPort=8080;ProxyAuth=1;ProxyUID=proxyUser;ProxyPwd=proxyPassword;";
+  public static final String VALID_URL_WITH_PROXY_AND_CF_PROXY =
+      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;UseSystemProxy=1;UseProxy=1;ProxyHost=127.0.0.1;ProxyPort=8080;ProxyAuth=1;ProxyUID=proxyUser;ProxyPwd=proxyPassword;UseCFProxy=1;CFProxyHost=127.0.1.2;CFProxyPort=8081;CFProxyAuth=2;CFProxyUID=cfProxyUser;CFProxyPwd=cfProxyPassword;";
   public static final String WAREHOUSE_ID = "warehouse_id";
   public static final String SESSION_ID = "12345678";
-  private static final String CATALOG = "field_demos";
-  private static final String SCHEMA = "ossjdbc";
   public static final Warehouse WAREHOUSE_COMPUTE = new Warehouse(WAREHOUSE_ID);
   public static final ComputeResource CLUSTER_COMPUTE =
       new AllPurposeCluster("6051921418418893", "1115-130834-ms4m0yv");
@@ -29,7 +66,6 @@ public class TestConstants {
   public static final String TEST_STATEMENT_ID = "testStatementId";
   public static final String UC_VOLUME_CATALOG = "uc_volume_test_catalog";
   public static final String UC_VOLUME_SCHEMA = "uc_volume_test_schema";
-
   public static final TSessionHandle SESSION_HANDLE =
       new TSessionHandle().setSessionId(new THandleIdentifier().setGuid(SESSION_ID.getBytes()));
   public static final ImmutableSessionInfo SESSION_INFO =
@@ -40,10 +76,8 @@ public class TestConstants {
           .build();
   public static final String WAREHOUSE_JDBC_URL =
       "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/warehouse_id;";
-
   public static final String WAREHOUSE_JDBC_URL_WITH_THRIFT =
       "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/warehouse_id;UseThriftClient=1;";
-
   public static final TRowSet binaryRowSet =
       new TRowSet()
           .setColumns(
@@ -83,14 +117,12 @@ public class TestConstants {
           .setColumns(
               Collections.singletonList(
                   TColumn.i64Val(new TI64Column().setValues(List.of(1L, 5L)))));
-
   public static final TRowSet stringRowSet =
       new TRowSet()
           .setColumns(
               Collections.singletonList(
                   TColumn.stringVal(
                       new TStringColumn().setValues(List.of(TEST_STRING, TEST_STRING)))));
-
   private static final TColumnDesc TEST_COLUMN_DESCRIPTION =
       new TColumnDesc().setColumnName("testCol");
   public static final TTableSchema TEST_TABLE_SCHEMA =

--- a/src/test/java/com/databricks/jdbc/client/http/DatabricksHttpClientTest.java
+++ b/src/test/java/com/databricks/jdbc/client/http/DatabricksHttpClientTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.*;
 import com.databricks.client.jdbc.Driver;
 import com.databricks.jdbc.client.DatabricksHttpException;
 import com.databricks.jdbc.client.DatabricksRetryHandlerException;
-import com.databricks.jdbc.driver.DatabricksConnectionContext;
+import com.databricks.jdbc.driver.DatabricksConnectionContextFactory;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import com.databricks.sdk.core.ProxyConfig;
 import java.io.IOException;
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class DatabricksHttpClientTest {
+
   @Mock CloseableHttpClient mockHttpClient;
 
   @Mock HttpUriRequest request;
@@ -50,6 +51,7 @@ public class DatabricksHttpClientTest {
 
   private static final String CLUSTER_JDBC_URL =
       "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;httpPath=sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv;AuthMech=3;UserAgentEntry=MyApp";
+
   private static final String DBSQL_JDBC_URL =
       "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;transportMode=http;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;UserAgentEntry=MyApp";
 
@@ -237,7 +239,7 @@ public class DatabricksHttpClientTest {
   void testUserAgent() throws Exception {
     // Thrift
     IDatabricksConnectionContext connectionContext =
-        DatabricksConnectionContext.parse(CLUSTER_JDBC_URL, new Properties());
+        DatabricksConnectionContextFactory.create(CLUSTER_JDBC_URL, new Properties());
     Driver.setUserAgent(connectionContext);
     String userAgent = DatabricksHttpClient.getUserAgent();
     assertTrue(userAgent.contains("DatabricksJDBCDriverOSS/0.9.1-oss"));
@@ -246,7 +248,7 @@ public class DatabricksHttpClientTest {
     assertFalse(userAgent.contains("databricks-sdk-java"));
 
     // SEA
-    connectionContext = DatabricksConnectionContext.parse(DBSQL_JDBC_URL, new Properties());
+    connectionContext = DatabricksConnectionContextFactory.create(DBSQL_JDBC_URL, new Properties());
     Driver.setUserAgent(connectionContext);
     userAgent = DatabricksHttpClient.getUserAgent();
     assertTrue(userAgent.contains("DatabricksJDBCDriverOSS/0.9.1-oss"));

--- a/src/test/java/com/databricks/jdbc/commons/ValidationUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/commons/ValidationUtilTest.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.commons;
 
+import static com.databricks.jdbc.TestConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -17,23 +18,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ValidationUtilTest {
   @Mock StatusLine statusLine;
   @Mock HttpResponse response;
-  private static ValidationUtil validationUtil = new ValidationUtil();
 
   @Test
   void testCheckIfPositive() {
     assertDoesNotThrow(() -> ValidationUtil.checkIfNonNegative(10, "testField"));
     assertThrows(
-        DatabricksSQLException.class, () -> validationUtil.checkIfNonNegative(-10, "testField"));
+        DatabricksSQLException.class, () -> ValidationUtil.checkIfNonNegative(-10, "testField"));
   }
 
   @Test
   void testSuccessfulResponseCheck() {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
-    assertDoesNotThrow(() -> validationUtil.checkHTTPError(response));
+    assertDoesNotThrow(() -> ValidationUtil.checkHTTPError(response));
 
     when(statusLine.getStatusCode()).thenReturn(202);
-    assertDoesNotThrow(() -> validationUtil.checkHTTPError(response));
+    assertDoesNotThrow(() -> ValidationUtil.checkHTTPError(response));
   }
 
   @Test
@@ -42,12 +42,32 @@ class ValidationUtilTest {
     when(statusLine.getStatusCode()).thenReturn(400);
     when(statusLine.toString()).thenReturn("mockStatusLine");
     Throwable exception =
-        assertThrows(DatabricksHttpException.class, () -> validationUtil.checkHTTPError(response));
+        assertThrows(DatabricksHttpException.class, () -> ValidationUtil.checkHTTPError(response));
     assertEquals(
         "Unable to fetch HTTP response successfully. HTTP request failed by code: 400, status line: mockStatusLine",
         exception.getMessage());
 
     when(statusLine.getStatusCode()).thenReturn(102);
-    assertThrows(DatabricksHttpException.class, () -> validationUtil.checkHTTPError(response));
+    assertThrows(DatabricksHttpException.class, () -> ValidationUtil.checkHTTPError(response));
+  }
+
+  @Test
+  public void testIsValidJdbcUrl() {
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_1));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_2));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_3));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_4));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_5));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_6));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_7));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_BASE_URL_1));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_BASE_URL_2));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_BASE_URL_3));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_JDBC_TEST_URL));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_CLUSTER_URL));
+    assertTrue(ValidationUtil.isValidJdbcUrl(VALID_URL_WITH_INVALID_COMPRESSION_TYPE));
+    assertFalse(ValidationUtil.isValidJdbcUrl(INVALID_URL_1));
+    assertFalse(ValidationUtil.isValidJdbcUrl(INVALID_URL_2));
+    assertFalse(ValidationUtil.isValidJdbcUrl(INVALID_CLUSTER_URL));
   }
 }

--- a/src/test/java/com/databricks/jdbc/core/ChunkDownloaderTest.java
+++ b/src/test/java/com/databricks/jdbc/core/ChunkDownloaderTest.java
@@ -1,71 +1,22 @@
 package com.databricks.jdbc.core;
 
-import static com.databricks.jdbc.TestConstants.WAREHOUSE_JDBC_URL;
-import static java.lang.Math.min;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import com.databricks.jdbc.client.IDatabricksHttpClient;
-import com.databricks.jdbc.client.impl.sdk.DatabricksSdkClient;
-import com.databricks.jdbc.client.sqlexec.ExternalLink;
 import com.databricks.jdbc.client.sqlexec.ResultData;
 import com.databricks.jdbc.client.sqlexec.ResultManifest;
-import com.databricks.jdbc.driver.DatabricksConnectionContext;
-import com.databricks.jdbc.driver.IDatabricksConnectionContext;
-import com.databricks.sdk.core.ApiClient;
-import com.databricks.sdk.service.sql.BaseChunkInfo;
-import com.databricks.sdk.service.sql.GetStatementResultChunkNRequest;
 import com.databricks.sdk.service.sql.ResultSchema;
-import com.databricks.sdk.service.sql.StatementExecutionService;
-import java.io.*;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.Float8Vector;
-import org.apache.arrow.vector.IntVector;
-import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.dictionary.DictionaryProvider;
-import org.apache.arrow.vector.ipc.ArrowStreamWriter;
-import org.apache.arrow.vector.ipc.ArrowWriter;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ChunkDownloaderTest {
+
   private static final String STATEMENT_ID = "statement_id";
-  private static final String CHUNK_URL_PREFIX = "chunk.databricks.com/";
-  private static final long TOTAL_CHUNKS = 5;
-  private static final long TOTAL_ROWS = 90;
-  private static final long TOTAL_BYTES = 1000;
-
-  private int rowsInRecordBatch = 20;
-  private Random random = new Random();
-
-  @Mock StatementExecutionService statementExecutionService;
-  @Mock DatabricksSdkClient mockedSdkClient;
-  @Mock IDatabricksHttpClient mockHttpClient;
-  @Mock CloseableHttpResponse httpResponse;
-  @Mock HttpEntity httpEntity;
-  @Mock ApiClient apiClient;
 
   @Test
-  public void testInitEmptyChunkDownloader() throws Exception {
+  public void testInitEmptyChunkDownloader() {
     ResultManifest resultManifest =
         new ResultManifest()
             .setTotalChunkCount(0L)
@@ -73,164 +24,5 @@ public class ChunkDownloaderTest {
     ResultData resultData = new ResultData().setExternalLinks(new ArrayList<>());
     assertDoesNotThrow(
         () -> new ChunkDownloader(STATEMENT_ID, resultManifest, resultData, null, null, 4));
-  }
-
-  // @Test
-  public void testInitChunkDownloader() throws Exception {
-    ResultManifest resultManifest = getResultManifest();
-    ResultData resultData = getResultData();
-
-    IDatabricksConnectionContext connectionContext =
-        DatabricksConnectionContext.parse(WAREHOUSE_JDBC_URL, new Properties());
-    DatabricksSession session =
-        new DatabricksSession(
-            connectionContext,
-            new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient));
-    setupMockResponse();
-    when(mockHttpClient.execute(isA(HttpUriRequest.class))).thenReturn(httpResponse);
-
-    ChunkDownloader chunkDownloader =
-        new ChunkDownloader(STATEMENT_ID, resultManifest, resultData, session, mockHttpClient, 4);
-    verify(statementExecutionService, times(3))
-        .getStatementResultChunkN(isA(GetStatementResultChunkNRequest.class));
-
-    assertEquals(4, chunkDownloader.getTotalChunksInMemory());
-    assertTrue(chunkDownloader.hasNextChunk());
-
-    for (long chunkResultIndex = 0L; chunkResultIndex < TOTAL_CHUNKS; chunkResultIndex++) {
-      assertTrue(chunkDownloader.next());
-      assertChunkResult(chunkDownloader.getChunk(), chunkResultIndex);
-    }
-    // TDOD: assert urls as well
-    verify(mockHttpClient, times(5)).execute(isA(HttpUriRequest.class));
-  }
-
-  private ResultData getResultData() {
-    return new ResultData().setExternalLinks(getChunkLinks(0L, false));
-  }
-
-  private ResultManifest getResultManifest() {
-    List<BaseChunkInfo> chunks = new ArrayList<>();
-    for (long chunkIndex = 0; chunkIndex < TOTAL_CHUNKS; chunkIndex++) {
-      BaseChunkInfo chunkInfo =
-          new BaseChunkInfo()
-              .setChunkIndex(chunkIndex)
-              .setByteCount(200L)
-              .setRowOffset(chunkIndex * 20);
-      if (chunkIndex < TOTAL_CHUNKS - 1) {
-        chunkInfo.setRowCount(20L);
-      } else {
-        chunkInfo.setRowCount(10L);
-      }
-      chunks.add(chunkInfo);
-    }
-    return new ResultManifest()
-        .setTotalChunkCount(TOTAL_CHUNKS)
-        .setTotalRowCount(TOTAL_ROWS)
-        .setTotalByteCount(TOTAL_BYTES)
-        .setChunks(chunks)
-        .setSchema(new ResultSchema().setColumns(new ArrayList<>()));
-  }
-
-  private void setupMockResponse() throws Exception {
-    Schema schema = createTestSchema();
-    Object[][] testData = createTestData(schema, 20);
-    File arrowFile =
-        createTestArrowFile("TestFile", schema, testData, new RootAllocator(Integer.MAX_VALUE));
-
-    when(httpResponse.getEntity()).thenReturn(httpEntity);
-    when(httpEntity.getContent()).thenAnswer(invocation -> new FileInputStream(arrowFile));
-  }
-
-  private List<ExternalLink> getChunkLinks(long chunkIndex, boolean isLast) {
-    List<ExternalLink> chunkLinks = new ArrayList<>();
-    ExternalLink chunkLink =
-        new ExternalLink()
-            .setChunkIndex(chunkIndex)
-            .setExternalLink(CHUNK_URL_PREFIX + chunkIndex)
-            .setExpiration(Instant.now().plusSeconds(3600L).toString());
-    if (!isLast) {
-      chunkLink.setNextChunkIndex(chunkIndex + 1);
-    }
-    chunkLinks.add(chunkLink);
-    return chunkLinks;
-  }
-
-  private void assertChunkResult(ArrowResultChunk chunk, long chunkIndex) {
-    long expectedRows = chunkIndex < 4 ? 20L : 10L;
-    long expectedRowsOffSet = chunkIndex * 20L;
-    assertEquals(chunkIndex, chunk.getChunkIndex());
-    assertEquals(expectedRows, chunk.numRows);
-    assertEquals(expectedRowsOffSet, chunk.rowOffset);
-    assertEquals(CHUNK_URL_PREFIX + chunkIndex, chunk.getChunkUrl());
-
-    assertNotNull(chunk.getDownloadFinishTime());
-    assertEquals(ArrowResultChunk.ChunkStatus.DOWNLOAD_SUCCEEDED, chunk.getStatus());
-  }
-
-  private File createTestArrowFile(
-      String fileName, Schema schema, Object[][] testData, RootAllocator allocator)
-      throws IOException {
-    File file = new File(fileName);
-    int cols = testData.length;
-    int rows = testData[0].length;
-    VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
-    ArrowWriter writer =
-        new ArrowStreamWriter(
-            vectorSchemaRoot,
-            new DictionaryProvider.MapDictionaryProvider(),
-            new FileOutputStream(file));
-    writer.start();
-    for (int j = 0; j < rows; j += rowsInRecordBatch) {
-      int rowsToAddToRecordBatch = min(rowsInRecordBatch, rows - j);
-      vectorSchemaRoot.setRowCount(rowsToAddToRecordBatch);
-      for (int i = 0; i < cols; i++) {
-        Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-        FieldVector fieldVector = vectorSchemaRoot.getFieldVectors().get(i);
-        if (type.equals(Types.MinorType.INT)) {
-          IntVector intVector = (IntVector) fieldVector;
-          intVector.setInitialCapacity(rowsToAddToRecordBatch);
-          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
-            intVector.set(k, 1, (int) testData[i][j + k]);
-          }
-        } else if (type.equals(Types.MinorType.FLOAT8)) {
-          Float8Vector float8Vector = (Float8Vector) fieldVector;
-          float8Vector.setInitialCapacity(rowsToAddToRecordBatch);
-          for (int k = 0; k < rowsToAddToRecordBatch; k++) {
-            float8Vector.set(k, 1, (double) testData[i][j + k]);
-          }
-        }
-        fieldVector.setValueCount(rowsToAddToRecordBatch);
-      }
-      writer.writeBatch();
-    }
-    return file;
-  }
-
-  private Schema createTestSchema() {
-    List<Field> fieldList = new ArrayList<>();
-    FieldType fieldType1 = new FieldType(false, Types.MinorType.INT.getType(), null);
-    FieldType fieldType2 = new FieldType(false, Types.MinorType.FLOAT8.getType(), null);
-    fieldList.add(new Field("Field1", fieldType1, null));
-    fieldList.add(new Field("Field2", fieldType2, null));
-    return new Schema(fieldList);
-  }
-
-  private Object[][] createTestData(Schema schema, int rows) {
-    int cols = schema.getFields().size();
-    Object[][] data = new Object[cols][rows];
-    for (int i = 0; i < cols; i++) {
-      Types.MinorType type = Types.getMinorTypeForArrowType(schema.getFields().get(i).getType());
-      if (type.equals(Types.MinorType.INT)) {
-        for (int j = 0; j < rows; j++) {
-          data[i][j] = random.nextInt();
-        }
-      } else if (type.equals(Types.MinorType.FLOAT8)) {
-        for (int j = 0; j < rows; j++) {
-          data[i][j] = random.nextDouble();
-        }
-      }
-    }
-    return data;
   }
 }

--- a/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/driver/DatabricksConnectionContextTest.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.driver;
 
+import static com.databricks.jdbc.TestConstants.*;
 import static com.databricks.jdbc.driver.DatabricksConnectionContext.getLogLevel;
 import static com.databricks.jdbc.driver.DatabricksJdbcConstants.DEFAULT_CATALOG;
 import static com.databricks.jdbc.driver.DatabricksJdbcConstants.DEFAULT_SCHEMA;
@@ -18,85 +19,17 @@ import org.junit.jupiter.api.Test;
 
 class DatabricksConnectionContextTest {
 
-  private static final String VALID_URL_1 =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2";
-  private static final String VALID_URL_2 =
-      "jdbc:databricks://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;LogLevel=invalid;EnableQueryResultLZ4Compression=1;UseThriftClient=0";
-  private static final String VALID_URL_3 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=0;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;EnableQueryResultLZ4Compression=0;UseThriftClient=1;LogLevel=1234";
-  private static final String VALID_URL_4 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1;EnableDirectResults=1;";
-  private static final String VALID_URL_5 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473;ssl=0;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1;EnableDirectResults=0";
-
-  private static final String VALID_URL_6 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473/schemaName;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;ConnCatalog=catalogName;QueryResultCompressionType=1";
-
-  private static final String VALID_URL_7 =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
-
-  private static final String VALID_URL_8 =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;port=123;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
-
-  private static final String VALID_URL_WITH_INVALID_COMPRESSION_TYPE =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=234";
-
-  private static final String INVALID_URL_1 =
-      "jdbc:oracle://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
-  private static final String INVALID_URL_2 =
-      "http:databricks://azuredatabricks.net/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/fgff575757;";
-
-  private static final String INVALID_URL_3 =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;port=alphabetical;AuthMech=3;httpPath=/sql/1.0/endpoints/erg6767gg;LogLevel=debug;LogPath=test1/application.log;auth_flow=2;enablearrow=0";
-
-  private static final String VALID_TEST_URL = "jdbc:databricks://test";
-
-  private static final String VALID_CLUSTER_URL =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;httpPath=sql/protocolv1/o/6051921418418893/1115-130834-ms4m0yv;AuthMech=3;loglevel=3";
-  private static final String INVALID_CLUSTER_URL =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;httpPath=sql/protocolv1/oo/6051921418418893/1115-130834-ms4m0yv;AuthMech=3";
-  private static final String VALID_BASE_URL_1 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;";
-  private static final String VALID_BASE_URL_2 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default";
-  private static final String VALID_BASE_URL_3 =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443";
-  private static final String VALID_URL_WITH_PROXY =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;UseProxy=1;ProxyHost=127.0.0.1;ProxyPort=8080;ProxyAuth=1;ProxyUID=proxyUser;ProxyPwd=proxyPassword;";
-  private static final String VALID_URL_WITH_PROXY_AND_CF_PROXY =
-      "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:443/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;UseSystemProxy=1;UseProxy=1;ProxyHost=127.0.0.1;ProxyPort=8080;ProxyAuth=1;ProxyUID=proxyUser;ProxyPwd=proxyPassword;UseCFProxy=1;CFProxyHost=127.0.1.2;CFProxyPort=8081;CFProxyAuth=2;CFProxyUID=cfProxyUser;CFProxyPwd=cfProxyPassword;";
-
-  private static Properties properties = new Properties();
+  private static final Properties properties = new Properties();
 
   private static final String VALID_URL_POLLING =
       "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473;ssl=1;asyncexecpollinterval=500;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1";
 
-  private static Properties properties_with_pwd = new Properties();
+  private static final Properties properties_with_pwd = new Properties();
 
   @BeforeAll
   public static void setUp() {
     properties.setProperty("password", "passwd");
     properties_with_pwd.setProperty("pwd", "passwd2");
-  }
-
-  @Test
-  public void testIsValid() {
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_1));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_BASE_URL_1));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_BASE_URL_2));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_BASE_URL_3));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_TEST_URL));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_2));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_3));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_4));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_5));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_6));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_7));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_URL_WITH_INVALID_COMPRESSION_TYPE));
-    assertFalse(DatabricksConnectionContext.isValid(INVALID_URL_1));
-    assertFalse(DatabricksConnectionContext.isValid(INVALID_URL_2));
-    assertTrue(DatabricksConnectionContext.isValid(VALID_CLUSTER_URL));
-    assertFalse(DatabricksConnectionContext.isValid(INVALID_CLUSTER_URL));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/pooling/DatabricksPooledConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/pooling/DatabricksPooledConnectionTest.java
@@ -13,7 +13,7 @@ import com.databricks.jdbc.core.DatabricksSQLException;
 import com.databricks.jdbc.core.ImmutableSessionInfo;
 import com.databricks.jdbc.core.types.ComputeResource;
 import com.databricks.jdbc.core.types.Warehouse;
-import com.databricks.jdbc.driver.DatabricksConnectionContext;
+import com.databricks.jdbc.driver.DatabricksConnectionContextFactory;
 import com.databricks.jdbc.driver.IDatabricksConnectionContext;
 import java.sql.*;
 import java.util.ArrayList;
@@ -37,12 +37,12 @@ public class DatabricksPooledConnectionTest {
   private static final String WAREHOUSE_ID = "791ba2a31c7fd70a";
   private static final ComputeResource warehouse = new Warehouse(WAREHOUSE_ID);
   private static final String SESSION_ID = "session_id";
-  @Mock private static DatabricksSdkClient databricksClient;
   private static IDatabricksConnectionContext connectionContext;
+  @Mock private static DatabricksSdkClient databricksClient;
 
   @BeforeAll
   public static void setUp() throws DatabricksSQLException {
-    connectionContext = DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    connectionContext = DatabricksConnectionContextFactory.create(JDBC_URL, new Properties());
   }
 
   @Test
@@ -203,7 +203,8 @@ public class DatabricksPooledConnectionTest {
     assertTrue(statement.isClosed());
   }
 
-  class TestListener implements ConnectionEventListener {
+  static class TestListener implements ConnectionEventListener {
+
     List<ConnectionEvent> connectionClosedEvents = new ArrayList<>();
     List<ConnectionEvent> connectionErrorEvents = new ArrayList<>();
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
- `DatabricksConnectionContext` is made package-private. Client code should use the interface `IDatabricksConnectionContext`.
- `DatabricksConnectionContextFactory` is added to create instances of interface `IDatabricksConnectionContext`.
- Minor cosmetic changes in related source and test files as per discussed code formatting guidelines
  -  static members (among groups like variables, methods) should precede non-static members.
  -  public members (among groups like variables, methods) should precede protected/package-private/private members.

## Testing
Unit tests.