### PR TITLE
Increase the scope of slf4j-api to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,10 +416,6 @@
                   <pattern>org.osgi</pattern>
                   <shadedPattern>com.databricks.internal.osgi</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.slf4j</pattern>
-                  <shadedPattern>com.databricks.internal.slf4j</shadedPattern>
-                </relocation>
               </relocations>
               <filters>
                 <filter>


### PR DESCRIPTION
## Description
Earlier the scope was `provided` so that customers have complete freedom to choose slf4j and binding pair.
But since, databricks-sdk (driver dependency) uses slf4j, databricks-driver need to include it in compile time.

## Testing
Unit tests and verified that dependency is included and correctly shaded.

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

