### PR TITLE
Add logging for logging

### DIFF
--- a/src/main/java/com/databricks/client/jdbc/Driver.java
+++ b/src/main/java/com/databricks/client/jdbc/Driver.java
@@ -63,6 +63,7 @@ public class Driver implements java.sql.Driver {
           connectionContext.getLogFileCount(),
           connectionContext.getLogLevel());
     } catch (IOException e) {
+      LOGGER.error("Error initializing the Java Util Logger (JUL).", e);
       throw new DatabricksSQLException("Error initializing the Java Util Logger (JUL).", e);
     }
     setUserAgent(connectionContext);

--- a/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
@@ -18,6 +18,7 @@ public class LoggingUtil {
       throws IOException {
     if (LOGGER instanceof JulLogger && System.getProperty(JAVA_UTIL_LOGGING_CONFIG_FILE) == null) {
       // Only configure JUL logger if it's not already configured via external properties file
+      LOGGER.info("Setting up JUL logger");
       JulLogger.initLogger(toJulLevel(level), logDir, logFileSizeMB * 1024 * 1024, logFileCount);
     }
   }

--- a/src/main/java/com/databricks/jdbc/log/JulLogger.java
+++ b/src/main/java/com/databricks/jdbc/log/JulLogger.java
@@ -23,6 +23,8 @@ import java.util.stream.Stream;
  */
 public class JulLogger implements JdbcLogger {
 
+  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(JulLogger.class);
+
   public static final String STDOUT = "STDOUT";
 
   public static final String PARENT_CLASS_PREFIX = "com.databricks.jdbc";
@@ -161,9 +163,12 @@ public class JulLogger implements JdbcLogger {
     Path dirPath = Paths.get(logDir);
     if (Files.notExists(dirPath)) {
       try {
+        LOGGER.info("Creating log directory for JUL logging: " + dirPath);
         Files.createDirectories(dirPath);
       } catch (IOException e) {
         // If the directory cannot be created, log to the console instead
+        LOGGER.info(
+            "Error creating log directory " + dirPath + " for JUL logging." + e.getMessage());
         return STDOUT;
       }
     }


### PR DESCRIPTION
## Description
In unlikely scenarios when JUL setup fails, these are precautionary logs in the hope that the customer application captures it on console or application logs.

