### PR TITLE
Fix flaky test ChunkLinkDownloadServiceTest#testBatchDownloadChaining

### DIFF
--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadServiceTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadServiceTest.java
@@ -206,6 +206,9 @@ class ChunkLinkDownloadServiceTest {
         createExternalLink("test-url", 5L, Collections.emptyMap(), "2025-02-16T00:00:00Z");
     ExternalLink linkForChunkIndex_6 =
         createExternalLink("test-url", 6L, Collections.emptyMap(), "2025-02-16T00:00:00Z");
+
+    ArrowResultChunk mockChunk = mock(ArrowResultChunk.class);
+    when(mockChunkMap.get(anyLong())).thenReturn(mockChunk);
     when(mockSession.getDatabricksClient()).thenReturn(mockClient);
     // Mock the links for the first batch. The link futures for both chunks will be completed at the
     // same time


### PR DESCRIPTION
## Description

The link download futures were being completed because the link download chain was triggered eagerly. When getLinkForChunk is called, the link download future is evaluated. If the future is already complete, it checks the status of the chunk. The test was not mocking the chunk, which caused a NullPointerException (NPE). Locally, the test passed because the link download futures weren't completing before getLinkForChunk was called. However, in the GitHub runs, the futures were completing, which led to a thread synchronization issue.

```
NO_CHANGELOG=true
```

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

