### PR TITLE
Get columns metadata benchmarking modified

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/benchmarking/MetadataBenchmarkingTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/benchmarking/MetadataBenchmarkingTests.java
@@ -196,7 +196,7 @@ public class MetadataBenchmarkingTests {
           case 4:
             System.out.println("START OF SECTION 5");
             for (int i = 0; i < ATTEMPTS; i++) {
-              metaData.getColumns(getDatabricksCatalog(), "%", "%", "%");
+              metaData.getColumns(getDatabricksCatalog(), BASE_SCHEMA_NAME + "%", "%", "%");
             }
             break;
           case 5:


### PR DESCRIPTION
## Description
metadata benchmarking takes a lot of time to run, throws heap error / read time out error on running getColumns() with just catalog filter. Added fllter of schema pattern to reduce result size.

