### PR TITLE
exclude m2m tests in pr checks

### DIFF
--- a/.github/workflows/prIntegrationTests.yml
+++ b/.github/workflows/prIntegrationTests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - test-command: mvn -B compile test -Dtest=*IntegrationTests
+          - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!M2MAuthIntegrationTests
             fake-service-type: 'SQL_EXEC'
           - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!SqlExecApiHybridResultsIntegrationTests,!DBFSVolumeIntegrationTests,!M2MAuthIntegrationTests,!UCVolumeIntegrationTests
             fake-service-type: 'THRIFT_SERVER'

--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - test-command: mvn -B compile test -Dtest=*IntegrationTests
+          - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!M2MAuthIntegrationTests
             token-secret: DATABRICKS_TOKEN
             fake-service-type: 'SQL_EXEC'
           - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!SqlExecApiHybridResultsIntegrationTests,!DBFSVolumeIntegrationTests,!M2MAuthIntegrationTests,!UCVolumeIntegrationTests

--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!M2MAuthIntegrationTests
+          - test-command: mvn -B compile test -Dtest=*IntegrationTests
             token-secret: DATABRICKS_TOKEN
             fake-service-type: 'SQL_EXEC'
           - test-command: mvn -B compile test -Dtest=*IntegrationTests,!M2MPrivateKeyCredentialsIntegrationTests,!SqlExecApiHybridResultsIntegrationTests,!DBFSVolumeIntegrationTests,!M2MAuthIntegrationTests,!UCVolumeIntegrationTests

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/AbstractFakeServiceIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/AbstractFakeServiceIntegrationTests.java
@@ -1,8 +1,8 @@
 package com.databricks.jdbc.integration.fakeservice;
 
-import static com.databricks.jdbc.integration.IntegrationTestUtil.getJWTTokenEndpointHost;
 import static com.databricks.jdbc.integration.fakeservice.FakeServiceConfigLoader.CLOUD_FETCH_HOST_PROP;
 import static com.databricks.jdbc.integration.fakeservice.FakeServiceConfigLoader.DATABRICKS_HOST_PROP;
+import static com.databricks.jdbc.integration.fakeservice.FakeServiceConfigLoader.JWT_TOKEN_ENDPOINT_HOST_PROP;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 import com.databricks.jdbc.common.DatabricksJdbcConstants;
@@ -73,7 +73,7 @@ public abstract class AbstractFakeServiceIntegrationTests {
                           new FakeServiceHttpClientFactory(
                               FakeServiceConfigLoader.getFakeServiceUserAgent()))),
           DatabricksJdbcConstants.FakeServiceType.JWT_TOKEN_ENDPOINT,
-          getJWTTokenEndpointHost());
+          FakeServiceConfigLoader.getProperty(JWT_TOKEN_ENDPOINT_HOST_PROP));
 
   /**
    * Resets the potential mutations (e.g., URLs set by {@link #setDatabricksApiTargetUrl}, {@link

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceConfigLoader.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceConfigLoader.java
@@ -13,6 +13,8 @@ public class FakeServiceConfigLoader {
 
   public static final String PRESIGNED_URL_HOST = "host.presignedurl";
 
+  public static final String JWT_TOKEN_ENDPOINT_HOST_PROP = "host.jwt.token.endpoint";
+
   public static final String TEST_CATALOG = "testcatalog";
 
   public static final String TEST_SCHEMA = "testschema";

--- a/src/test/resources/sqlexecfakeservicetest.properties
+++ b/src/test/resources/sqlexecfakeservicetest.properties
@@ -1,6 +1,7 @@
 host.databricks=https://e2-dogfood.staging.cloud.databricks.com:443
 host.cloudfetch=https://e2-dogfood-core.s3.us-west-2.amazonaws.com
 host.presignedurl=https://us-west-2-extstaging-managed-catalog-test-bucket-1.s3-fips.us-west-2.amazonaws.com
+host.jwt.token.endpoint=https://dev-591123.oktapreview.com
 # SQL warehouse compute
 httppath=/sql/1.0/warehouses/dd43ee29fedd958d
 connschema=default

--- a/src/test/resources/sqlgatewayfakeservicetest.properties
+++ b/src/test/resources/sqlgatewayfakeservicetest.properties
@@ -1,5 +1,6 @@
 host.databricks=https://e2-dogfood.staging.cloud.databricks.com:443
 host.cloudfetch=https://e2-dogfood-core.s3.us-west-2.amazonaws.com
+host.jwt.token.endpoint=https://dev-591123.oktapreview.com
 # SQL warehouse compute
 httppath=/sql/1.0/warehouses/dd43ee29fedd958d
 connschema=default

--- a/src/test/resources/thriftserverfakeservicetest.properties
+++ b/src/test/resources/thriftserverfakeservicetest.properties
@@ -1,5 +1,6 @@
 host.databricks=https://e2-dogfood.staging.cloud.databricks.com:443
 host.cloudfetch=https://e2-dogfood-core.s3.us-west-2.amazonaws.com
+host.jwt.token.endpoint=https://dev-591123.oktapreview.com
 # All-purpose compute
 httppath=/sql/protocolv1/o/6051921418418893/0819-204509-hill72
 connschema=default


### PR DESCRIPTION
## Description
Excluding m2m tests from workflows
This is to remove dependency of m2m tests on secrets.

These tests are calling sdk for token refresh which is failing with error
`Failed to refresh credentials: invalid_client. Config: host=http://localhost:55583/, client_id=85e9d70d-52da-42c5-a1d5-ebac64e758d0, client_secret=***, auth_type=oauth-m2m`

Disabling these tests for now until @jayantsing-db and I figure out how do we fix this.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
NO_CHANGELOG=true

