### PR TITLE
Remove redundanat CommandName in getThriftResponse

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
@@ -8,7 +8,6 @@ import com.databricks.jdbc.api.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.IDatabricksSession;
 import com.databricks.jdbc.api.IDatabricksStatement;
 import com.databricks.jdbc.api.impl.*;
-import com.databricks.jdbc.common.CommandName;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
@@ -88,8 +87,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
       openSessionReq.setInitialNamespace(getNamespace(catalog, schema));
     }
     TOpenSessionResp response =
-        (TOpenSessionResp)
-            thriftAccessor.getThriftResponse(openSessionReq, CommandName.OPEN_SESSION, null);
+        (TOpenSessionResp) thriftAccessor.getThriftResponse(openSessionReq, null);
     verifySuccessStatus(response.status.getStatusCode(), response.toString());
 
     TProtocolVersion serverProtocol = response.getServerProtocolVersion();
@@ -117,8 +115,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
     TCloseSessionReq closeSessionReq =
         new TCloseSessionReq().setSessionHandle(session.getSessionInfo().sessionHandle());
     TCloseSessionResp response =
-        (TCloseSessionResp)
-            thriftAccessor.getThriftResponse(closeSessionReq, CommandName.CLOSE_SESSION, null);
+        (TCloseSessionResp) thriftAccessor.getThriftResponse(closeSessionReq, null);
     verifySuccessStatus(response.status.getStatusCode(), response.toString());
   }
 
@@ -201,8 +198,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
     TGetTypeInfoReq request =
         new TGetTypeInfoReq().setSessionHandle(session.getSessionInfo().sessionHandle());
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_TYPE_INFO, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getTypeInfoResult(extractValues(response.getResults().getColumns()));
   }
 
@@ -215,8 +211,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
     TGetCatalogsReq request =
         new TGetCatalogsReq().setSessionHandle(session.getSessionInfo().sessionHandle());
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_CATALOGS, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getCatalogsResult(extractValuesColumnar(response.getResults().getColumns()));
   }
 
@@ -236,8 +231,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
       request.setSchemaName(schemaNamePattern);
     }
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_SCHEMAS, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getSchemasResult(extractValuesColumnar(response.getResults().getColumns()));
   }
 
@@ -264,8 +258,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
       request.setTableTypes(Arrays.asList(tableTypes));
     }
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_TABLES, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getTablesResult(catalog, extractValuesColumnar(response.getResults().getColumns()));
   }
 
@@ -299,8 +292,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
             .setTableName(tableNamePattern)
             .setColumnName(columnNamePattern);
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_COLUMNS, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getColumnsResult(extractValuesColumnar(response.getResults().getColumns()));
   }
 
@@ -323,8 +315,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
             .setSchemaName(schemaNamePattern)
             .setFunctionName(functionNamePattern);
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_FUNCTIONS, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getFunctionsResult(extractValuesColumnar(response.getResults().getColumns()));
   }
 
@@ -343,8 +334,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
             .setSchemaName(schema)
             .setTableName(table);
     TFetchResultsResp response =
-        (TFetchResultsResp)
-            thriftAccessor.getThriftResponse(request, CommandName.LIST_PRIMARY_KEYS, null);
+        (TFetchResultsResp) thriftAccessor.getThriftResponse(request, null);
     return getPrimaryKeysResult(extractValues(response.getResults().getColumns()));
   }
 }

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessorTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessorTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.*;
 import com.databricks.jdbc.api.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.IDatabricksStatement;
 import com.databricks.jdbc.api.impl.DatabricksResultSet;
-import com.databricks.jdbc.common.CommandName;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.exception.DatabricksHttpException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
@@ -85,7 +84,7 @@ public class DatabricksThriftAccessorTest {
     TOpenSessionReq request = new TOpenSessionReq();
     TOpenSessionResp response = new TOpenSessionResp();
     when(thriftClient.OpenSession(request)).thenReturn(response);
-    assertEquals(accessor.getThriftResponse(request, CommandName.OPEN_SESSION, null), response);
+    assertEquals(accessor.getThriftResponse(request, null), response);
   }
 
   @Test
@@ -94,7 +93,7 @@ public class DatabricksThriftAccessorTest {
     TCloseSessionReq request = new TCloseSessionReq();
     TCloseSessionResp response = new TCloseSessionResp();
     when(thriftClient.CloseSession(request)).thenReturn(response);
-    assertEquals(accessor.getThriftResponse(request, CommandName.CLOSE_SESSION, null), response);
+    assertEquals(accessor.getThriftResponse(request, null), response);
   }
 
   @Test
