### PR TITLE
feat: Add W3C Trace Context support for distributed tracing

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
@@ -256,6 +256,18 @@ public interface IDatabricksConnectionContext {
   /** Returns true if request tracing should be enabled. */
   boolean isRequestTracingEnabled();
 
+  /** Returns the W3C Trace Context traceparent header if provided. */
+  String getTraceParent();
+
+  /** Returns the W3C Trace Context tracestate header if provided. */
+  String getTraceState();
+
+  /** Returns the trace ID for this connection (extracted or generated). */
+  String getTraceId();
+
+  /** Returns the trace flags for this connection. */
+  String getTraceFlags();
+
   /** Returns maximum number of characters that can be contained in STRING columns. */
   int getDefaultStringColumnLength();
 

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -129,6 +129,8 @@ public enum DatabricksJdbcUrlParams {
   TOKEN_CACHE_PASS_PHRASE("TokenCachePassPhrase", "Pass phrase to use for OAuth U2M Token Cache"),
   ENABLE_TOKEN_CACHE("EnableTokenCache", "Enable caching OAuth tokens", "1"),
   APPLICATION_NAME("ApplicationName", "Name of application using the driver", ""),
+  TRACE_PARENT("TraceParent", "W3C Trace Context traceparent header to propagate", ""),
+  TRACE_STATE("TraceState", "W3C Trace Context tracestate header to propagate", ""),
   ;
 
   private final String paramName;

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/TracingUtil.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/TracingUtil.java
@@ -1,24 +1,146 @@
 package com.databricks.jdbc.dbclient.impl.common;
 
-/** Utility class to support request tracing */
+import java.security.SecureRandom;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Utility class to support W3C Trace Context request tracing */
 public final class TracingUtil {
 
   public static final String TRACE_HEADER = "traceparent";
+  public static final String TRACE_STATE_HEADER = "tracestate";
 
   private static final String SEED_CHARACTERS = "0123456789abcdef";
-  private static final int SEED_CHARACTERS_LENGTH = SEED_CHARACTERS.length();
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  public static String getTraceHeader() {
-    // Construct the string with the specified format
-    return String.format("00-%s-%s-01", randomSegment(32), randomSegment(16));
+  // W3C Trace Context format: version-trace-id-parent-id-trace-flags
+  private static final Pattern TRACEPARENT_PATTERN =
+      Pattern.compile("^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$");
+
+  private static final String VERSION = "00";
+  private static final String DEFAULT_FLAGS = "01"; // sampled
+
+  private TracingUtil() {
+    // Utility class
+  }
+
+  /**
+   * Validates a W3C traceparent header format.
+   *
+   * @param traceparent The traceparent header to validate
+   * @return true if valid, false otherwise
+   */
+  public static boolean isValidTraceparent(String traceparent) {
+    if (traceparent == null || traceparent.isEmpty()) {
+      return false;
+    }
+
+    Matcher matcher = TRACEPARENT_PATTERN.matcher(traceparent.toLowerCase());
+    if (!matcher.matches()) {
+      return false;
+    }
+
+    // Only support version 00 for now
+    String version = matcher.group(1);
+    return VERSION.equals(version);
+  }
+
+  /**
+   * Extracts the trace ID from a valid traceparent header.
+   *
+   * @param traceparent The traceparent header
+   * @return The trace ID or null if invalid
+   */
+  public static String extractTraceId(String traceparent) {
+    if (!isValidTraceparent(traceparent)) {
+      return null;
+    }
+
+    Matcher matcher = TRACEPARENT_PATTERN.matcher(traceparent.toLowerCase());
+    if (matcher.matches()) {
+      return matcher.group(2);
+    }
+    return null;
+  }
+
+  /**
+   * Extracts the trace flags from a valid traceparent header.
+   *
+   * @param traceparent The traceparent header
+   * @return The trace flags or null if invalid
+   */
+  public static String extractTraceFlags(String traceparent) {
+    if (!isValidTraceparent(traceparent)) {
+      return null;
+    }
+
+    Matcher matcher = TRACEPARENT_PATTERN.matcher(traceparent.toLowerCase());
+    if (matcher.matches()) {
+      return matcher.group(4);
+    }
+    return null;
+  }
+
+  /**
+   * Generates a new trace ID.
+   *
+   * @return A 32-character hex trace ID
+   */
+  public static String generateTraceId() {
+    return randomSegment(32);
+  }
+
+  /**
+   * Generates a new span ID.
+   *
+   * @return A 16-character hex span ID
+   */
+  public static String generateSpanId() {
+    return randomSegment(16);
+  }
+
+  /**
+   * Builds a W3C compliant traceparent header.
+   *
+   * @param traceId The trace ID (32 hex characters)
+   * @param spanId The span ID (16 hex characters)
+   * @param traceFlags The trace flags (2 hex characters)
+   * @return The formatted traceparent header
+   */
+  public static String buildTraceparent(String traceId, String spanId, String traceFlags) {
+    return String.format("%s-%s-%s-%s", VERSION, traceId, spanId, traceFlags);
+  }
+
+  /**
+   * Generates a complete traceparent header with new IDs.
+   *
+   * @return A new traceparent header
+   */
+  public static String generateTraceparent() {
+    return buildTraceparent(generateTraceId(), generateSpanId(), DEFAULT_FLAGS);
+  }
+
+  /**
+   * Generates a traceparent header with the given trace ID and flags, and a new span ID.
+   *
+   * @param traceId The trace ID to use
+   * @param traceFlags The trace flags to use
+   * @return A traceparent header with new span ID
+   */
+  public static String generateTraceparentWithTraceId(String traceId, String traceFlags) {
+    return buildTraceparent(traceId, generateSpanId(), traceFlags);
   }
 
   private static String randomSegment(int length) {
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i < length; i++) {
-      result.append(
-          SEED_CHARACTERS.charAt((int) Math.floor(Math.random() * SEED_CHARACTERS_LENGTH)));
+    StringBuilder result = new StringBuilder(length);
+    byte[] bytes = new byte[length / 2];
+    SECURE_RANDOM.nextBytes(bytes);
+
+    for (byte b : bytes) {
+      result.append(SEED_CHARACTERS.charAt((b >> 4) & 0xF));
+      result.append(SEED_CHARACTERS.charAt(b & 0xF));
     }
+
     return result.toString();
   }
 }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -450,10 +450,18 @@ public class DatabricksSdkClient implements IDatabricksClient {
 
   private Map<String, String> getHeaders(String method) {
     Map<String, String> headers = new HashMap<>(JSON_HTTP_HEADERS);
-    if (connectionContext.isRequestTracingEnabled()) {
-      String traceHeader = TracingUtil.getTraceHeader();
+    if (connectionContext.isRequestTracingEnabled() && connectionContext.getTraceId() != null) {
+      String traceHeader =
+          TracingUtil.generateTraceparentWithTraceId(
+              connectionContext.getTraceId(), connectionContext.getTraceFlags());
       LOGGER.debug("Tracing header for method {}: [{}]", method, traceHeader);
       headers.put(TracingUtil.TRACE_HEADER, traceHeader);
+
+      // Add tracestate if present
+      String traceState = connectionContext.getTraceState();
+      if (traceState != null && !traceState.isEmpty()) {
+        headers.put(TracingUtil.TRACE_STATE_HEADER, traceState);
+      }
     }
 
     // Overriding with URL defined headers

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksHttpTTransport.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksHttpTTransport.java
@@ -110,11 +110,18 @@ public class DatabricksHttpTTransport extends TTransport {
     // Overriding with URL defined headers
     this.connectionContext.getCustomHeaders().forEach(request::setHeader);
 
-    if (connectionContext.isRequestTracingEnabled()) {
-      String traceHeader = TracingUtil.getTraceHeader();
+    if (connectionContext.isRequestTracingEnabled() && connectionContext.getTraceId() != null) {
+      String traceHeader =
+          TracingUtil.generateTraceparentWithTraceId(
+              connectionContext.getTraceId(), connectionContext.getTraceFlags());
       LOGGER.debug("Thrift tracing header: " + traceHeader);
-
       request.addHeader(TracingUtil.TRACE_HEADER, traceHeader);
+
+      // Add tracestate if present
+      String traceState = connectionContext.getTraceState();
+      if (traceState != null && !traceState.isEmpty()) {
+        request.addHeader(TracingUtil.TRACE_STATE_HEADER, traceState);
+      }
     }
 
     // Set the request entity

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/TracingUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/TracingUtilTest.java
@@ -1,0 +1,109 @@
+package com.databricks.jdbc.dbclient.impl.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+public class TracingUtilTest {
+
+  private static final Pattern TRACEPARENT_PATTERN =
+      Pattern.compile("^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$");
+
+  @Test
+  void testGenerateTraceparentGeneratesValidFormat() {
+    String traceHeader = TracingUtil.generateTraceparent();
+    assertNotNull(traceHeader);
+    assertTrue(
+        TRACEPARENT_PATTERN.matcher(traceHeader).matches(),
+        "Trace header should match W3C format: " + traceHeader);
+  }
+
+  @Test
+  void testValidateTraceparent() {
+    String validTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assertTrue(TracingUtil.isValidTraceparent(validTraceparent));
+
+    // Test invalid formats
+    assertFalse(TracingUtil.isValidTraceparent(null));
+    assertFalse(TracingUtil.isValidTraceparent(""));
+    assertFalse(TracingUtil.isValidTraceparent("invalid-format"));
+    assertFalse(TracingUtil.isValidTraceparent("00-invalid-00f067aa0ba902b7-01"));
+    assertFalse(
+        TracingUtil.isValidTraceparent(
+            "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")); // wrong version
+  }
+
+  @Test
+  void testExtractTraceId() {
+    String validTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assertEquals("4bf92f3577b34da6a3ce929d0e0e4736", TracingUtil.extractTraceId(validTraceparent));
+
+    // Invalid traceparent should return null
+    assertNull(TracingUtil.extractTraceId("invalid-format"));
+    assertNull(TracingUtil.extractTraceId(null));
+  }
+
+  @Test
+  void testExtractTraceFlags() {
+    String validTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    assertEquals("01", TracingUtil.extractTraceFlags(validTraceparent));
+
+    // Invalid traceparent should return null
+    assertNull(TracingUtil.extractTraceFlags("invalid-format"));
+    assertNull(TracingUtil.extractTraceFlags(null));
+  }
+
+  @Test
+  void testGenerateTraceparentWithTraceId() {
+    String traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    String traceFlags = "01";
+
+    String header1 = TracingUtil.generateTraceparentWithTraceId(traceId, traceFlags);
+    String header2 = TracingUtil.generateTraceparentWithTraceId(traceId, traceFlags);
+
+    // Both should have same trace ID
+    assertTrue(header1.contains(traceId));
+    assertTrue(header2.contains(traceId));
+
+    // But different span IDs
+    String spanId1 = extractSpanId(header1);
+    String spanId2 = extractSpanId(header2);
+    assertNotEquals(spanId1, spanId2);
+  }
+
+  @Test
+  void testBuildTraceparent() {
+    String traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    String spanId = "00f067aa0ba902b7";
+    String traceFlags = "01";
+
+    String result = TracingUtil.buildTraceparent(traceId, spanId, traceFlags);
+    assertEquals("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", result);
+  }
+
+  @Test
+  void testGenerateIds() {
+    // Test trace ID generation
+    String traceId = TracingUtil.generateTraceId();
+    assertNotNull(traceId);
+    assertEquals(32, traceId.length());
+    assertTrue(traceId.matches("[0-9a-f]{32}"));
+
+    // Test span ID generation
+    String spanId = TracingUtil.generateSpanId();
+    assertNotNull(spanId);
+    assertEquals(16, spanId.length());
+    assertTrue(spanId.matches("[0-9a-f]{16}"));
+
+    // IDs should be different each time
+    assertNotEquals(traceId, TracingUtil.generateTraceId());
+    assertNotEquals(spanId, TracingUtil.generateSpanId());
+  }
+
+  private String extractSpanId(String traceparent) {
+    var matcher = TRACEPARENT_PATTERN.matcher(traceparent);
+    assertTrue(matcher.matches());
+    return matcher.group(3);
+  }
+}

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientTest.java
@@ -45,7 +45,8 @@ public class DatabricksHttpClientTest {
 
   @BeforeEach
   public void setUp() {
-    databricksHttpClient = new DatabricksHttpClient(mockHttpClient, mockConnectionManager);
+    databricksHttpClient =
+        new DatabricksHttpClient(mockHttpClient, mockConnectionManager, mockConnectionContext);
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksHttpTTransportTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksHttpTTransportTest.java
@@ -110,6 +110,8 @@ public class DatabricksHttpTTransportTest {
     when(mockEntity.getContent()).thenReturn(new ByteArrayInputStream(testData));
     when(mockedHttpClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
     when(mockConnectionContext.isRequestTracingEnabled()).thenReturn(true);
+    when(mockConnectionContext.getTraceId()).thenReturn("4bf92f3577b34da6a3ce929d0e0e4736");
+    when(mockConnectionContext.getTraceFlags()).thenReturn("01");
 
     transport.flush();
     ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);


### PR DESCRIPTION
  ## Summary

  This PR adds W3C Trace Context (traceparent/tracestate) header support to the Databricks JDBC
   driver, enabling distributed tracing across service boundaries. The implementation follows
  the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/) and allows trace
  context propagation for better observability.

  ## Changes

  ### Core Implementation
  - **TracingUtil**: Added utility class for W3C trace context operations
    - Validates and parses traceparent headers
    - Generates trace IDs and span IDs
    - Builds W3C-compliant traceparent headers

  - **Connection Context**: Enhanced to store trace context at connection scope
    - Added `TraceParent` and `TraceState` connection parameters
    - Stores extracted/generated trace ID and flags per connection
    - Initializes trace context when connection is created

  - **HTTP Headers**: Added traceparent/tracestate headers to all HTTP requests
    - DatabricksHttpClient (volume operations, telemetry)
    - Thrift transport (Thrift protocol requests)
    - SDK client (SQL execution API requests)

  ### Configuration
  New connection parameters:
  - `EnableRequestTracing=1` - Enable trace context headers (existing, now enhanced)
  - `TraceParent=<header>` - Provide external W3C traceparent header
  - `TraceState=<header>` - Provide vendor-specific trace state

  ### Design Decisions
  - **Connection-scoped**: Trace context is scoped to connection lifetime, not thread-local
    - Avoids issues with connection pooling and async operations
    - Context follows the connection across thread boundaries
  - **Stateless utility**: TracingUtil is a pure utility class with no state
  - **Backward compatible**: Existing `EnableRequestTracing` behavior preserved

  ## Usage Examples

  ```java
  // Auto-generate trace context
  jdbc:databricks://host:port/db;EnableRequestTracing=1

  // Propagate existing trace context
  jdbc:databricks://host:port/db;EnableRequestTracing=1;TraceParent=00-4bf92f3577b34da6a3ce929d
  0e0e4736-00f067aa0ba902b7-01

  // With trace state
  jdbc:databricks://host:port/db;EnableRequestTracing=1;TraceParent=00-4bf92f3577b34da6a3ce929d
  0e0e4736-00f067aa0ba902b7-01;TraceState=vendor1=value1

  Testing

  - Added comprehensive unit tests for TracingUtil
  - Tests cover W3C format validation, ID generation, and header building
  - All existing tests pass

  Impact

  - Enables distributed tracing for Databricks JDBC applications
  - Helps debug and monitor cross-service request flows
  - No impact when tracing is disabled (default)

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

