### PR TITLE
Deploy reduced pom during release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ TestFile
 logs/
 *.log
 *.pem
+dependency-reduced-pom.xml

--- a/bin/version_updater.py
+++ b/bin/version_updater.py
@@ -115,6 +115,7 @@ def main():
 
     driver_util_file_path = "../src/main/java/com/databricks/jdbc/common/util/DriverUtil.java"
     pom_file_path = "../pom.xml"
+    reduced_pom_file_path = "../uber-minimal-pom.xml"
     connection_test_file_path = "../src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java"
     database_metadata_test_file_path = ("../src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest"
                                         ".java")
@@ -126,6 +127,9 @@ def main():
 
         _update_pom_xml(pom_file_path, version)
         print(f"Updated version in {pom_file_path}")
+
+        _update_pom_xml(reduced_pom_file_path, version)
+        print(f"Updated version in {reduced_pom_file_path}")
 
         _update_assertions_test_file(connection_test_file_path, version)
         print("Updated version in {}".format(connection_test_file_path))

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
     </developer>
   </developers>
   <scm>
-      <connection>scm:git:https://github.com/databricks/databricks-jdbc.git</connection>
-      <developerConnection>scm:git:https://github.com/databricks/databricks-jdbc.git</developerConnection>
-      <url>https://github.com/databricks/databricks-jdbc</url>
+    <connection>scm:git:https://github.com/databricks/databricks-jdbc.git</connection>
+    <developerConnection>scm:git:https://github.com/databricks/databricks-jdbc.git</developerConnection>
+    <url>https://github.com/databricks/databricks-jdbc</url>
   </scm>
   <issueManagement>
     <system>GitHub Issues</system>
@@ -35,8 +35,8 @@
   </issueManagement>
   <distributionManagement>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>local-test-repo</id>
+      <url>file://${project.build.directory}/local-repo</url>
     </repository>
   </distributionManagement>
   <properties>
@@ -389,7 +389,6 @@
             </goals>
             <configuration>
               <!-- The shaded uber jar is the default jar produced by this build -->
-              <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <relocations>
                 <relocation>
@@ -490,6 +489,51 @@
   </build>
   <profiles>
     <profile>
+      <!-- Local deploy for testing -->
+      <id>local-deploy</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
+            <executions>
+              <!-- Skip the default deploy execution -->
+              <execution>
+                <id>skip-default-deploy</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+              <!-- Use deploy-file goal to deploy with custom POM -->
+              <execution>
+                <id>deploy-with-custom-pom</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                  <pomFile>${project.basedir}/uber-minimal-pom.xml</pomFile>
+                  <!-- Include other artifacts like sources and javadocs -->
+                  <files>${project.build.directory}/${project.build.finalName}-thin.jar</files>
+                  <types>jar</types>
+                  <classifiers>thin</classifiers>
+                  <!-- Use repository details from distributionManagement -->
+                  <repositoryId>local-test-repo</repositoryId>
+                  <url>file://${project.build.directory}/local-repo</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -527,22 +571,40 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-            <configuration>
-              <!-- Prevent gpg from using pinentry programs -->
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
             <executions>
               <execution>
-                <id>sign-artifacts</id>
                 <goals>
-                  <goal>sign</goal>
+                  <!-- Refer: https://maven.apache.org/plugins/maven-gpg-plugin/sign-and-deploy-file-mojo.html -->
+                  <goal>sign-and-deploy-file</goal>
                 </goals>
-                <phase>verify</phase>
+                <phase>deploy</phase>
+                <configuration>
+                  <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                  <repositoryId>ossrh</repositoryId>
+                  <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                  <!-- Prevent gpg from using pinentry programs -->
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <!-- Custom reduced pom file for fat jar -->
+                  <pomFile>${project.basedir}/uber-minimal-pom.xml</pomFile>
+                  <sources>${project.build.directory}/${project.build.finalName}-sources.jar</sources>
+                  <javadoc>${project.build.directory}/${project.build.finalName}-javadoc.jar</javadoc>
+                  <files>${project.build.directory}/${project.build.finalName}-thin.jar</files>
+                  <types>jar</types>
+                  <classifiers>thin</classifiers>
+                </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
@@ -557,6 +619,12 @@
           </plugin>
         </plugins>
       </build>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
     </profile>
   </profiles>
 </project>

--- a/uber-minimal-pom.xml
+++ b/uber-minimal-pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.databricks</groupId>
+  <artifactId>databricks-jdbc</artifactId>
+  <!-- This value may be modified by a release script to reflect the current version of the driver. -->
+  <version>0.9.6-oss</version>
+  <packaging>jar</packaging>
+  <name>Databricks JDBC Driver</name>
+  <description>Databricks JDBC Driver.</description>
+  <url>https://github.com/databricks/databricks-jdbc</url>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://github.com/databricks/databricks-jdbc/blob/main/LICENSE</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Databricks JDBC Team</name>
+      <email>eng-oss-sql-driver@databricks.com</email>
+      <organization>Databricks</organization>
+      <organizationUrl>https://www.databricks.com</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/databricks/databricks-jdbc.git</connection>
+    <developerConnection>scm:git:https://github.com/databricks/databricks-jdbc.git</developerConnection>
+    <url>https://github.com/databricks/databricks-jdbc</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/databricks/databricks-jdbc/issues</url>
+  </issueManagement>
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+</project>


### PR DESCRIPTION
## Description
this is coming from https://databricks.slack.com/archives/C07AYHNFYCS/p1730236893677539
- shaded uber jar was made as the default artifact in 4a449675bf23a2983a32d3299da79a8373783b1d
- the uber jar (as the name suggests) does not need dependencies in the pom and other details
- this commit adds a reduced pom file to be deployed during the release of the new artifact
- the original pom file is modified to sign and deploy the reduced pom file along with other files
- version updater script is updated to automatically modify the version during release

## Testing
- testing with a sample application. verified that reduced pom does not import dependencies
- added a local-deploy profile to test maven deployment of artifacts locally
- existing tests in CI/CD