### PR TITLE
[PECOBLR-530] Fix leak in preparedStatement + fix interpolation in metadata

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added support for DoD (.mil) domains
-- Support to fetch metadata in PreparedStatement for SELECT queries before executing the query.
+- Enables fetching of metadata for SELECT queries using PreparedStatement prior to setting parameters or executing the query.
 - Added support for SSL client certificate authentication via keystore configuration parameters: SSLKeyStore, SSLKeyStorePwd, SSLKeyStoreType, and SSLKeyStoreProvider.
 
 

--- a/src/main/java/com/databricks/jdbc/common/util/SQLInterpolator.java
+++ b/src/main/java/com/databricks/jdbc/common/util/SQLInterpolator.java
@@ -6,6 +6,8 @@ import com.databricks.jdbc.api.impl.ImmutableSqlParameter;
 import com.databricks.jdbc.exception.DatabricksValidationException;
 import com.databricks.sdk.service.sql.ColumnInfoTypeName;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SQLInterpolator {
   private static String escapeApostrophes(String input) {
@@ -65,6 +67,24 @@ public class SQLInterpolator {
         sb.append(formatObject(params.get(i + 1))); // because we have 1 based index in params
       }
     }
+    return sb.toString();
+  }
+
+  /**
+   * Surrounds unquoted placeholders (?) with single quotes, preserving already quoted ones. This is
+   * crucial for DESCRIBE QUERY commands as unquoted placeholders will cause a parse_syntax_error.
+   */
+  public static String surroundPlaceholdersWithQuotes(String sql) {
+    if (sql == null || sql.isEmpty()) {
+      return sql;
+    }
+    // This pattern matches any '?' that is NOT already inside single quotes
+    StringBuilder sb = new StringBuilder();
+    Matcher m = Pattern.compile("(?<!')\\?(?!')").matcher(sql);
+    while (m.find()) {
+      m.appendReplacement(sb, "'?'");
+    }
+    m.appendTail(sb);
     return sb.toString();
   }
 }

--- a/src/test/java/com/databricks/jdbc/common/util/SQLInterpolatorTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/SQLInterpolatorTest.java
@@ -9,7 +9,11 @@ import com.databricks.jdbc.api.impl.ImmutableSqlParameter;
 import com.databricks.jdbc.exception.DatabricksValidationException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class SQLInterpolatorTest {
 
@@ -86,5 +90,53 @@ public class SQLInterpolatorTest {
     params.put(2, getSqlParam(2, "X'0102030405'", DatabricksTypeUtil.BINARY));
     String expected = "INSERT INTO sales (id, data) VALUES (101, X'0102030405')";
     assertEquals(expected, SQLInterpolator.interpolateSQL(sql, params));
+  }
+
+  private static Stream<Arguments> providePlaceholderQuotingTestCases() {
+    return Stream.of(
+        // Basic placeholder quoting
+        Arguments.of(
+            "SELECT * FROM table WHERE id = ?",
+            "SELECT * FROM table WHERE id = '?'",
+            "Basic placeholder quoting"),
+
+        // Multiple placeholders
+        Arguments.of(
+            "SELECT * FROM table WHERE id = ? AND name = ?",
+            "SELECT * FROM table WHERE id = '?' AND name = '?'",
+            "Multiple placeholders"),
+
+        // Already quoted placeholders
+        Arguments.of(
+            "SELECT * FROM table WHERE id = '?' AND name = ?",
+            "SELECT * FROM table WHERE id = '?' AND name = '?'",
+            "Already quoted placeholders"),
+
+        // Mixed quoted and unquoted placeholders
+        Arguments.of(
+            "SELECT * FROM table WHERE id = '?' AND name = ? AND age = '?'",
+            "SELECT * FROM table WHERE id = '?' AND name = '?' AND age = '?'",
+            "Mixed quoted and unquoted placeholders"),
+
+        // Null input
+        Arguments.of(null, null, "Null input"),
+
+        // Empty input
+        Arguments.of("", "", "Empty input"),
+
+        // No placeholders
+        Arguments.of("SELECT * FROM table", "SELECT * FROM table", "No placeholders"),
+
+        // Complex query with multiple conditions
+        Arguments.of(
+            "SELECT * FROM table WHERE id = ? AND (name = ? OR age = ?) AND status = ?",
+            "SELECT * FROM table WHERE id = '?' AND (name = '?' OR age = '?') AND status = '?'",
+            "Complex query with multiple conditions"));
+  }
+
+  @ParameterizedTest(name = "{2}")
+  @MethodSource("providePlaceholderQuotingTestCases")
+  public void testSurroundPlaceholdersWithQuotes(String input, String expected, String testName) {
+    assertEquals(expected, SQLInterpolator.surroundPlaceholdersWithQuotes(input), testName);
   }
 }


### PR DESCRIPTION
## Description

This PR does 2 things : 
1. Closes the describe query statement in preparedStatement (fix the leak)
2. Fixes the errors when sql does not have parameters defined (Otherwise a parsing error is thrown from the backend). For example `Describe select ?` fails whereas `Describe select '?'` passes


## Testing
- The  leakage in our driver is fixed after this code change. Verified by using a serverless warehouse I created on dogfood `samikshya-test-small-warehouse`. The warehouse closes within 5 minutes (which is the timeout I have set too)

Code used :

```
Connection connection = DriverManager.getConnection(JDBC_URL, USERNAME, PASSWORD);
PreparedStatement preparedStatement = connection.prepareStatement("select 1");
ResultSetMetaData rs= preparedStatement.getMetaData();
```

<img width="237" alt="Screenshot 2025-06-03 at 9 19 32 PM" src="https://github.com/user-attachments/assets/46a08583-4621-49bc-be4c-6c9ea7b0cc57" />


## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

