### PR TITLE
[ES-1235956] Change thread pool size for getFutureResult

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.api.impl;
 
 import static com.databricks.jdbc.common.DatabricksJdbcConstants.*;
 import static com.databricks.jdbc.common.EnvironmentVariables.*;
+import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
 
 import com.databricks.jdbc.api.IDatabricksResultSet;
@@ -38,8 +39,6 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
   private boolean escapeProcessing = DEFAULT_ESCAPE_PROCESSING;
   private InputStreamEntity inputStream = null;
   private boolean allowInputStreamForUCVolume = false;
-
-  private final int DEFAULT_FORK_JOIN_POOL_SIZE = 64;
 
   public DatabricksStatement(DatabricksConnection connection) {
     this.connection = connection;
@@ -564,10 +563,7 @@ public class DatabricksStatement implements IDatabricksStatement, Statement {
 
   CompletableFuture<DatabricksResultSet> getFutureResult(
       String sql, Map<Integer, ImmutableSqlParameter> params, StatementType statementType) {
-    int poolSize = Runtime.getRuntime().availableProcessors() * 2;
-    if (poolSize == 0) {
-      poolSize = DEFAULT_FORK_JOIN_POOL_SIZE;
-    }
+    int poolSize = getRuntime().availableProcessors() * 2;
     ExecutorService executor = Executors.newFixedThreadPool(poolSize);
     return CompletableFuture.supplyAsync(
         () -> {


### PR DESCRIPTION
## Description
Some of the queries were waiting indefinitely during execution when running 3,296 queries across 32 streams. This occurred because the default thread pool size used by CompletableFuture.supplyAsync (ForkJoinPool.commonPool)  which we were using to send queries to SEA via the SdkClient was insufficient to handle the high concurrency, leading to thread pool saturation, which was causing queries never to be sent to SEA The default thread pool size is based on the number of available CPU cores, which was too small to support all the queries. With a large number of queries, the pool was saturated, causing some queries to wait indefinitely.I used a custom thread pool with a higher capacity by using Executors.newFixedThreadPool(). This allowedus to allocate enough threads to handle the concurrent execution of queries without blocking.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

