### PR TITLE
resolve flaky ChunkLinkDownloadServiceTest.testBatchDownloadChaining …

### DIFF
--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadServiceTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadServiceTest.java
@@ -13,6 +13,8 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksValidationException;
 import com.databricks.jdbc.model.core.ExternalLink;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -203,7 +205,7 @@ class ChunkLinkDownloadServiceTest {
   void testBatchDownloadChaining()
       throws DatabricksSQLException, ExecutionException, InterruptedException, TimeoutException {
     // Use a far future date to ensure links are never considered expired
-    String farFutureExpiration = "2030-12-31T23:59:59Z";
+    String farFutureExpiration = Instant.now().plus(10, ChronoUnit.MINUTES).toString();
 
     ExternalLink linkForChunkIndex_1 =
         createExternalLink("test-url", 1L, Collections.emptyMap(), farFutureExpiration);


### PR DESCRIPTION
…in CI

NO_CHANGELOG=true

## Description
The test was intermittently failing on GitHub Actions with getResultChunks() being called 3 times instead of the expected 1 time, while consistently passing locally.

Root cause:
- Race condition between concurrent getLinkForChunk() calls and expired link detection
- Test used expiration date "2025-02-16T00:00:00Z" which could be considered expired depending on SECONDS_BUFFER_FOR_EXPIRY and timing
- When multiple threads detected expired links, they triggered multiple reset operations
- Different thread scheduling between local Mac and GitHub Actions runners exposed the issue

Changes:
- Use far future expiration dates (2030-12-31) to prevent unintended link expiration

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

