### PR TITLE
[ES-1436915] Modify an e2e test to iterate over the rs in a separate thread

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/MultiChunkExecutionIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/MultiChunkExecutionIntegrationTests.java
@@ -84,9 +84,7 @@ public class MultiChunkExecutionIntegrationTests extends AbstractFakeServiceInte
             });
 
     thread.start();
-    if (!thread.join(10_000)) { // Wait for up to 10 seconds
-      fail("Test thread did not terminate within the timeout period.");
-    }
+    thread.join(10_000);
 
     // Check if the thread had an exception
     if (threadException.get() != null) {


### PR DESCRIPTION
## Description
```
NO_CHANGELOG=true
```

This will help identify potential thread-safety issues, such as problems with state propagation and context management. In this scenario, customers can interact with first-class JDBC objects like Statement and ResultSet from a separate thread, while the JDBC connection object itself is managed in a different thread. The test is designed to simulate this type of multithreaded environment, ensuring that the system can handle concurrent access to these objects without issues. By doing so, it helps uncover any synchronization problems or unintended side effects that may arise when JDBC components are accessed from multiple threads.

## Testing
The test is expected to fail now due to a bug in the implementation of DatabricksContextHolder.

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

