### PR TITLE
[PECOBLR-52] added getHoldability and absolute functions in ResultSet

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
@@ -1,5 +1,7 @@
 package com.databricks.jdbc.api.impl;
 
+import static com.databricks.jdbc.common.DatabricksJdbcConstants.EMPTY_STRING;
+
 import com.databricks.jdbc.api.IDatabricksResultSet;
 import com.databricks.jdbc.api.IDatabricksSession;
 import com.databricks.jdbc.api.impl.converters.ConverterHelper;
@@ -445,7 +447,7 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
   @Override
   public String getCursorName() throws SQLException {
     checkIfClosed();
-    return "";
+    return EMPTY_STRING;
   }
 
   @Override
@@ -575,9 +577,8 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
   public boolean absolute(int row) throws SQLException {
     checkIfClosed();
     if (row < 1 || row < executionResult.getCurrentRow()) {
-      throw new DatabricksSQLException(
-          "Invalid operation for forward only ResultSets",
-          DatabricksDriverErrorCode.UNSUPPORTED_OPERATION);
+      throw new DatabricksSQLFeatureNotSupportedException(
+          "Invalid operation for forward only ResultSets");
     }
     while (executionResult.getCurrentRow() < row - 1) {
       if (!next()) {

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
@@ -91,14 +91,14 @@ public class DatabricksResultSetTest {
   @Test
   void testAbsolute() throws SQLException {
     DatabricksResultSet resultSet = getResultSet(StatementState.SUCCEEDED, null);
-    assertThrows(DatabricksSQLException.class, () -> resultSet.absolute(0));
+    assertThrows(DatabricksSQLFeatureNotSupportedException.class, () -> resultSet.absolute(0));
 
     when(mockedExecutionResult.getCurrentRow()).thenReturn(0L, 1L, 2L);
     doReturn(true).doReturn(true).doReturn(false).when(mockedExecutionResult).next();
 
     assertTrue(resultSet.absolute(3));
     // throws exception for backward exception
-    assertThrows(DatabricksSQLException.class, () -> resultSet.absolute(1));
+    assertThrows(DatabricksSQLFeatureNotSupportedException.class, () -> resultSet.absolute(1));
 
     assertFalse(resultSet.absolute(4));
   }


### PR DESCRIPTION
## Description

1. Implemented absolute method in ResultSet.
2. holdability is returned as `CLOSE_CURSORS_AT_COMMIT` by default in databricks driver. Replicating same here
3. cursorName is "" by default.

## Testing
Unit test
driver test

## Additional Notes to the Reviewer

