### PR TITLE
updated upload-artifact to v4

### DIFF
--- a/.github/workflows/runJdbcComparator.yml
+++ b/.github/workflows/runJdbcComparator.yml
@@ -82,7 +82,7 @@ jobs:
           content_type: text/html
 
       - name: Upload Report as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jdbc-comparison-report
           path: |


### PR DESCRIPTION
## Description
Got error ` This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/` on running workflow.
Updating v3 to v4.

## Testing
<!-- Describe how the changes have been tested-->


