### PR TITLE
Eliminate the statement execution thread pool

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -2,7 +2,6 @@ package com.databricks.jdbc.api.impl;
 
 import static com.databricks.jdbc.common.DatabricksJdbcConstants.*;
 import static com.databricks.jdbc.common.EnvironmentVariables.*;
-import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
 
 import com.databricks.jdbc.api.IDatabricksResultSet;
@@ -20,6 +19,7 @@ import com.databricks.jdbc.exception.DatabricksTimeoutException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.sql.*;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,9 +31,8 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(DatabricksStatement.class);
 
-  /** ExecutorService for handling asynchronous execution of statements. */
-  private final ExecutorService executor =
-      Executors.newFixedThreadPool(getRuntime().availableProcessors() * 2);
+  /** Same-Thread-ExecutorService for handling execution of statements. */
+  private final ExecutorService executor = MoreExecutors.newDirectExecutorService();
 
   private int timeoutInSeconds;
   private final DatabricksConnection connection;
@@ -646,9 +645,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
    *
    * <p>Initiates an orderly shutdown of the executor, waiting up to 60 seconds for currently
    * executing tasks to terminate. If the executor does not terminate within the timeout, it is
-   * forcefully shut down. This method is called when the statement is closed to ensure that all
-   * threads are properly terminated, preventing the JVM from hanging due to lingering non-daemon
-   * threads.
+   * forcefully shut down.
    */
   private void shutDownExecutor() {
     executor.shutdown();


### PR DESCRIPTION
## Description
- Change it to same-thread executor because the main thread is anyways waiting on the task
- We no longer have to mange the lifecycle of a java thread pool (shutting down same-thread executor has almost no effect)

## Testing
CI

## Additional Notes to the Reviewer
This was suggested somewhere in the dense discussion forest of https://github.com/databricks/databricks-jdbc/pull/539. The PR will take some time to get merged so making this minor improvement separately

