### PR TITLE
Make UBER jar as the default jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,13 @@
   </dependencies>
 
   <build>
+    <!-- The build process produces the following artifacts in the target directory:
+       - Shaded uber JAR (default): ${project.artifactId}-${project.version}.jar
+       - Thin JAR without dependencies: ${project.artifactId}-${project.version}-thin.jar
+       - Test JAR containing test classes: ${project.artifactId}-${project.version}-tests.jar
+       - Sources JAR (when 'release' profile is active): ${project.artifactId}-${project.version}-sources.jar
+       - Javadoc JAR (when 'release' profile is active): ${project.artifactId}-${project.version}-javadoc.jar
+    -->
     <finalName>${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
@@ -381,6 +388,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <!-- The shaded uber jar is the default jar produced by this build -->
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <relocations>


### PR DESCRIPTION
## Description
🚨 BEHAVIOR/BREAKING CHANGE (Release Note Required)
Make UBER jar as the default jar

The build process produces the following artifacts in the target directory:
 - Shaded uber JAR (default): ${project.artifactId}-${project.version}.jar
 - Thin JAR without dependencies: ${project.artifactId}-${project.version}-thin.jar
 - Test JAR containing test classes: ${project.artifactId}-${project.version}-tests.jar
 - Sources JAR (when 'release' profile is active): ${project.artifactId}-${project.version}-sources.jar
 - Javadoc JAR (when 'release' profile is active): ${project.artifactId}-${project.version}-javadoc.jar

