### PR TITLE
Fix for nexus staging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,7 @@
                 <id>nexus-deploy</id>
                 <phase>deploy</phase>
                 <goals>
+                  <goal>close</goal>
                   <goal>release</goal>
                 </goals>
               </execution>


### PR DESCRIPTION
## Description
GPG plugin is doing sign and release. For nexus staging to work with external deploy, it needs a staging repository id. Added a close goal, which is expected to get the repository id.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

