### PR TITLE
[PECO-1922] Implement close and cancel in thrift accessor

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
@@ -25,6 +25,11 @@ public class DatabricksThriftUtil {
     return new TNamespace().setCatalogName(catalog).setSchemaName(schema);
   }
 
+  public static TOperationHandle getOperationHandle(String statementId) {
+    THandleIdentifier handleIdentifier = new THandleIdentifier().setGuid(statementId.getBytes());
+    return new TOperationHandle().setOperationId(handleIdentifier).setHasResultSet(false);
+  }
+
   public static String byteBufferToString(ByteBuffer buffer) {
     ByteBuffer newBuffer = buffer.duplicate(); // This is to avoid a BufferUnderflowException
     long sigBits = newBuffer.getLong();

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
@@ -97,6 +97,10 @@ final class DatabricksThriftAccessor {
         return getTableTypes((TGetTableTypesReq) request);
       } else if (request instanceof TGetTypeInfoReq) {
         return getTypeInfo((TGetTypeInfoReq) request);
+      } else if (request instanceof TCloseOperationReq) {
+        return getThriftClient().CloseOperation((TCloseOperationReq) request);
+      } else if (request instanceof TCancelOperationReq) {
+        return getThriftClient().CancelOperation((TCancelOperationReq) request);
       } else {
         String errorMessage =
             String.format(


### PR DESCRIPTION
## Description
- The memory was not released in JdbcRegressionTestSuite thrift mode : because there was no call to server. This PR fixes it. 

## Testing
- Unit tests

