### PR TITLE
Renaming UC Volume retryable codes and retry timeout parameters as per Docs team feedback

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -795,7 +795,10 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public List<Integer> getUCIngestionRetriableHttpCodes() {
     return Arrays.stream(
-            getParameter(DatabricksJdbcUrlParams.UC_INGESTION_RETRIABLE_HTTP_CODE).split(","))
+            getParameter(
+                    DatabricksJdbcUrlParams.VOLUME_OPERATION_RETRYABLE_HTTP_CODE,
+                    getParameter(DatabricksJdbcUrlParams.UC_INGESTION_RETRIABLE_HTTP_CODE))
+                .split(","))
         .map(String::trim)
         .filter(num -> num.matches("\\d+")) // Ensure only positive integers
         .map(Integer::parseInt)
@@ -805,7 +808,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public int getUCIngestionRetryTimeoutSeconds() {
     // The Url param takes value in minutes
-    return 60 * Integer.parseInt(getParameter(DatabricksJdbcUrlParams.UC_INGESTION_RETRY_TIMEOUT));
+    return 60
+        * Integer.parseInt(
+            getParameter(
+                DatabricksJdbcUrlParams.VOLUME_OPERATION_RETRY_TIMEOUT,
+                getParameter(DatabricksJdbcUrlParams.UC_INGESTION_RETRY_TIMEOUT)));
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -85,9 +85,17 @@ public enum DatabricksJdbcUrlParams {
   ALLOWED_VOLUME_INGESTION_PATHS("VolumeOperationAllowedLocalPaths", ""),
   ALLOWED_STAGING_INGESTION_PATHS("StagingAllowedLocalPaths", ""),
   UC_INGESTION_RETRIABLE_HTTP_CODE(
-      "UCIngestionRetriableHttpCode", "Retriable HTTP codes for UC Ingestion", "408,502,503,504"),
+      "UCIngestionRetriableHttpCode", "Retryable HTTP codes for UC Ingestion", "408,502,503,504"),
+  VOLUME_OPERATION_RETRYABLE_HTTP_CODE(
+      "VolumeOperationRetryableHttpCode",
+      "Retryable HTTP codes for UC Ingestion",
+      "408,502,503,504"),
   UC_INGESTION_RETRY_TIMEOUT(
       "UCIngestionRetryTimeout",
+      "The retry timeout in minutes for UC Ingestion HTTP requests.",
+      "15"),
+  VOLUME_OPERATION_RETRY_TIMEOUT(
+      "VolumeOperationRetryTimeout",
       "The retry timeout in minutes for UC Ingestion HTTP requests.",
       "15"),
   ENABLE_REQUEST_TRACING("EnableRequestTracing", "flag to enable request tracing", "0"),

--- a/src/test/java/com/databricks/jdbc/TestConstants.java
+++ b/src/test/java/com/databricks/jdbc/TestConstants.java
@@ -207,9 +207,9 @@ public class TestConstants {
   public static final String VALID_URL_POLLING =
       "jdbc:databricks://e2-dogfood.staging.cloud.databricks.com:4473;ssl=1;asyncexecpollinterval=500;AuthMech=3;httpPath=/sql/1.0/warehouses/5c89f447c476a5a8;QueryResultCompressionType=1";
   public static final String VALID_URL_WITH_STAGING_ALLOWED_PATH =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=./test1;auth_flow=2;StagingAllowedLocalPaths=/tmp";
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=./test1;auth_flow=2;StagingAllowedLocalPaths=/tmp;UCIngestionRetriableHttpCode=503,504;UCIngestionRetryTimeout=12";
   public static final String VALID_URL_WITH_VOLUME_ALLOWED_PATH =
-      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=./test1;auth_flow=2;VolumeOperationAllowedLocalPaths=/tmp2";
+      "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=./test1;auth_flow=2;VolumeOperationAllowedLocalPaths=/tmp2;VolumeOperationRetryableHttpCode=429,503,504;VolumeOperationRetryTimeout=10";
 
   public static final String VALID_URL_WITH_CONN_CATALOG_CONN_SCHEMA_PROVIDED =
       "jdbc:databricks://adb-565757575.18.azuredatabricks.net:4423/default;ssl=1;AuthMech=3;httpPath=/sql/1.0/warehouses/erg6767gg;LogLevel=debug;LogPath=./test1;auth_flow=2;VolumeOperationAllowedLocalPaths=/tmp2;connCatalog=sampleCatalog;connSchema=sampleSchema";

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -392,14 +392,20 @@ class DatabricksConnectionContextTest {
         DatabricksConnectionContext.parse(
             TestConstants.VALID_URL_WITH_VOLUME_ALLOWED_PATH, properties);
     assertEquals("/tmp2", connectionContext.getVolumeOperationAllowedPaths());
+    assertEquals(List.of(429, 503, 504), connectionContext.getUCIngestionRetriableHttpCodes());
+    assertEquals(600, connectionContext.getUCIngestionRetryTimeoutSeconds());
 
     connectionContext =
         DatabricksConnectionContext.parse(
             TestConstants.VALID_URL_WITH_STAGING_ALLOWED_PATH, properties);
     assertEquals("/tmp", connectionContext.getVolumeOperationAllowedPaths());
+    assertEquals(List.of(503, 504), connectionContext.getUCIngestionRetriableHttpCodes());
+    assertEquals(720, connectionContext.getUCIngestionRetryTimeoutSeconds());
 
     connectionContext = DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
     assertEquals("", connectionContext.getVolumeOperationAllowedPaths());
+    assertEquals(List.of(408, 502, 503, 504), connectionContext.getUCIngestionRetriableHttpCodes());
+    assertEquals(900, connectionContext.getUCIngestionRetryTimeoutSeconds());
   }
 
   @Test


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Renaming UC Volume retryable codes and retry timeout parameters as per Docs team feedback

`UCIngestionRetriableHttpCode` -> `VolumeOperationRetryableHttpCode`
`UCIngestionRetryTimeout` -> `VolumeOperationRetryTimeout`

Old parameters are still retained as fallback aliases of new params


## Testing
<!-- Describe how the changes have been tested-->

Added Unit tests for new params, old params and default values

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

