### PR TITLE
Sunset username

### DIFF
--- a/src/main/java/com/databricks/client/jdbc/DataSource.java
+++ b/src/main/java/com/databricks/client/jdbc/DataSource.java
@@ -118,11 +118,12 @@ public class DataSource implements javax.sql.DataSource, ConnectionPoolDataSourc
   }
 
   public String getUsername() {
-    return properties.getProperty(DatabricksJdbcConstants.USER, properties.getProperty(UID));
+    LoggingUtil.log(LogLevel.WARN, USERNAME_ERROR);
+    return DEFAULT_USERNAME;
   }
 
   public void setUsername(String username) {
-    properties.put(DatabricksJdbcConstants.USER, username);
+    LoggingUtil.log(LogLevel.WARN, USERNAME_ERROR);
   }
 
   public String getPassword() {

--- a/src/main/java/com/databricks/jdbc/client/impl/common/ClientUtils.java
+++ b/src/main/java/com/databricks/jdbc/client/impl/common/ClientUtils.java
@@ -8,11 +8,7 @@ public class ClientUtils {
   public static DatabricksConfig generateDatabricksConfig(
       IDatabricksConnectionContext connectionContext) throws DatabricksParsingException {
     DatabricksConfig databricksConfig =
-        new DatabricksConfig()
-            .setHost(connectionContext.getHostUrl())
-            .setUsername(connectionContext.getUserName())
-            .setToken(connectionContext.getToken())
-            .setUseSystemPropertiesHttp(connectionContext.getUseSystemProxy());
+        new DatabricksConfig().setUseSystemPropertiesHttp(connectionContext.getUseSystemProxy());
     // Setup proxy settings
     if (connectionContext.getUseProxy()) {
       databricksConfig

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksConnectionContext.java
@@ -528,11 +528,6 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   }
 
   @Override
-  public String getUserName() {
-    return getParameter(USER_NAME, getParameter(UID));
-  }
-
-  @Override
   public Boolean shouldRetryRateLimitError() {
     return Objects.equals(getParameter(RATE_LIMIT_RETRY, "1"), "1");
   }

--- a/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/driver/DatabricksJdbcConstants.java
@@ -258,4 +258,8 @@ public final class DatabricksJdbcConstants {
 
   public static final int DEFAULT_RETRY_COUNT = 5;
   public static final LogLevel TELEMETRY_LOG_LEVEL = LogLevel.OFF;
+  public static final String DEFAULT_USERNAME =
+      "token"; // This is for PAT. We do not support Basic Auth.
+  public static final String USERNAME_ERROR =
+      "Username authentication is no longer supported.\n Please use OAuth or access token instead.\n See https://docs.databricks.com/en/integrations/jdbc/oss.html#authenticate-the-driver";
 }

--- a/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/driver/IDatabricksConnectionContext.java
@@ -152,6 +152,4 @@ public interface IDatabricksConnectionContext {
   boolean enableTelemetry();
 
   String getConnectionURL();
-
-  String getUserName();
 }


### PR DESCRIPTION
## Description
Currently, we don't honour username in our driver. In the next version, we'll be throwing a warning if the userName is set. And in eventual releases we'll throw an error.
See : https://docs.databricks.com/en/security/auth/password-deprecation.html

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

