### PR TITLE
Column Builder default values mismatch

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -35,7 +35,6 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
   private final ImmutableMap<String, Integer> columnNameIndex;
   private final long totalRows;
   private Long chunkCount;
-  private static final String DEFAULT_CATALOGUE_NAME = "Spark";
 
   public DatabricksResultSetMetaData(String statementId, ResultManifest resultManifest) {
     this.statementId = statementId;
@@ -376,13 +375,13 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
   private ImmutableDatabricksColumn.Builder getColumnBuilder() {
     return ImmutableDatabricksColumn.builder()
         .isAutoIncrement(false)
-        .isSearchable(true)
+        .isSearchable(false)
         .nullable(Nullable.NULLABLE)
         .accessType(AccessType.READ_ONLY)
         .isDefinitelyWritable(false)
-        .schemaName(null)
-        .tableName(null)
-        .catalogName(DEFAULT_CATALOGUE_NAME)
+        .schemaName("")
+        .tableName("")
+        .catalogName("")
         .isCurrency(false)
         .typeScale(0)
         .isCaseSensitive(false);

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.api.impl;
 
 import static com.databricks.jdbc.common.util.DatabricksThriftUtil.getTypeFromTypeDesc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import com.databricks.jdbc.common.util.DatabricksTypeUtil;
@@ -10,6 +11,7 @@ import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.sdk.service.sql.ColumnInfo;
 import com.databricks.sdk.service.sql.ColumnInfoTypeName;
 import com.databricks.sdk.service.sql.ResultSchema;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -150,6 +152,48 @@ public class DatabricksResultSetMetaDataTest {
             stringColumnInfo, DatabricksTypeUtil.getColumnType(stringColumnInfo.getTypeName()));
     assertEquals(255, scaleAndPrecision[0]);
     assertEquals(0, scaleAndPrecision[1]);
+  }
+
+  public void verifyDefaultMetadataProperties(DatabricksResultSetMetaData metaData)
+      throws SQLException {
+    for (int i = 1; i <= metaData.getColumnCount(); i++) {
+      // verify metadata properties default value
+      assertFalse(metaData.isAutoIncrement(i));
+      assertFalse(metaData.isSearchable(i));
+      assertEquals(ResultSetMetaData.columnNullable, metaData.isNullable(i));
+      assertFalse(metaData.isDefinitelyWritable(i));
+      assertEquals("", metaData.getSchemaName(i));
+      assertEquals("", metaData.getTableName(i));
+      assertEquals("", metaData.getCatalogName(i));
+      assertFalse(metaData.isCurrency(i));
+      assertEquals(0, metaData.getScale(i));
+      assertFalse(metaData.isCaseSensitive(i));
+    }
+  }
+
+  @Test
+  public void testColumnBuilderDefaultMetadata() throws SQLException {
+    ResultManifest resultManifest = getResultManifest();
+    DatabricksResultSetMetaData metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest);
+    assertEquals(4, metaData.getColumnCount());
+    verifyDefaultMetadataProperties(metaData);
+
+    metaData =
+        new DatabricksResultSetMetaData(
+            STATEMENT_ID,
+            List.of("col1", "col2", "col2"),
+            List.of("int", "string", "double"),
+            List.of(4, 12, 8),
+            List.of(0, 0, 0),
+            10);
+    assertEquals(3, metaData.getColumnCount());
+    verifyDefaultMetadataProperties(metaData);
+
+    TGetResultSetMetadataResp thriftResultManifest = getThriftResultManifest();
+    metaData = new DatabricksResultSetMetaData(STATEMENT_ID, thriftResultManifest, 1, 1);
+    assertEquals(1, metaData.getColumnCount());
+    verifyDefaultMetadataProperties(metaData);
   }
 
   @Test


### PR DESCRIPTION
## Description
In metadata queries result set columns, competitive driver sets properties like schemaName, tableName, catalogName as empty string. These properties are null in server metadata. 
To fix this, default values in column builder is changed.
NOTE: VARCHAR vs STRING column type name mismatch is fixed in [PR](https://github.com/databricks/databricks-jdbc/pull/491)

## Testing
- Ran all 8 metadata calls on databricks-jdbc-comparator and no difference was reported for aforementioned properties.
- Added unit test for DatabricksResultSetMetadata to verify default properties are picked up when server result manifest have null properties.

