### PR TITLE
TableType issue with Denodo/TPG Capital

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/MetadataResultConstants.java
+++ b/src/main/java/com/databricks/jdbc/common/MetadataResultConstants.java
@@ -37,7 +37,7 @@ public class MetadataResultConstants {
 
   public static final ResultColumn TABLE_NAME_COLUMN =
       new ResultColumn("TABLE_NAME", "tableName", Types.VARCHAR);
-  private static final ResultColumn TABLE_TYPE_COLUMN =
+  public static final ResultColumn TABLE_TYPE_COLUMN =
       new ResultColumn("TABLE_TYPE", "tableType", Types.VARCHAR);
   public static final ResultColumn REMARKS_COLUMN =
       new ResultColumn("REMARKS", "remarks", Types.VARCHAR);

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
@@ -131,6 +131,12 @@ public class MetadataResultSetBuilder {
                 object = null;
               }
             }
+
+            if (column.getColumnName().equals(TABLE_TYPE_COLUMN.getColumnName())
+                && (object == null || object.equals(""))) {
+              object = "TABLE";
+            }
+
             // Handle TYPE_NAME separately for potential modifications
             if (column.getColumnName().equals(TYPE_NAME_COLUMN.getColumnName())) {
               object = stripTypeName((String) object);

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
@@ -110,6 +110,29 @@ public class MetadataResultSetBuilderTest {
         Arguments.of("TEXT", 10, 255));
   }
 
+  private static Stream<Arguments> getRowsTableTypeColumnArguments() {
+    return Stream.of(
+        Arguments.of("TABLE", "TABLE"),
+        Arguments.of("VIEW", "VIEW"),
+        Arguments.of("SYSTEM TABLE", "SYSTEM TABLE"),
+        Arguments.of("", "TABLE"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getRowsTableTypeColumnArguments")
+  void testGetRowsHandlesTableTypeColumn(String tableTypeValue, String expectedTableType)
+      throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    Mockito.when(resultSet.next()).thenReturn(true).thenReturn(false);
+    Mockito.when(resultSet.getObject(TABLE_TYPE_COLUMN.getResultSetColumnName()))
+        .thenReturn(tableTypeValue);
+
+    List<List<Object>> rows = MetadataResultSetBuilder.getRows(resultSet, TABLE_COLUMNS);
+
+    assertEquals(expectedTableType, rows.get(0).get(3));
+    assertEquals(String.class, rows.get(0).get(3).getClass());
+  }
+
   private static Stream<Arguments> getRowsNullableColumnArguments() {
     return Stream.of(Arguments.of("true", 1), Arguments.of("false", 0), Arguments.of(null, 1));
   }


### PR DESCRIPTION
## Description
Customer comment : 
When invoking java.sql.DatabaseMetaData#getTables, the value of the attribute TABLE_TYPE is returned empty

Handled empty table type values, setting it to "TABLE" by default.


