### PR TITLE
Close the allocator after data is initialised

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
@@ -312,8 +312,8 @@ public class ArrowResultChunk {
     }
     if (isDataInitialized) {
       purgeArrowData(this.recordBatchList);
+      rootAllocator.close();
     }
-    rootAllocator.close();
     setStatus(ChunkStatus.CHUNK_RELEASED);
     return true;
   }

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -2,7 +2,7 @@
 .level=INFO
 
 # Set the logging level for the JDBC driver
-com.databricks.jdbc.level=INFO
+com.databricks.jdbc.level=FINE
 
 # Configure the console handler
 handlers=java.util.logging.ConsoleHandler


### PR DESCRIPTION
## Description
There might be cases when root allocator is in use by incomplete arrow data. Consider the below scenario:
- Data init fails for some chunk which causes 1. interrupts to chunks further ahead 2. release of all chunks
- As part of release, I was closing the allocator. But other threads might still be using allocator in uninitialised data

Note that we were not closing allocator in previous versions. So the issue didn't surface. But it's generally good to close it wherever possible.

## Testing
Integration tests.
Partially reproduced the error and fix seems to work.

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

