### PR TITLE
fix charOctetLength

### DIFF
--- a/src/test/java/com/databricks/jdbc/client/impl/helper/MetadataResultSetBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/client/impl/helper/MetadataResultSetBuilderTest.java
@@ -55,6 +55,27 @@ public class MetadataResultSetBuilderTest {
         Arguments.of("VARCHAR(abc)", 0));
   }
 
+  private static Stream<Arguments> stripTypeNameArguments() {
+    return Stream.of(
+        Arguments.of("VARCHAR(100)", "VARCHAR"),
+        Arguments.of("VARCHAR", "VARCHAR"),
+        Arguments.of("CHAR(255)", "CHAR"),
+        Arguments.of("TEXT", "TEXT"),
+        Arguments.of("VARCHAR(", "VARCHAR"),
+        Arguments.of("VARCHAR(100,200)", "VARCHAR"),
+        Arguments.of("CHAR(123)", "CHAR"),
+        Arguments.of(null, null),
+        Arguments.of("", ""),
+        Arguments.of("INTEGER(10,5)", "INTEGER"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("stripTypeNameArguments")
+  public void testStripTypeName(String input, String expected) {
+    String actual = MetadataResultSetBuilder.stripTypeName(input);
+    assertEquals(expected, actual);
+  }
+
   @ParameterizedTest
   @MethodSource("charOctetArguments")
   public void testGetCharOctetLength(String typeVal, int expected) {


### PR DESCRIPTION
## Description
- The following snippet was throwing an error  :`ResultSet columns = dbMetadata.getColumns("field_demos", "gopaldb", "%pkeyTab%", "%");`

```
java.lang.NumberFormatException: For input string: "100)"
  at java.lang.NumberFormatException.forInputString (NumberFormatException.java:67)
  at java.lang.Integer.parseInt (Integer.java:588)
  at java.lang.Integer.parseInt (Integer.java:685)
  at com.databricks.jdbc.client.impl.helper.MetadataResultSetBuilder.getRows (MetadataResultSetBuilder.java:116)
  at com.databricks.jdbc.client.impl.helper.MetadataResultSetBuilder.getColumnsRe
```
-  This PR fixes this.

## Testing
- added unit tests

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

