### PR TITLE
Add ChunkProvider interface and unify chunk management

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
@@ -9,16 +9,16 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 
 /** Task class to manage download for a single chunk. */
-class SingleChunkDownloader implements Callable<Void> {
+class ChunkDownloadTask implements Callable<Void> {
 
-  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(SingleChunkDownloader.class);
+  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ChunkDownloadTask.class);
   public static final int MAX_RETRIES = 5;
   private static final long RETRY_DELAY_MS = 1500; // 1.5 seconds
   private final ArrowResultChunk chunk;
   private final IDatabricksHttpClient httpClient;
   private final ChunkDownloadCallback chunkDownloader;
 
-  SingleChunkDownloader(
+  ChunkDownloadTask(
       ArrowResultChunk chunk,
       IDatabricksHttpClient httpClient,
       ChunkDownloadCallback chunkDownloader) {

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkProvider.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkProvider.java
@@ -1,0 +1,40 @@
+package com.databricks.jdbc.api.impl.arrow;
+
+import com.databricks.jdbc.exception.DatabricksSQLException;
+
+/**
+ * Implementations of this interface manage the retrieval and iteration over {@link
+ * ArrowResultChunk}s.
+ */
+public interface ChunkProvider {
+
+  /**
+   * Checks if there are more chunks available to iterate over.
+   *
+   * @return {@code true} if there are additional chunks to be retrieved; {@code false} otherwise.
+   */
+  boolean hasNextChunk();
+
+  /**
+   * Advances to the next available chunk. This method should be called before calling {@link
+   * #getChunk()} to retrieve the data from the next chunk.
+   *
+   * @return {@code true} if the next chunk was successfully moved to; {@code false} if there are no
+   *     more chunks.
+   */
+  boolean next();
+
+  /**
+   * Retrieves the current chunk of data after a successful call to {@link #next()}.
+   *
+   * @return The current {@link ArrowResultChunk} containing the data.
+   * @throws DatabricksSQLException if an error occurs while fetching the chunk.
+   */
+  ArrowResultChunk getChunk() throws DatabricksSQLException;
+
+  /**
+   * Closes the chunk provider and releases any resources associated with it. After calling this
+   * method, the chunk provider should not be used again.
+   */
+  void close();
+}

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/InlineChunkProviderTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/InlineChunkProviderTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class ChunkExtractorTest {
+public class InlineChunkProviderTest {
   @Mock TGetResultSetMetadataResp metadata;
 
   @Test
@@ -24,20 +24,21 @@ public class ChunkExtractorTest {
         new TSparkArrowBatch().setRowCount(0).setBatch(new byte[] {65, 66, 67});
     when(metadata.getArrowSchema()).thenReturn(null);
     when(metadata.getSchema()).thenReturn(TEST_TABLE_SCHEMA);
-    ChunkExtractor chunkExtractor =
-        new ChunkExtractor(Collections.singletonList(arrowBatch), metadata, TEST_STATEMENT_ID);
-    assertTrue(chunkExtractor.hasNext());
-    assertNotNull(chunkExtractor.next());
-    assertNull(chunkExtractor.next());
+    InlineChunkProvider inlineChunkProvider =
+        new InlineChunkProvider(Collections.singletonList(arrowBatch), metadata, TEST_STATEMENT_ID);
+    assertTrue(inlineChunkProvider.hasNextChunk());
+    assertTrue(inlineChunkProvider.next());
+    assertFalse(inlineChunkProvider.next());
   }
 
   @Test
   void handleErrorTest() throws DatabricksParsingException {
     TSparkArrowBatch arrowBatch =
         new TSparkArrowBatch().setRowCount(0).setBatch(new byte[] {65, 66, 67});
-    ChunkExtractor chunkExtractor =
-        new ChunkExtractor(Collections.singletonList(arrowBatch), metadata, TEST_STATEMENT_ID);
+    InlineChunkProvider inlineChunkProvider =
+        new InlineChunkProvider(Collections.singletonList(arrowBatch), metadata, TEST_STATEMENT_ID);
     assertThrows(
-        DatabricksParsingException.class, () -> chunkExtractor.handleError(new RuntimeException()));
+        DatabricksParsingException.class,
+        () -> inlineChunkProvider.handleError(new RuntimeException()));
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/RemoteChunkProviderTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/RemoteChunkProviderTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class ChunkDownloaderTest {
+public class RemoteChunkProviderTest {
   private static final String STATEMENT_ID = "statement_id";
 
   @Test
@@ -22,6 +22,6 @@ public class ChunkDownloaderTest {
             .setSchema(new ResultSchema().setColumns(new ArrayList<>()));
     ResultData resultData = new ResultData().setExternalLinks(new ArrayList<>());
     assertDoesNotThrow(
-        () -> new ChunkDownloader(STATEMENT_ID, resultManifest, resultData, null, null, 4));
+        () -> new RemoteChunkProvider(STATEMENT_ID, resultManifest, resultData, null, null, 4));
   }
 }


### PR DESCRIPTION
## Description
This is coming from https://github.com/databricks/databricks-jdbc/issues/542

- Added a new ChunkProvider interface to abstract chunk retrieval methods:
  - boolean hasNextChunk();
  - boolean next();
  - ArrowResultChunk getChunk() throws DatabricksSQLException;
  - void close();
- Implemented ChunkProvider in both ChunkDownloader and ChunkExtractor.
- Updated ArrowStreamResult to use ChunkProvider for chunk management.

## Testing
- Unit Tests
- FakeService Integration Tests

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

