### PR TITLE
Improve telemetry

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -501,6 +501,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
     LOGGER.debug("ResultSet executeAsync() for statement {%s}", sql);
     checkIfClosed();
     IDatabricksClient client = connection.getSession().getDatabricksClient();
+    DatabricksThreadContextHolder.setStatementType(StatementType.SQL);
     return client.executeStatementAsync(
         sql,
         connection.getSession().getComputeResource(),
@@ -610,6 +611,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
   DatabricksResultSet executeInternal(
       String sql, Map<Integer, ImmutableSqlParameter> params, StatementType statementType)
       throws SQLException {
+    DatabricksThreadContextHolder.setStatementType(statementType);
     return executeInternal(sql, params, statementType, true);
   }
 

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/RemoteChunkProvider.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/RemoteChunkProvider.java
@@ -18,7 +18,6 @@ import com.databricks.jdbc.model.core.ExternalLink;
 import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
-import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimedProcessor;
 import com.databricks.sdk.service.sql.BaseChunkInfo;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
@@ -218,9 +217,7 @@ public class RemoteChunkProvider implements ChunkProvider, ChunkDownloadCallback
         && totalChunksInMemory < allowedChunksInMemory) {
       ArrowResultChunk chunk = chunkIndexToChunksMap.get(nextChunkToDownload);
       if (chunk.getStatus() != ArrowResultChunk.ChunkStatus.DOWNLOAD_SUCCEEDED) {
-        this.chunkDownloaderExecutorService.submit(
-            DatabricksMetricsTimedProcessor.createProxy(
-                new ChunkDownloadTask(chunk, httpClient, this)));
+        this.chunkDownloaderExecutorService.submit(new ChunkDownloadTask(chunk, httpClient, this));
         totalChunksInMemory++;
       }
       nextChunkToDownload++;

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThreadContextHolder.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThreadContextHolder.java
@@ -9,6 +9,7 @@ public class DatabricksThreadContextHolder {
       new ThreadLocal<>();
   private static final ThreadLocal<StatementId> localStatementId = new ThreadLocal<>();
   private static final ThreadLocal<Long> localChunkId = new ThreadLocal<>();
+  private static final ThreadLocal<Integer> localRetryCount = new ThreadLocal<>();
   private static final ThreadLocal<StatementType> localStatementType = new ThreadLocal<>();
 
   public static void setConnectionContext(IDatabricksConnectionContext context) {
@@ -31,6 +32,14 @@ public class DatabricksThreadContextHolder {
     localStatementType.set(statementType);
   }
 
+  public static Integer getRetryCount() {
+    return localRetryCount.get();
+  }
+
+  public static void setRetryCount(Integer retryCount) {
+    localRetryCount.set(retryCount);
+  }
+
   public static StatementType getStatementType() {
     return localStatementType.get();
   }
@@ -45,17 +54,17 @@ public class DatabricksThreadContextHolder {
 
   public static void clearConnectionContext() {
     localConnectionContext.remove();
-    localStatementId.remove();
   }
 
   public static void clearStatementInfo() {
     localStatementId.remove();
     localChunkId.remove();
+    localStatementType.remove();
+    localRetryCount.remove();
   }
 
   public static void clearAllContext() {
-    localConnectionContext.remove();
-    localStatementId.remove();
-    localChunkId.remove();
+    clearStatementInfo();
+    clearConnectionContext();
   }
 }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -10,6 +10,7 @@ import com.databricks.jdbc.api.impl.*;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
 import com.databricks.jdbc.common.*;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
 import com.databricks.jdbc.dbclient.impl.common.ClientConfigurator;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
@@ -130,6 +131,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
             sql, computeResource.toString(), statementType));
     long pollCount = 0;
     long executionStartTime = Instant.now().toEpochMilli();
+    DatabricksThreadContextHolder.setStatementType(statementType);
     ExecuteStatementRequest request =
         getRequest(
             statementType,

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
@@ -10,6 +10,7 @@ import com.databricks.jdbc.api.impl.*;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.StatementType;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.common.util.DriverUtil;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
 import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
@@ -122,6 +123,7 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
         String.format(
             "public DatabricksResultSet executeStatement(String sql = {%s}, Compute cluster = {%s}, Map<Integer, ImmutableSqlParameter> parameters = {%s}, StatementType statementType = {%s}, IDatabricksSession session)",
             sql, computeResource.toString(), parameters.toString(), statementType));
+    DatabricksThreadContextHolder.setStatementType(statementType);
     TExecuteStatementReq request =
         new TExecuteStatementReq()
             .setStatement(sql)

--- a/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
@@ -3,6 +3,7 @@ package com.databricks.jdbc.model.telemetry;
 import com.databricks.jdbc.common.AuthFlow;
 import com.databricks.jdbc.common.AuthMech;
 import com.databricks.jdbc.common.DatabricksClientType;
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
@@ -159,5 +160,30 @@ public class DriverConnectionParameters {
       boolean acceptUndeterminedCertificateRevocation) {
     this.acceptUndeterminedCertificateRevocation = acceptUndeterminedCertificateRevocation;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(DriverConnectionParameters.class)
+        .add("httpPath", httpPath)
+        .add("driverMode", driverMode)
+        .add("hostDetails", hostDetails)
+        .add("authMech", authMech)
+        .add("driverAuthFlow", driverAuthFlow)
+        .add("authScope", authScope)
+        .add("useProxy", useProxy)
+        .add("nonProxyHosts", non_proxy_hosts)
+        .add("useSystemProxy", useSystemProxy)
+        .add("useCfProxy", useCfProxy)
+        .add("proxyHostDetails", proxyHostDetails)
+        .add("cfProxyHostDetails", cfProxyHostDetails)
+        .add("discoveryModeEnabled", discoveryModeEnabled)
+        .add("discoveryUrl", discoveryUrl)
+        .add("useEmptyMetadata", useEmptyMetadata)
+        .add("supportManyParameters", supportManyParameters)
+        .add("sslTrustStoreType", sslTrustStoreType)
+        .add("checkCertificateRevocation", checkCertificateRevocation)
+        .add("acceptUndeterminedCertificateRevocation", acceptUndeterminedCertificateRevocation)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/FrontendLogContext.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/FrontendLogContext.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.telemetry;
 
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FrontendLogContext {
@@ -15,5 +16,12 @@ public class FrontendLogContext {
   public FrontendLogContext setClientContext(TelemetryClientContext clientContext) {
     this.clientContext = clientContext;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(TelemetryFrontendLog.class)
+        .add("client_context", clientContext)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/FrontendLogEntry.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/FrontendLogEntry.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.telemetry;
 
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FrontendLogEntry {
@@ -15,5 +16,10 @@ public class FrontendLogEntry {
   public FrontendLogEntry setSqlDriverLog(TelemetryEvent sqlDriverLog) {
     this.sqlDriverLog = sqlDriverLog;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(FrontendLogEntry.class).add("sql_driver_log", sqlDriverLog).toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/SqlExecutionEvent.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/SqlExecutionEvent.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.model.telemetry;
 
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.model.telemetry.enums.ExecutionResultFormat;
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SqlExecutionEvent {
@@ -18,7 +19,7 @@ public class SqlExecutionEvent {
   Long chunkId;
 
   @JsonProperty("retry_count")
-  int retryCount;
+  Integer retryCount;
 
   public SqlExecutionEvent setDriverStatementType(StatementType driverStatementType) {
     this.driverStatementType = driverStatementType;
@@ -40,8 +41,19 @@ public class SqlExecutionEvent {
     return this;
   }
 
-  public SqlExecutionEvent setRetryCount(int retryCount) {
+  public SqlExecutionEvent setRetryCount(Integer retryCount) {
     this.retryCount = retryCount;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(SqlExecutionEvent.class)
+        .add("statement_type", driverStatementType)
+        .add("is_compressed", isCompressed)
+        .add("execution_result", executionResultFormat)
+        .add("chunk_id", chunkId)
+        .add("retry_count", retryCount)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryClientContext.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryClientContext.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.telemetry;
 
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TelemetryClientContext {
@@ -16,5 +17,12 @@ public class TelemetryClientContext {
   public TelemetryClientContext setTimestampMillis(Long timestampMillis) {
     this.timestampMillis = timestampMillis;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(TelemetryFrontendLog.class)
+        .add("timestampMillis", timestampMillis)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryEvent.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryEvent.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.telemetry;
 
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TelemetryEvent {
@@ -90,5 +91,20 @@ public class TelemetryEvent {
   public TelemetryEvent setDriverErrorInfo(DriverErrorInfo driverErrorInfo) {
     this.driverErrorInfo = driverErrorInfo;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(TelemetryEvent.class)
+        .add("sessionId", sessionId)
+        .add("sqlStatementId", sqlStatementId)
+        .add("driverSystemConfiguration", driverSystemConfiguration)
+        .add("driverConnectionParameters", driverConnectionParameters)
+        .add("authType", authType)
+        .add("volumeOperation", volumeOperation)
+        .add("sqlOperation", sqlOperation)
+        .add("driverErrorInfo", driverErrorInfo)
+        .add("latency", latency)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryFrontendLog.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/TelemetryFrontendLog.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.telemetry;
 
+import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TelemetryFrontendLog {
@@ -52,5 +53,15 @@ public class TelemetryFrontendLog {
   public TelemetryFrontendLog setEntry(FrontendLogEntry entry) {
     this.entry = entry;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(TelemetryFrontendLog.class)
+        .add("workspaceId", workspaceId)
+        .add("frontendLogEventId", frontendLogEventId)
+        .add("context", context)
+        .add("entry", entry)
+        .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessor.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessor.java
@@ -2,8 +2,6 @@ package com.databricks.jdbc.telemetry.latency;
 
 import static com.databricks.jdbc.telemetry.TelemetryHelper.exportLatencyLog;
 
-import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
-import com.databricks.jdbc.model.telemetry.SqlExecutionEvent;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -36,15 +34,8 @@ public class DatabricksMetricsTimedProcessor {
           Object result = method.invoke(target, args);
           // Calculate execution time
           long executionTime = System.currentTimeMillis() - startTime;
-          SqlExecutionEvent executionEvent =
-              new SqlExecutionEvent()
-                  .setDriverStatementType(DatabricksThreadContextHolder.getStatementType())
-                  .setChunkId(DatabricksThreadContextHolder.getChunkId());
-          exportLatencyLog(
-              DatabricksThreadContextHolder.getConnectionContext(),
-              executionTime,
-              executionEvent,
-              DatabricksThreadContextHolder.getStatementId());
+          System.out.println("here is start of log " + method.getName());
+          exportLatencyLog(executionTime);
           return result;
         } catch (Throwable throwable) {
           // Handle exceptions from the target method


### PR DESCRIPTION
## Description
- We can't really add annotation to send telemetry latency for chunk downloader because threadContext doesn't pass on to child threads. 
- This PR also adds statement type and chunk ID
- Added `Stringer` methods for telemetry models for easy debugging.

## Testing
- verified using driverTester

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

