### PR TITLE
Logging error, when scale from arrowMetaData is not found

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
@@ -275,9 +275,8 @@ public class ArrowToJavaObjectConverter {
                   .substring(arrowMetadata.indexOf(',') + 1, arrowMetadata.indexOf(')'))
                   .trim());
     } catch (Exception e) {
-      LOGGER.error(e,
-          "Failed to parse scale from arrow metadata: {}. Defaulting to scale 0",
-          arrowMetadata);
+      LOGGER.error(
+          e, "Failed to parse scale from arrow metadata: {}. Defaulting to scale 0", arrowMetadata);
       scale = 0;
     }
     if (object instanceof Number) {


### PR DESCRIPTION
## Description
Logging error, when scale from arrowMetaData is not found

`NO_CHANGELOG=true`