### PR TITLE
[PECOBLR-51] Modify userAgent to fix queryHistory

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -1,6 +1,8 @@
 package com.databricks.jdbc.api.impl;
 
 import static com.databricks.jdbc.common.DatabricksJdbcConstants.*;
+import static com.databricks.jdbc.common.util.UserAgentManager.USER_AGENT_SEA_CLIENT;
+import static com.databricks.jdbc.common.util.UserAgentManager.USER_AGENT_THRIFT_CLIENT;
 
 import com.databricks.jdbc.api.IDatabricksConnectionContext;
 import com.databricks.jdbc.common.*;
@@ -353,8 +355,8 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public String getClientUserAgent() {
     return getClientType().equals(DatabricksClientType.SEA)
-        ? DatabricksJdbcConstants.USER_AGENT_SEA_CLIENT
-        : DatabricksJdbcConstants.USER_AGENT_THRIFT_CLIENT;
+        ? USER_AGENT_SEA_CLIENT
+        : USER_AGENT_THRIFT_CLIENT;
   }
 
   public String getCustomerUserAgent() {

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
@@ -58,10 +58,6 @@ public final class DatabricksJdbcConstants {
   public static final String USER_NAME = "User";
   public static final String PORT = "port";
   public static final int DEFAULT_PORT = 443;
-  public static final String DEFAULT_USER_AGENT = "DatabricksJDBCDriverOSS";
-  public static final String CLIENT_USER_AGENT_PREFIX = "Java";
-  public static final String USER_AGENT_SEA_CLIENT = "SQLExecHttpClient/HC";
-  public static final String USER_AGENT_THRIFT_CLIENT = "THttpClient/HC";
   public static final String THRIFT_ERROR_MESSAGE_HEADER = "X-Thriftserver-Error-Message";
   public static final String ALLOWED_VOLUME_INGESTION_PATHS = "VolumeOperationAllowedLocalPaths";
   public static final String ALLOWED_STAGING_INGESTION_PATHS = "StagingAllowedLocalPaths";

--- a/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
+++ b/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
@@ -1,16 +1,18 @@
 package com.databricks.jdbc.common.util;
 
-import static com.databricks.jdbc.common.DatabricksJdbcConstants.CLIENT_USER_AGENT_PREFIX;
-import static com.databricks.jdbc.common.DatabricksJdbcConstants.USER_AGENT_DELIMITER;
 import static com.databricks.jdbc.common.util.WildcardUtil.isNullOrEmpty;
 
 import com.databricks.jdbc.api.IDatabricksConnectionContext;
-import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import com.databricks.sdk.core.UserAgent;
 
 public class UserAgentManager {
   private static final String SDK_USER_AGENT = "databricks-sdk-java";
   private static final String JDBC_HTTP_USER_AGENT = "databricks-jdbc-http";
+  private static final String VERSION_FILLER_FOR_CUSTOMER_USER_AGENT = "version";
+  private static final String DEFAULT_USER_AGENT = "DatabricksJDBCDriverOSS";
+  private static final String CLIENT_USER_AGENT_PREFIX = "Java";
+  public static final String USER_AGENT_SEA_CLIENT = "SQLExecHttpClient";
+  public static final String USER_AGENT_THRIFT_CLIENT = "THttpClient";
 
   /**
    * Set the user agent for the Databricks JDBC driver.
@@ -18,14 +20,16 @@ public class UserAgentManager {
    * @param connectionContext The connection context.
    */
   public static void setUserAgent(IDatabricksConnectionContext connectionContext) {
-    UserAgent.withProduct(DatabricksJdbcConstants.DEFAULT_USER_AGENT, DriverUtil.getVersion());
+    UserAgent.withProduct(DEFAULT_USER_AGENT, DriverUtil.getVersion());
+    UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, connectionContext.getClientUserAgent());
     String customerUA = connectionContext.getCustomerUserAgent();
-    String userAgentInfo = connectionContext.getClientUserAgent();
     if (!isNullOrEmpty(customerUA)) {
-      userAgentInfo += USER_AGENT_DELIMITER + customerUA.trim();
+      int i = customerUA.indexOf('/');
+      String customerName = (i < 0) ? customerUA : customerUA.substring(0, i);
+      String customerVersion =
+          (i < 0) ? VERSION_FILLER_FOR_CUSTOMER_USER_AGENT : customerUA.substring(i + 1);
+      UserAgent.withOtherInfo(customerName, UserAgent.sanitize(customerVersion));
     }
-    String sanitisedUserAgentInfo = UserAgent.sanitize(userAgentInfo);
-    UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, sanitisedUserAgentInfo);
   }
 
   /** Gets the user agent string for Databricks Driver HTTP Client. */

--- a/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
@@ -20,7 +20,8 @@ public class UserAgentManagerTest {
     String userAgent = getUserAgentString();
     System.out.println(getUserAgentString());
     assertTrue(userAgent.contains("DatabricksJDBCDriverOSS/0.9.9-oss"));
-    assertTrue(userAgent.contains(" Java/THttpClient-HC-MyApp"));
+    assertTrue(userAgent.contains(" Java/THttpClient"));
+    assertTrue(userAgent.contains(" MyApp/version"));
     assertTrue(userAgent.contains(" databricks-jdbc-http "));
     assertFalse(userAgent.contains("databricks-sdk-java"));
 
@@ -30,7 +31,7 @@ public class UserAgentManagerTest {
     UserAgentManager.setUserAgent(connectionContext);
     userAgent = getUserAgentString();
     assertTrue(userAgent.contains("DatabricksJDBCDriverOSS/0.9.9-oss"));
-    assertTrue(userAgent.contains(" Java/SQLExecHttpClient-HC-MyApp"));
+    assertTrue(userAgent.contains(" Java/SQLExecHttpClient"));
     assertTrue(userAgent.contains(" databricks-jdbc-http "));
     assertFalse(userAgent.contains("databricks-sdk-java"));
   }
@@ -41,6 +42,6 @@ public class UserAgentManagerTest {
         DatabricksConnectionContextFactory.create(USER_AGENT_URL, new Properties());
     UserAgentManager.setUserAgent(connectionContext);
     String userAgent = getUserAgentString();
-    assertTrue(userAgent.contains("TEST-24.2.0.2712019"));
+    assertTrue(userAgent.contains("TEST/24.2.0.2712019"));
   }
 }


### PR DESCRIPTION
## Description
- If we go ahead with the [right way of adding user-Agent](https://docs.google.com/document/d/1_3LykhwbljhfVbUJ_U8bQw21G5VZb05dcGmOxtg2Ols/edit?tab=t.0#heading=h.dd2cc57oc5wk), it will take us a long time to get the changes merged in [ThriftUserAgentRedactor](https://github.com/databricks-eng/universe/blob/b49cc49dd2b5dc176035366457df2c034e2066b3/log-sync/lumberjack-compat/src/ThriftOperationUdf.scala#L166). 
- The goal of this PR is to make changes to the passing of user-Agent in a way that there are minimal changes in the universe code. 

## Testing
- added unit tests 

## Additional Notes to the Reviewer
- Example thrift user-agent : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-jdbc-http jvm/22.0.1 os/darwin Java/THttpClient`
- Example warehouse via thrift user-agent [same as above] : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-jdbc-http jvm/22.0.1 os/darwin Java/THttpClient`
-  Example warehouse via SEA user-agent : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-sdk-java/0.35.0 jvm/22.0.1 os/darwin Java/SQLExecHttpClient`
- With userAgent SEA : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-sdk-java/0.35.0 jvm/22.0.1 os/darwin Matlab/version Java/SQLExecHttpClient` 
- with userAgent Thrift: `DatabricksJDBCDriverOSS/0.9.9-oss databricks-jdbc-http jvm/22.0.1 os/darwin Java/THttpClient matlab/version`
- with userAgent and version Thrift : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-jdbc-http jvm/22.0.1 os/darwin Java/THttpClient matlab/0.7.7`
-  with userAgent and version SEA : `DatabricksJDBCDriverOSS/0.9.9-oss databricks-sdk-java/0.35.0 jvm/22.0.1 os/darwin matlab/0.7.7 Java/SQLExecHttpClient`
- ## Another thing to note is in SEA, all userAgents passed by JDBC will be suffixed with `DatabricksSqlExecApi/2.0`
