### PR TITLE
Implement JDBC wrapper methods in DatabricksDatabaseMetaData

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
@@ -1516,18 +1516,25 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
     return false;
   }
 
+  /** {@inheritDoc} */
   @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     LOGGER.debug(String.format("public <T> T unwrap(Class<T> iface = {%s})", iface));
-    throw new UnsupportedOperationException(
-        "Not implemented in DatabricksDatabaseMetaData - unwrap(Class<T> iface)");
+
+    if (isWrapperFor(iface)) {
+      return iface.cast(this);
+    }
+
+    throw new DatabricksSQLException(
+        "Cannot unwrap to " + iface.getName(), DatabricksDriverErrorCode.INVALID_STATE);
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
     LOGGER.debug(String.format("public boolean isWrapperFor(Class<?> iface = {%s})", iface));
-    throw new UnsupportedOperationException(
-        "Not implemented in DatabricksDatabaseMetaData - isWrapperFor(Class<?> iface)");
+
+    return iface != null && iface.isAssignableFrom(this.getClass());
   }
 
   private void throwExceptionIfConnectionIsClosed() throws SQLException {

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
@@ -1011,9 +1011,7 @@ public class DatabricksDatabaseMetaDataTest {
     List<Callable<Object>> tasks =
         Arrays.asList(
             () -> metaData.supportsTransactionIsolationLevel(0),
-            () -> metaData.supportsConvert(0, 0),
-            () -> metaData.isWrapperFor(DatabricksDatabaseMetaData.class),
-            () -> metaData.unwrap(DatabricksDatabaseMetaData.class));
+            () -> metaData.supportsConvert(0, 0));
 
     for (Callable<Object> task : tasks) {
       try {
@@ -1509,6 +1507,46 @@ public class DatabricksDatabaseMetaDataTest {
 
     // Result set is empty
     assertFalse(resultSet.next());
+  }
+
+  @Test
+  public void testIsWrapperFor_ReturnsTrueForDatabaseMetaData() throws SQLException {
+    // Test that it returns true for DatabaseMetaData interface
+    assertTrue(metaData.isWrapperFor(DatabaseMetaData.class));
+  }
+
+  @Test
+  public void testIsWrapperFor_ReturnsTrueForSameClass() throws SQLException {
+    // Test that it returns true for its own class
+    assertTrue(metaData.isWrapperFor(DatabricksDatabaseMetaData.class));
+  }
+
+  @Test
+  public void testIsWrapperFor_ReturnsFalseForUnrelatedInterface() throws SQLException {
+    // Test that it returns false for unrelated interfaces
+    assertFalse(metaData.isWrapperFor(Runnable.class));
+  }
+
+  @Test
+  public void testUnwrap_SuccessfullyUnwrapsDatabaseMetaData() throws SQLException {
+    // Test unwrapping to DatabaseMetaData interface
+    DatabaseMetaData unwrapped = metaData.unwrap(DatabaseMetaData.class);
+    assertNotNull(unwrapped);
+    assertSame(metaData, unwrapped);
+  }
+
+  @Test
+  public void testUnwrap_SuccessfullyUnwrapsSameClass() throws SQLException {
+    // Test unwrapping to its own class
+    DatabricksDatabaseMetaData unwrapped = metaData.unwrap(DatabricksDatabaseMetaData.class);
+    assertNotNull(unwrapped);
+    assertSame(metaData, unwrapped);
+  }
+
+  @Test
+  public void testUnwrap_ThrowsExceptionForUnrelatedInterface() throws SQLException {
+    // Test that unwrapping to an unrelated interface throws exception
+    assertThrows(DatabricksSQLException.class, () -> metaData.unwrap(Runnable.class));
   }
 
   private static Stream<Arguments> provideAttributeParameters() {


### PR DESCRIPTION
## Description
Added implementations for unwrap() and isWrapperFor() methods to support JDBC wrapper pattern compliance and access to vendor extensions.

## Testing
Unit tests

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

