### PR TITLE
Add api key in OWASP weekly vulnerability scan

### DIFF
--- a/.github/workflows/vulnerabilityCatcher.yml
+++ b/.github/workflows/vulnerabilityCatcher.yml
@@ -23,7 +23,7 @@ jobs:
           cache: maven
 
       - name: Run OWASP Dependency Check
-        run: mvn org.owasp:dependency-check-maven:check
+        run: mvn org.owasp:dependency-check-maven:check -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
 
       - name: Check for vulnerabilities
         id: check_vulnerabilities


### PR DESCRIPTION
## Description
- Adding an NVD Key to make weekly scans faster. The weekly scans were broken but now they are fixed and will run every Sunday.
- Note that we already have vulnerability scans during release. So, any CVE would block the release.

## Testing
- tested the run locally using my NVD key

## Additional Notes to the Reviewer
- Note : Integration tests are breaking because of a known orthogonal issue, and the team is fixing it. 

NO_CHANGELOG=true

