### PR TITLE
Schema column in getSchemas metadata call is not nullable

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/MetadataResultConstants.java
+++ b/src/main/java/com/databricks/jdbc/common/MetadataResultConstants.java
@@ -212,7 +212,7 @@ public class MetadataResultConstants {
               List.of(
                   MetadataResultConstants.TABLE_NAME_COLUMN,
                   MetadataResultConstants.COLUMN_NAME_COLUMN),
-          CommandName.LIST_SCHEMAS, List.of(MetadataResultConstants.SCHEMA_COLUMN),
+          CommandName.LIST_SCHEMAS, List.of(MetadataResultConstants.SCHEMA_COLUMN_FOR_GET_SCHEMA),
           CommandName.LIST_TABLE_TYPES, List.of(MetadataResultConstants.TABLE_TYPE_COLUMN),
           CommandName.LIST_COLUMNS,
               List.of(


### PR DESCRIPTION
## Description
Schema column in getSchemas metadata call is not nullable. Incorrect column was being used in metadata constants.
