### PR TITLE
Increase chunk download retries

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/SingleChunkDownloader.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/SingleChunkDownloader.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable;
 class SingleChunkDownloader implements Callable<Void> {
 
   public static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(SingleChunkDownloader.class);
-  private static final int MAX_RETRIES = 5;
+  public static final int MAX_RETRIES = 5;
   private static final long RETRY_DELAY_MS = 1500; // 1.5 seconds
   private final ArrowResultChunk chunk;
   private final IDatabricksHttpClient httpClient;

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/SingleChunkDownloaderTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/SingleChunkDownloaderTest.java
@@ -62,7 +62,7 @@ public class SingleChunkDownloaderTest {
         .downloadData(httpClient);
 
     assertThrows(DatabricksSQLException.class, () -> singleChunkDownloader.call());
-    verify(chunk, times(3)).downloadData(httpClient);
+    verify(chunk, times(SingleChunkDownloader.MAX_RETRIES)).downloadData(httpClient);
     verify(chunkDownloader, times(1)).downloadProcessed(7L);
   }
 }


### PR DESCRIPTION
## Description
Increase chunk download retries to 5.

## Additional Notes to the Reviewer
The competitive driver retries 10 times. But it would not be sensible to do that straight away without much info. It would be great if this is merged before latest cut.

