### PR TITLE
Support configurable package prefix for logging via env variable

### DIFF
--- a/src/main/java/com/databricks/jdbc/log/JulLogger.java
+++ b/src/main/java/com/databricks/jdbc/log/JulLogger.java
@@ -25,9 +25,11 @@ public class JulLogger implements JdbcLogger {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(JulLogger.class);
 
+  private static final String DEFAULT_PACKAGE_PREFIX = "com.databricks.jdbc";
+
   public static final String STDOUT = "STDOUT";
 
-  public static final String PARENT_CLASS_PREFIX = "com.databricks.jdbc";
+  public static final String PARENT_CLASS_PREFIX = getPackagePrefix();
 
   public static final String DATABRICKS_LOG_FILE = "databricks_jdbc.log";
 
@@ -213,5 +215,13 @@ public class JulLogger implements JdbcLogger {
     }
 
     return dirPath.resolve(DATABRICKS_LOG_FILE).toString();
+  }
+
+  private static String getPackagePrefix() {
+    String prefix = System.getenv("JDBC_PACKAGE_PREFIX");
+    if (prefix != null && !prefix.isEmpty()) {
+      return prefix;
+    }
+    return DEFAULT_PACKAGE_PREFIX;
   }
 }


### PR DESCRIPTION
## Description
The JDBC driver's logging framework previously had a hardcoded package prefix "com.databricks.jdbc" which didn't work with shaded OSS JDBC builds that use a different prefix (e.g. "jdbc.shaded.0.9.9.OSS__JDBC.com.databricks.jdbc").

This change:
- Makes the package prefix configurable via JDBC_PACKAGE_PREFIX environment variable
- Maintains backwards compatibility by defaulting to "com.databricks.jdbc"

This fixes logging issues when running tests with shaded OSS JDBC builds.

Example Bazel build file setting the env for shaded JDBC: https://github.com/databricks-eng/universe/blob/b9984cbd69d2da1b249bc7a61cfaa11a468e5330/peco/correctness/jdbc/BUILD.bazel

## Testing
Multi-DBR tests

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

