### PR TITLE
[PECOBLR-288] Align behaviour for ResultSet#getBoolean

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ByteArrayConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ByteArrayConverter.java
@@ -40,16 +40,6 @@ public class ByteArrayConverter implements ObjectConverter {
   }
 
   @Override
-  public boolean toBoolean(Object object) throws DatabricksSQLException {
-    byte[] byteArray = toByteArray(object);
-    if (byteArray.length > 0) {
-      return byteArray[0] != 0;
-    } else {
-      return false;
-    }
-  }
-
-  @Override
   public String toString(Object object) throws DatabricksSQLException {
     return Base64.getEncoder().encodeToString(toByteArray(object));
   }

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/StringConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/StringConverter.java
@@ -95,7 +95,7 @@ public class StringConverter implements ObjectConverter {
     } else if ("1".equals(str) || "true".equals(str)) {
       return true;
     }
-    throw new DatabricksValidationException("Invalid conversion to boolean");
+    return true;
   }
 
   @Override

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ByteArrayConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ByteArrayConverterTest.java
@@ -47,17 +47,9 @@ public class ByteArrayConverterTest {
   }
 
   @Test
-  void testConvertToBooleanTrue() throws DatabricksSQLException {
-    byte[] byteArray = {1};
-    assertTrue(converter.toBoolean(byteArray));
-    byteArray = new byte[] {};
-    assertFalse(converter.toBoolean(byteArray));
-  }
-
-  @Test
-  void testConvertToBooleanFalse() throws DatabricksSQLException {
-    byte[] byteArray = {0};
-    assertFalse(converter.toBoolean(byteArray));
+  void testConvertToBoolean() throws DatabricksSQLException {
+    assertThrows(DatabricksSQLException.class, () -> converter.toBoolean(new byte[] {1}));
+    assertThrows(DatabricksSQLException.class, () -> converter.toBoolean(new byte[] {}));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/StringConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/StringConverterTest.java
@@ -123,16 +123,10 @@ public class StringConverterTest {
     assertFalse(new StringConverter().toBoolean(NUMBERICAL_ZERO_STRING));
     assertTrue(new StringConverter().toBoolean("true"));
     assertFalse(new StringConverter().toBoolean("false"));
-
-    DatabricksSQLException invalidCharactersException =
-        assertThrows(
-            DatabricksSQLException.class, () -> new StringConverter().toBoolean(CHARACTER_STRING));
-    assertTrue(invalidCharactersException.getMessage().contains("Invalid conversion"));
-
-    DatabricksSQLException invalidNumberException =
-        assertThrows(
-            DatabricksSQLException.class, () -> new StringConverter().toBoolean(NUMERICAL_STRING));
-    assertTrue(invalidNumberException.getMessage().contains("Invalid conversion"));
+    assertTrue(new StringConverter().toBoolean("TRUE"));
+    assertFalse(new StringConverter().toBoolean("FALSE"));
+    assertTrue(new StringConverter().toBoolean(CHARACTER_STRING));
+    assertTrue(new StringConverter().toBoolean(NUMERICAL_STRING));
   }
 
   @Test


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
The existing driver:
1. Returns false for null values except, for `date, timestamp, timestamp_ntz, binary` type columns where it throws an error.
2. For non-null values: return false for 0s of int/double/float/etc and parse string type columns for true/false.

## Testing
<!-- Describe how the changes have been tested-->
Unit tests + manual testing
## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