@@ -207,8 +206,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetPrimaryKeys(request)).thenReturn(tGetPrimaryKeysResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp)
-            accessor.getThriftResponse(request, CommandName.LIST_PRIMARY_KEYS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -223,8 +221,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetPrimaryKeys(request)).thenReturn(tGetPrimaryKeysResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp)
-            accessor.getThriftResponse(request, CommandName.LIST_PRIMARY_KEYS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -239,7 +236,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetFunctions(request)).thenReturn(tGetFunctionsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_FUNCTIONS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -254,7 +251,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetFunctions(request)).thenReturn(tGetFunctionsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_FUNCTIONS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -269,7 +266,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetSchemas(request)).thenReturn(tGetSchemasResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_SCHEMAS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -284,7 +281,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetSchemas(request)).thenReturn(tGetSchemasResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_SCHEMAS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -299,7 +296,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetColumns(request)).thenReturn(tGetColumnsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_COLUMNS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -314,7 +311,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetColumns(request)).thenReturn(tGetColumnsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_COLUMNS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -329,7 +326,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetCatalogs(request)).thenReturn(tGetCatalogsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_CATALOGS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -344,7 +341,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetCatalogs(request)).thenReturn(tGetCatalogsResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_CATALOGS, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -359,7 +356,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetTables(request)).thenReturn(tGetTablesResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TABLES, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -374,7 +371,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetTables(request)).thenReturn(tGetTablesResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TABLES, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -389,7 +386,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetTableTypes(request)).thenReturn(tGetTableTypesResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TABLE_TYPES, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -404,7 +401,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetTableTypes(request)).thenReturn(tGetTableTypesResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TABLE_TYPES, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -419,7 +416,7 @@ public class DatabricksThriftAccessorTest {
     when(thriftClient.FetchResults(fetchResultsReq)).thenReturn(response);
     when(thriftClient.GetTypeInfo(request)).thenReturn(tGetTypeInfoResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TYPE_INFO, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -434,7 +431,7 @@ public class DatabricksThriftAccessorTest {
             .setDirectResults(directResults);
     when(thriftClient.GetTypeInfo(request)).thenReturn(tGetTypeInfoResp);
     TFetchResultsResp actualResponse =
-        (TFetchResultsResp) accessor.getThriftResponse(request, CommandName.LIST_TYPE_INFO, null);
+        (TFetchResultsResp) accessor.getThriftResponse(request, null);
     assertEquals(actualResponse, response);
   }
 
@@ -448,9 +445,7 @@ public class DatabricksThriftAccessorTest {
             .setStatus(new TStatus().setStatusCode(TStatusCode.SUCCESS_STATUS));
     when(thriftClient.GetTables(request)).thenReturn(tGetTablesResp);
     when(thriftClient.FetchResults(fetchResultsReq)).thenThrow(new TException());
-    assertThrows(
-        DatabricksSQLException.class,
-        () -> accessor.getThriftResponse(request, CommandName.LIST_TABLES, null));
+    assertThrows(DatabricksSQLException.class, () -> accessor.getThriftResponse(request, null));
   }
 
   @Test
@@ -458,9 +453,7 @@ public class DatabricksThriftAccessorTest {
     setup(true);
     TGetTablesReq request = new TGetTablesReq();
     when(thriftClient.GetTables(request)).thenThrow(new TException());
-    assertThrows(
-        DatabricksSQLException.class,
-        () -> accessor.getThriftResponse(request, CommandName.LIST_TABLES, null));
+    assertThrows(DatabricksSQLException.class, () -> accessor.getThriftResponse(request, null));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import com.databricks.jdbc.api.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.IDatabricksSession;
 import com.databricks.jdbc.api.impl.*;
-import com.databricks.jdbc.common.CommandName;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksSQLFeatureNotImplementedException;
@@ -53,8 +52,7 @@ public class DatabricksThriftServiceClientTest {
             .setSessionHandle(SESSION_HANDLE)
             .setServerProtocolVersion(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9)
             .setStatus(new TStatus().setStatusCode(TStatusCode.SUCCESS_STATUS));
-    when(thriftAccessor.getThriftResponse(openSessionReq, CommandName.OPEN_SESSION, null))
-        .thenReturn(openSessionResp);
+    when(thriftAccessor.getThriftResponse(openSessionReq, null)).thenReturn(openSessionResp);
     ImmutableSessionInfo actualResponse =
         client.createSession(CLUSTER_COMPUTE, CATALOG, SCHEMA, EMPTY_MAP);
     assertEquals(actualResponse.sessionHandle(), SESSION_HANDLE);
@@ -68,8 +66,7 @@ public class DatabricksThriftServiceClientTest {
     TCloseSessionReq closeSessionReq = new TCloseSessionReq().setSessionHandle(SESSION_HANDLE);
     TCloseSessionResp closeSessionResp =
         new TCloseSessionResp().setStatus(new TStatus().setStatusCode(TStatusCode.SUCCESS_STATUS));
-    when(thriftAccessor.getThriftResponse(closeSessionReq, CommandName.CLOSE_SESSION, null))
-        .thenReturn(closeSessionResp);
+    when(thriftAccessor.getThriftResponse(closeSessionReq, null)).thenReturn(closeSessionResp);
     assertDoesNotThrow(() -> client.deleteSession(session, CLUSTER_COMPUTE));
   }
 
@@ -116,8 +113,7 @@ public class DatabricksThriftServiceClientTest {
     TColumn tColumn = new TColumn();
     tColumn.setStringVal(new TStringColumn().setValues(Collections.singletonList(TEST_CATALOG)));
     when(resultData.getColumns()).thenReturn(Collections.singletonList(tColumn));
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_CATALOGS, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet = client.listCatalogs(session);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
   }
@@ -179,8 +175,7 @@ public class DatabricksThriftServiceClientTest {
             .setResults(resultData)
             .setResultSetMetadata(resultMetadataData);
     when(resultData.getColumns()).thenReturn(Collections.emptyList());
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_TYPE_INFO, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet = client.listTypeInfo(session);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
   }
@@ -201,8 +196,7 @@ public class DatabricksThriftServiceClientTest {
             .setResults(resultData)
             .setResultSetMetadata(resultMetadataData);
     when(resultData.getColumns()).thenReturn(Collections.emptyList());
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_SCHEMAS, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet = client.listSchemas(session, TEST_CATALOG, TEST_SCHEMA);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
   }
@@ -228,8 +222,7 @@ public class DatabricksThriftServiceClientTest {
     TColumn tColumn = new TColumn();
     tColumn.setStringVal(new TStringColumn().setValues(Collections.singletonList("")));
     when(resultData.getColumns()).thenReturn(List.of(tColumn, tColumn, tColumn, tColumn));
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_TABLES, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet =
         client.listTables(session, TEST_CATALOG, TEST_SCHEMA, TEST_TABLE, tableTypes);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
@@ -253,8 +246,7 @@ public class DatabricksThriftServiceClientTest {
             .setResults(resultData)
             .setResultSetMetadata(resultMetadataData);
     when(resultData.getColumns()).thenReturn(new ArrayList<>());
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_COLUMNS, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet =
         client.listColumns(session, TEST_CATALOG, TEST_SCHEMA, TEST_TABLE, TEST_STRING);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
@@ -277,8 +269,7 @@ public class DatabricksThriftServiceClientTest {
             .setResults(resultData)
             .setResultSetMetadata(resultMetadataData);
     when(resultData.getColumns()).thenReturn(null);
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_FUNCTIONS, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet =
         client.listFunctions(session, TEST_CATALOG, TEST_SCHEMA, TEST_STRING);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
@@ -301,8 +292,7 @@ public class DatabricksThriftServiceClientTest {
             .setResults(resultData)
             .setResultSetMetadata(resultMetadataData);
     when(resultData.getColumns()).thenReturn(null);
-    when(thriftAccessor.getThriftResponse(request, CommandName.LIST_PRIMARY_KEYS, null))
-        .thenReturn(response);
+    when(thriftAccessor.getThriftResponse(request, null)).thenReturn(response);
     DatabricksResultSet resultSet =
         client.listPrimaryKeys(session, TEST_CATALOG, TEST_SCHEMA, TEST_TABLE);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);


### PR DESCRIPTION
## Description
`commandName` is redundant for getThriftResponse() and it is prone to human error.

Now the code detects request type automatically.

## Testing
mvn clean package

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

