### PR TITLE
Add client side telemetry fields inline with proto

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/StringUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/StringUtil.java
@@ -1,5 +1,8 @@
 package com.databricks.jdbc.common.util;
 
+import java.util.Collections;
+import java.util.List;
+
 public class StringUtil {
   public static String convertJdbcEscapeSequences(String sql) {
     // Replace JDBC escape sequences;
@@ -38,6 +41,13 @@ public class StringUtil {
             /* StringToCheck= */ prefix,
             /* sourceOffset= */ 0,
             /* lengthToMatch= */ prefix.length());
+  }
+
+  public static List<String> split(String value) {
+    if (value == null) {
+      return Collections.emptyList();
+    }
+    return List.of(value.split(","));
   }
 
   /** Function to return the folder name from the path */

--- a/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
@@ -2,16 +2,16 @@ package com.databricks.jdbc.model.telemetry;
 
 import com.databricks.jdbc.common.AuthFlow;
 import com.databricks.jdbc.common.AuthMech;
-import com.databricks.jdbc.common.DatabricksClientType;
 import com.databricks.sdk.support.ToStringer;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 public class DriverConnectionParameters {
   @JsonProperty("http_path")
   String httpPath;
 
   @JsonProperty("mode")
-  DatabricksClientType driverMode;
+  String driverMode;
 
   @JsonProperty("host_info")
   HostDetails hostDetails;
@@ -106,13 +106,43 @@ public class DriverConnectionParameters {
   @JsonProperty("enable_token_cache")
   boolean enableTokenCache;
 
+  @JsonProperty("auth_endpoint")
+  String authEndpoint;
+
+  @JsonProperty("token_endpoint")
+  String tokenEndpoint;
+
+  @JsonProperty("non_proxy_hosts")
+  List<String> nonProxyHosts;
+
+  @JsonProperty("http_connection_pool_size")
+  int httpConnectionPoolSize;
+
+  @JsonProperty("enable_sea_hybrid_results")
+  boolean enableSeaHybridResults;
+
+  @JsonProperty("enable_complex_datatype_support")
+  boolean enableComplexSupport;
+
+  @JsonProperty("allow_self_signed_support")
+  boolean allowSelfSignedSupport;
+
+  @JsonProperty("use_system_trust_store")
+  boolean useSystemTrustStore;
+
+  @JsonProperty("rows_fetched_per_block")
+  int rowsFetchedPerBlock;
+
+  @JsonProperty("async_poll_interval_millis")
+  int asyncPollIntervalMillis;
+
   public DriverConnectionParameters setHttpPath(String httpPath) {
     this.httpPath = httpPath;
     return this;
   }
 
-  public DriverConnectionParameters setDriverMode(DatabricksClientType clientType) {
-    this.driverMode = clientType;
+  public DriverConnectionParameters setDriverMode(String clientType) {
+    this.driverMode = clientType.toString();
     return this;
   }
 
@@ -276,6 +306,56 @@ public class DriverConnectionParameters {
     return this;
   }
 
+  public DriverConnectionParameters setAuthEndpoint(String authEndpoint) {
+    this.authEndpoint = authEndpoint;
+    return this;
+  }
+
+  public DriverConnectionParameters setTokenEndpoint(String tokenEndpoint) {
+    this.tokenEndpoint = tokenEndpoint;
+    return this;
+  }
+
+  public DriverConnectionParameters setNonProxyHosts(List<String> nonProxyHosts) {
+    this.nonProxyHosts = nonProxyHosts;
+    return this;
+  }
+
+  public DriverConnectionParameters setHttpConnectionPoolSize(int httpConnectionPoolSize) {
+    this.httpConnectionPoolSize = httpConnectionPoolSize;
+    return this;
+  }
+
+  public DriverConnectionParameters setEnableSeaHybridResults(boolean enableSeaHybridResults) {
+    this.enableSeaHybridResults = enableSeaHybridResults;
+    return this;
+  }
+
+  public DriverConnectionParameters setEnableComplexSupport(boolean enableComplexSupport) {
+    this.enableComplexSupport = enableComplexSupport;
+    return this;
+  }
+
+  public DriverConnectionParameters setAllowSelfSignedSupport(boolean allowSelfSignedSupport) {
+    this.allowSelfSignedSupport = allowSelfSignedSupport;
+    return this;
+  }
+
+  public DriverConnectionParameters setUseSystemTrustStore(boolean useSystemTrustStore) {
+    this.useSystemTrustStore = useSystemTrustStore;
+    return this;
+  }
+
+  public DriverConnectionParameters setRowsFetchedPerBlock(int rowsFetchedPerBlock) {
+    this.rowsFetchedPerBlock = rowsFetchedPerBlock;
+    return this;
+  }
+
+  public DriverConnectionParameters setAsyncPollIntervalMillis(int asyncPollIntervalMillis) {
+    this.asyncPollIntervalMillis = asyncPollIntervalMillis;
+    return this;
+  }
+
   @Override
   public String toString() {
     return new ToStringer(DriverConnectionParameters.class)
@@ -300,6 +380,7 @@ public class DriverConnectionParameters {
         .add("acceptUndeterminedCertificateRevocation", acceptUndeterminedCertificateRevocation)
         .add("enableArrow", enableArrow)
         .add("enableDirectResults", enableDirectResults)
+        .add("enableJwtAssertion", enableJwtAssertion)
         .add("jwtKeyFile", jwtKeyFile)
         .add("jwtAlgorithm", jwtAlgorithm)
         .add("googleServiceAccount", googleServiceAccount)
@@ -311,6 +392,16 @@ public class DriverConnectionParameters {
         .add("stringColumnLength", stringColumnLength)
         .add("socketTimeout", socketTimeout)
         .add("enableTokenCache", enableTokenCache)
+        .add("authEndpoint", authEndpoint)
+        .add("tokenEndpoint", tokenEndpoint)
+        .add("nonProxyHosts", nonProxyHosts)
+        .add("httpConnectionPoolSize", httpConnectionPoolSize)
+        .add("enableSeaHybridResults", enableSeaHybridResults)
+        .add("enableComplexSupport", enableComplexSupport)
+        .add("allowSelfSignedSupport", allowSelfSignedSupport)
+        .add("useSystemTrustStore", useSystemTrustStore)
+        .add("rowsFetchedPerBlock", rowsFetchedPerBlock)
+        .add("asyncPollIntervalMillis", asyncPollIntervalMillis)
         .toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -3,6 +3,7 @@ package com.databricks.jdbc.telemetry;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.common.util.DriverUtil;
+import com.databricks.jdbc.common.util.StringUtil;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.model.telemetry.*;
@@ -209,7 +210,17 @@ public class TelemetryHelper {
             .setCheckCertificateRevocation(connectionContext.checkCertificateRevocation())
             .setAcceptUndeterminedCertificateRevocation(
                 connectionContext.acceptUndeterminedCertificateRevocation())
-            .setDriverMode(connectionContext.getClientType())
+            .setDriverMode(connectionContext.getClientType().toString())
+            .setAuthEndpoint(connectionContext.getAuthEndpoint())
+            .setTokenEndpoint(connectionContext.getTokenEndpoint())
+            .setNonProxyHosts(StringUtil.split(connectionContext.getNonProxyHosts()))
+            .setHttpConnectionPoolSize(connectionContext.getHttpConnectionPoolSize())
+            .setEnableSeaHybridResults(connectionContext.isSqlExecHybridResultsEnabled())
+            .setEnableComplexSupport(connectionContext.isComplexDatatypeSupportEnabled())
+            .setAllowSelfSignedSupport(connectionContext.allowSelfSignedCerts())
+            .setUseSystemTrustStore(connectionContext.useSystemTrustStore())
+            .setRowsFetchedPerBlock(connectionContext.getRowsFetchedPerBlock())
+            .setAsyncPollIntervalMillis(connectionContext.getAsyncExecPollInterval())
             .setEnableTokenCache(connectionContext.isTokenCacheEnabled())
             .setHttpPath(connectionContext.getHttpPath());
     if (connectionContext.useJWTAssertion()) {

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.DatabricksClientType;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.model.telemetry.SqlExecutionEvent;
@@ -27,6 +28,7 @@ public class TelemetryHelperTest {
     when(connectionContext.getProxyAuthType()).thenReturn(ProxyConfig.ProxyAuthType.BASIC);
     when(connectionContext.getProxyPort()).thenReturn(443);
     when(connectionContext.getProxyHost()).thenReturn(TEST_STRING);
+    when(connectionContext.getClientType()).thenReturn(DatabricksClientType.SEA);
     when(connectionContext.getUseCloudFetchProxy()).thenReturn(true);
     when(connectionContext.getCloudFetchProxyAuthType())
         .thenReturn(ProxyConfig.ProxyAuthType.BASIC);
@@ -43,6 +45,7 @@ public class TelemetryHelperTest {
   @Test
   void testHostFetchThrowsErrorInTelemetryLog() throws DatabricksParsingException {
     when(connectionContext.getConnectionUuid()).thenReturn(UUID.randomUUID().toString());
+    when(connectionContext.getClientType()).thenReturn(DatabricksClientType.SEA);
     when(connectionContext.getHostUrl())
         .thenThrow(
             new DatabricksParsingException(TEST_STRING, DatabricksDriverErrorCode.INVALID_STATE));
@@ -52,6 +55,7 @@ public class TelemetryHelperTest {
   @Test
   void testLatencyTelemetryLogDoesNotThrowError() {
     when(connectionContext.getConnectionUuid()).thenReturn(TEST_STRING);
+    when(connectionContext.getClientType()).thenReturn(DatabricksClientType.SEA);
     SqlExecutionEvent event = new SqlExecutionEvent().setDriverStatementType(StatementType.QUERY);
     assertDoesNotThrow(() -> TelemetryHelper.exportLatencyLog(connectionContext, 150, event, null));
   }
@@ -59,7 +63,6 @@ public class TelemetryHelperTest {
   @Test
   void testErrorTelemetryLogDoesNotThrowError() {
     when(connectionContext.getConnectionUuid()).thenReturn(TEST_STRING);
-    SqlExecutionEvent event = new SqlExecutionEvent().setDriverStatementType(StatementType.QUERY);
     assertDoesNotThrow(
         () -> TelemetryHelper.exportFailureLog(connectionContext, TEST_STRING, TEST_STRING));
   }


### PR DESCRIPTION
## Description
- More proto fields are added to incorporate different kind of connection parameters in the driver, this PR makes the client side telemetry to be inline with the proto

NO_CHANGELOG=true

## Testing
- unit testing added

## Additional Notes to the Reviewer
- Proto changes change : https://github.com/databricks-eng/universe/pull/1083688
