### PR TITLE
Make hybrid as default mode for metadata queries

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataSdkClient.java
@@ -128,8 +128,14 @@ public class DatabricksMetadataSdkClient implements IDatabricksMetadataClient {
         SQL,
         session.getComputeResource(),
         new HashMap<>(),
-        StatementType.METADATA,
+        getMetadataStatementType(session),
         session,
         null /* parentStatement */);
+  }
+
+  private StatementType getMetadataStatementType(IDatabricksSession session) {
+    return session.getConnectionContext().isSqlExecHybridResultsEnabled()
+        ? StatementType.QUERY
+        : StatementType.METADATA;
   }
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Metadata queries will use Hybrid mode instead of Inline JSON. Also will cleanup Metadata as statement type in next iteration.

## Testing
<!-- Describe how the changes have been tested-->
Tested using unit tests. Guarded by Hybrid results flag

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

