### PR TITLE
Fix flaky unit test!

### DIFF
--- a/src/test/java/com/databricks/jdbc/auth/JwtPrivateKeyClientCredentialsTest.java
+++ b/src/test/java/com/databricks/jdbc/auth/JwtPrivateKeyClientCredentialsTest.java
@@ -94,7 +94,8 @@ public class JwtPrivateKeyClientCredentialsTest {
   @Test
   void testFetchSignedJWTWithRSAKey() throws Exception {
     when(rsaPrivateKey.getAlgorithm()).thenReturn("RSA");
-    when(rsaPrivateKey.getModulus()).thenReturn(new BigInteger(2050, new SecureRandom()));
+    when(rsaPrivateKey.getModulus())
+        .thenReturn(new BigInteger(2048, new SecureRandom()).setBit(2047));
     when(rsaPrivateKey.getPrivateExponent()).thenReturn(new BigInteger(10, new SecureRandom()));
     SignedJWT signedJWT = clientCredentials.fetchSignedJWT(rsaPrivateKey);
     assertNotNull(signedJWT);


### PR DESCRIPTION
## Description
- We are testing RSA key sign that requires modulus to have 2048 bits. But while generating 2048 bits - not necessarily the MSB is set. This PR fixes that. 

## Testing
UT passes

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

