### PR TITLE
Configure NVD API key for dependency check plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Publish to the Maven Central Repository
-        run: mvn -Prelease --batch-mode deploy
+        run: mvn -Prelease --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,9 @@
               This helps us identify and address significant security risks early in the development process.
            -->
           <failBuildOnCVSS>7</failBuildOnCVSS>
+          <nvdApiKey>${nvd.api.key}</nvdApiKey>
+          <nvdMaxRetryCount>10</nvdMaxRetryCount>
+          <nvdApiDelay>4000</nvdApiDelay>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
NO_CHANGELOG=true

## Description
- Add nvdApiKey configuration to OWASP dependency-check-maven plugin
- Configure retry settings and API delay for better performance
- Update GitHub Actions workflow to pass NVD_API_KEY secret
- Resolves warning about missing NVD API key and improves scan performance

Without this, release shows a warning: An NVD API Key was not provided - it is highly recommended to use an NVD API key as the update can take a VERY long time without an API Key

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

