### PR TITLE
[ES-1361736] Fix bug : modify driver version

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
@@ -10,8 +10,6 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Utility class for operations related to the Databricks JDBC driver.
@@ -22,20 +20,14 @@ import java.util.concurrent.ConcurrentMap;
 public class DriverUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(DriverUtil.class);
-  public static final String DBSQL_VERSION_SQL = "SELECT current_version().dbsql_version";
-  private static final String VERSION = "0.9.9-oss";
+  private static final String DRIVER_VERSION = "0.9.9-oss";
   private static final String DRIVER_NAME = "oss-jdbc";
-  private static final int DBSQL_MIN_MAJOR_VERSION_FOR_SEA_SUPPORT = 2024;
-  private static final int DBSQL_MIN_MINOR_VERSION_FOR_SEA_SUPPORT = 30;
+  private static final String JDBC_VERSION = "4.3";
 
-  /** Cached DBSQL version mapped by HTTP path to avoid repeated queries to the cluster. */
-  private static final ConcurrentMap<String, String> cachedDBSQLVersions =
-      new ConcurrentHashMap<>();
-
-  private static final String[] VERSION_PARTS = VERSION.split("[.-]");
+  private static final String[] JDBC_VERSION_PARTS = JDBC_VERSION.split("[.-]");
 
   public static String getVersion() {
-    return VERSION;
+    return DRIVER_VERSION;
   }
 
   public static String getDriverName() {
@@ -43,11 +35,11 @@ public class DriverUtil {
   }
 
   public static int getMajorVersion() {
-    return Integer.parseInt(VERSION_PARTS[0]);
+    return Integer.parseInt(JDBC_VERSION_PARTS[0]);
   }
 
   public static int getMinorVersion() {
-    return Integer.parseInt(VERSION_PARTS[1]);
+    return Integer.parseInt(JDBC_VERSION_PARTS[1]);
   }
 
   public static void resolveMetadataClient(IDatabricksConnectionInternal connection)

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
@@ -89,13 +89,13 @@ public class DatabricksDatabaseMetaDataTest {
   @Test
   public void getJDBCMajorVersion_returnsCorrectVersion() throws Exception {
     int majorVersion = metaData.getJDBCMajorVersion();
-    assertEquals(0, majorVersion);
+    assertEquals(4, majorVersion);
   }
 
   @Test
   public void getJDBCMinorVersion_returnsCorrectVersion() throws Exception {
     int minorVersion = metaData.getJDBCMinorVersion();
-    assertEquals(9, minorVersion);
+    assertEquals(3, minorVersion);
   }
 
   @Test


### PR DESCRIPTION
## Description
- Currently `metadata.getJDBCMinorVersion` and `.getJDBCMajorVersion` is returning the driver Major Version and not the JDBC Major Version. This PR fixes this.
- As we have support for JDK9+ in our driver, we should be using JDBC v4.3 and not JDBC v4.2 (as it is for packages stuck with JDK8 build). This is why we vary from our legacy driver as well.

## Testing
added UTs

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

