### PR TITLE
[SEC-11759] Fix vulnerable GH action

### DIFF
--- a/.github/workflows/loggingTesting.yml
+++ b/.github/workflows/loggingTesting.yml
@@ -1,17 +1,15 @@
 name: Test JDBC Logging
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to checkout'
         required: false
         default: 'main'
-      repository:
-        description: 'Repository to checkout (e.g., user/repo)'
-        required: false
-        default: 'databricks/databricks-jdbc'
-  pull_request_target:
 
 jobs:
   test-logging:
@@ -33,8 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || inputs.branch }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/prCheckJDK8.yml
+++ b/.github/workflows/prCheckJDK8.yml
@@ -1,7 +1,7 @@
 name: JDK 8 Build and Test
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [jdk-8]
 

--- a/.github/workflows/prIntegrationTests.yml
+++ b/.github/workflows/prIntegrationTests.yml
@@ -1,0 +1,37 @@
+name: Integration Tests Workflow - Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build and Run Integration Tests (PR)
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - test-command: mvn -B compile test -Dtest=*IntegrationTests
+            fake-service-type: 'SQL_EXEC'
+          - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!SqlExecApiHybridResultsIntegrationTests,!DBFSVolumeIntegrationTests,!M2MAuthIntegrationTests,!UCVolumeIntegrationTests
+            fake-service-type: 'THRIFT_SERVER'
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'adopt'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Integration Tests (without secrets)
+        run: ${{ matrix.test-command }}
+        env:
+          FAKE_SERVICE_TYPE: ${{ matrix.fake-service-type }} 

--- a/.github/workflows/proxyTesting.yml
+++ b/.github/workflows/proxyTesting.yml
@@ -1,17 +1,8 @@
 name: Proxy Test with Dual Squid Proxies
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to checkout'
-        required: false
-        default: 'main'
-      repository:
-        description: 'Repository to checkout (e.g., user/repo)'
-        required: false
-        default: 'databricks/databricks-jdbc'
-  pull_request_target:
+  push:
+    branches: [main]
 
 jobs:
   proxy-test:
@@ -25,9 +16,6 @@ jobs:
       ################################################################
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref || inputs.branch }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository }}
 
       ################################################################
       # 2) Set Up Java

--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -1,21 +1,8 @@
-name: Integration Tests Workflow
+name: Integration Tests Workflow - Main Branch
 
 on:
   push:
     branches: [main]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to checkout'
-        required: false
-        default: 'main'
-      repository:
-        description: 'Repository to checkout (e.g., user/repo)'
-        required: false
-        default: 'databricks/databricks-jdbc'
 
 jobs:
   build-and-test:
@@ -34,12 +21,8 @@ jobs:
             token-secret: THRIFT_DATABRICKS_TOKEN
             fake-service-type: 'THRIFT_SERVER'
     steps:
-      - name: Checkout PR or Manual Dispatch
+      - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref || inputs.branch || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Description

 - `pull_request_target` ensures the workflow file from base repo is used for running code submitted in the PR by contributors. But, the PR author could submit a malicious script, and since it’s running on a trusted workflow file, it might access tokens, secrets.

- Workflows triggered by `pull_request_target` events are run in the context of the base branch. Since the base branch is considered trusted, workflows triggered by these events will always run, regardless of approval settings.

- In this PR : 
  - Added loggingTest and ssl/proxy to run only on mainline, rather than on every PR (as this touches internal workspaces)
  - Added separate flow for PR integration tests (as they touch the JWT Integration test)

## Testing
- This won't be tested in this PR, only when the change reaches the `main` branch, we can test this out

## Additional Notes to the Reviewer
- We will have to exclude a few tests from PR integration tests, will raise that in the followup PR. Some of our tests are not truly fake and require certain env variables

NO_CHANGELOG=true

