### PR TITLE
[PECOBLR-591] Add chunk latency telemetry

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -23,6 +23,7 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.jdbc.telemetry.TelemetryClientFactory;
+import com.databricks.jdbc.telemetry.latency.ChunkLatencyHandler;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.*;
 import java.util.*;
@@ -150,6 +151,7 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
     LOGGER.debug("public void close()");
     for (IDatabricksStatementInternal statement : statementSet) {
       statement.close(false);
+      ChunkLatencyHandler.getInstance().clearStatement(statement.getStatementId());
       statementSet.remove(statement);
     }
     this.session.close();

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
@@ -47,7 +47,6 @@ class ChunkDownloadTask implements DatabricksCallableTask {
     boolean downloadSuccessful = false;
 
     // Sets context in the newly spawned thread
-    DatabricksThreadContextHolder.setChunkId(chunk.getChunkIndex());
     DatabricksThreadContextHolder.setConnectionContext(this.connectionContext);
     DatabricksThreadContextHolder.setStatementId(this.statementId);
 
@@ -84,7 +83,9 @@ class ChunkDownloadTask implements DatabricksCallableTask {
             throw new DatabricksSQLException(
                 "Failed to download chunk after multiple attempts",
                 e,
-                DatabricksDriverErrorCode.CHUNK_DOWNLOAD_ERROR);
+                statementId,
+                chunk.getChunkIndex(),
+                DatabricksDriverErrorCode.CHUNK_DOWNLOAD_ERROR.name());
           } else {
             LOGGER.warn(
                 String.format(

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadService.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadService.java
@@ -10,6 +10,7 @@ import com.databricks.jdbc.exception.DatabricksValidationException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.core.ExternalLink;
+import com.databricks.jdbc.telemetry.latency.ChunkLatencyHandler;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
@@ -103,6 +104,7 @@ public class ChunkLinkDownloadService {
     this.isDownloadInProgress = new AtomicBoolean(false);
     this.isDownloadChainStarted = new AtomicBoolean(false);
     this.isShutdown = false;
+    ChunkLatencyHandler.getInstance().initializeStatement(statementId, totalChunks);
 
     this.chunkIndexToLinkFuture = new ConcurrentHashMap<>();
     for (long i = 0; i < totalChunks; i++) {

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThreadContextHolder.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThreadContextHolder.java
@@ -9,7 +9,6 @@ public class DatabricksThreadContextHolder {
   private static final ThreadLocal<IDatabricksConnectionContext> localConnectionContext =
       new ThreadLocal<>();
   private static final ThreadLocal<String> localStatementId = new ThreadLocal<>();
-  private static final ThreadLocal<Long> localChunkId = new ThreadLocal<>();
   private static final ThreadLocal<Integer> localRetryCount = new ThreadLocal<>();
   private static final ThreadLocal<StatementType> localStatementType = new ThreadLocal<>();
   private static final ThreadLocal<String> localSessionId = new ThreadLocal<>();
@@ -61,21 +60,12 @@ public class DatabricksThreadContextHolder {
     return localStatementType.get();
   }
 
-  public static void setChunkId(Long chunkId) {
-    localChunkId.set(chunkId);
-  }
-
-  public static Long getChunkId() {
-    return localChunkId.get();
-  }
-
   public static void clearConnectionContext() {
     localConnectionContext.remove();
   }
 
   public static void clearStatementInfo() {
     localStatementId.remove();
-    localChunkId.remove();
     localStatementType.remove();
     localRetryCount.remove();
   }

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksSQLException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksSQLException.java
@@ -25,6 +25,18 @@ public class DatabricksSQLException extends SQLException {
         reason);
   }
 
+  // This constructor is used to export chunk download failure logs
+  public DatabricksSQLException(
+      String reason, Throwable cause, String statementId, Long chunkIndex, String sqlState) {
+    super(reason, sqlState, cause);
+    exportFailureLog(
+        DatabricksThreadContextHolder.getConnectionContext(),
+        DatabricksDriverErrorCode.CONNECTION_ERROR.name(),
+        reason,
+        chunkIndex,
+        statementId);
+  }
+
   public DatabricksSQLException(String reason, String sqlState) {
     super(reason, sqlState);
     exportFailureLog(DatabricksThreadContextHolder.getConnectionContext(), sqlState, reason);

--- a/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/DriverConnectionParameters.java
@@ -121,9 +121,6 @@ public class DriverConnectionParameters {
   @JsonProperty("enable_sea_hybrid_results")
   boolean enableSeaHybridResults;
 
-  @JsonProperty("enable_complex_datatype_support")
-  boolean enableComplexSupport;
-
   @JsonProperty("allow_self_signed_support")
   boolean allowSelfSignedSupport;
 
@@ -331,11 +328,6 @@ public class DriverConnectionParameters {
     return this;
   }
 
-  public DriverConnectionParameters setEnableComplexSupport(boolean enableComplexSupport) {
-    this.enableComplexSupport = enableComplexSupport;
-    return this;
-  }
-
   public DriverConnectionParameters setAllowSelfSignedSupport(boolean allowSelfSignedSupport) {
     this.allowSelfSignedSupport = allowSelfSignedSupport;
     return this;
@@ -397,7 +389,6 @@ public class DriverConnectionParameters {
         .add("nonProxyHosts", nonProxyHosts)
         .add("httpConnectionPoolSize", httpConnectionPoolSize)
         .add("enableSeaHybridResults", enableSeaHybridResults)
-        .add("enableComplexSupport", enableComplexSupport)
         .add("allowSelfSignedSupport", allowSelfSignedSupport)
         .add("useSystemTrustStore", useSystemTrustStore)
         .add("rowsFetchedPerBlock", rowsFetchedPerBlock)

--- a/src/main/java/com/databricks/jdbc/model/telemetry/latency/ChunkDetails.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/latency/ChunkDetails.java
@@ -12,13 +12,19 @@ public class ChunkDetails {
   private Long slowestChunkLatencyMillis;
 
   @JsonProperty("total_chunks_present")
-  private Integer totalChunksPresent;
+  private Long totalChunksPresent;
 
   @JsonProperty("total_chunks_iterated")
-  private Integer totalChunksIterated;
+  private Long totalChunksIterated;
 
   @JsonProperty("sum_chunks_download_time_millis")
   private Long sumChunksDownloadTimeMillis;
+
+  public ChunkDetails(long totalChunks) {
+    this.totalChunksIterated = 0L;
+    this.sumChunksDownloadTimeMillis = 0L;
+    this.totalChunksPresent = totalChunks;
+  }
 
   public ChunkDetails setInitialChunkLatencyMillis(Long initialChunkLatencyMillis) {
     this.initialChunkLatencyMillis = initialChunkLatencyMillis;
@@ -30,12 +36,12 @@ public class ChunkDetails {
     return this;
   }
 
-  public ChunkDetails setTotalChunksPresent(Integer totalChunksPresent) {
+  public ChunkDetails setTotalChunksPresent(Long totalChunksPresent) {
     this.totalChunksPresent = totalChunksPresent;
     return this;
   }
 
-  public ChunkDetails setTotalChunksIterated(Integer totalChunksIterated) {
+  public ChunkDetails setTotalChunksIterated(Long totalChunksIterated) {
     this.totalChunksIterated = totalChunksIterated;
     return this;
   }
@@ -43,6 +49,22 @@ public class ChunkDetails {
   public ChunkDetails setSumChunksDownloadTimeMillis(Long sumChunksDownloadTimeMillis) {
     this.sumChunksDownloadTimeMillis = sumChunksDownloadTimeMillis;
     return this;
+  }
+
+  public Long getSlowestChunkLatencyMillis() {
+    return slowestChunkLatencyMillis;
+  }
+
+  public Long getTotalChunksPresent() {
+    return totalChunksPresent;
+  }
+
+  public Long getTotalChunksIterated() {
+    return totalChunksIterated;
+  }
+
+  public Long getSumChunksDownloadTimeMillis() {
+    return sumChunksDownloadTimeMillis;
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/model/telemetry/latency/ChunkDetails.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/latency/ChunkDetails.java
@@ -51,6 +51,10 @@ public class ChunkDetails {
     return this;
   }
 
+  public Long getInitialChunkLatencyMillis() {
+    return initialChunkLatencyMillis;
+  }
+
   public Long getSlowestChunkLatencyMillis() {
     return slowestChunkLatencyMillis;
   }

--- a/src/main/java/com/databricks/jdbc/telemetry/ITelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/ITelemetryClient.java
@@ -6,4 +6,6 @@ public interface ITelemetryClient {
   void exportEvent(TelemetryFrontendLog event);
 
   void close();
+
+  void closeStatement(String statementId);
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/NoopTelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/NoopTelemetryClient.java
@@ -25,4 +25,9 @@ public class NoopTelemetryClient implements ITelemetryClient {
   public void close() {
     // do nothing
   }
+
+  @Override
+  public void closeStatement(String statementId) {
+    // do nothing
+  }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -2,6 +2,8 @@ package com.databricks.jdbc.telemetry;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.model.telemetry.TelemetryFrontendLog;
+import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
+import com.databricks.jdbc.telemetry.latency.ChunkLatencyHandler;
 import com.databricks.sdk.core.DatabricksConfig;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,7 +53,23 @@ public class TelemetryClient implements ITelemetryClient {
 
   @Override
   public void close() {
+    // Export any pending chunk latency telemetry before flushing
+    ChunkLatencyHandler.getInstance()
+        .getAllPendingChunkDetails()
+        .forEach(
+            (statementId, chunkDetails) -> {
+              TelemetryHelper.exportChunkLatencyTelemetry(chunkDetails, statementId);
+            });
     flush();
+  }
+
+  @Override
+  public void closeStatement(String statementId) {
+    ChunkDetails chunkDetails =
+        ChunkLatencyHandler.getInstance().getChunkDetailsAndCleanup(statementId);
+    if (chunkDetails != null) {
+      TelemetryHelper.exportChunkLatencyTelemetry(chunkDetails, statementId);
+    }
   }
 
   private void flush() {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -70,6 +70,7 @@ public class TelemetryClient implements ITelemetryClient {
     if (chunkDetails != null) {
       TelemetryHelper.exportChunkLatencyTelemetry(chunkDetails, statementId);
     }
+    flush();
   }
 
   private void flush() {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -12,6 +12,7 @@ import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.*;
+import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.databricks.sdk.core.ProxyConfig;
 import com.databricks.sdk.core.UserAgent;
@@ -85,6 +86,20 @@ public class TelemetryHelper {
 
   public static void exportFailureLog(
       IDatabricksConnectionContext connectionContext, String errorName, String errorMessage) {
+    exportFailureLog(
+        connectionContext,
+        errorName,
+        errorMessage,
+        null,
+        DatabricksThreadContextHolder.getStatementId());
+  }
+
+  public static void exportFailureLog(
+      IDatabricksConnectionContext connectionContext,
+      String errorName,
+      String errorMessage,
+      Long chunkIndex,
+      String statementId) {
 
     // Connection context is not set in following scenarios:
     // a. Unit tests
@@ -101,10 +116,18 @@ public class TelemetryHelper {
                   new FrontendLogEntry()
                       .setSqlDriverLog(
                           new TelemetryEvent()
+                              .setSqlStatementId(statementId)
                               .setDriverConnectionParameters(
                                   getDriverConnectionParameter(connectionContext))
                               .setDriverErrorInfo(errorInfo)
                               .setDriverSystemConfiguration(getDriverSystemConfiguration())));
+      if (chunkIndex != null) {
+        // When chunkIndex is provided, we are exporting a chunk download failure log
+        telemetryFrontendLog
+            .getEntry()
+            .getSqlDriverLog()
+            .setSqlOperation(new SqlExecutionEvent().setChunkId(chunkIndex));
+      }
       ITelemetryClient client =
           TelemetryClientFactory.getInstance().getTelemetryClient(connectionContext);
       client.exportEvent(telemetryFrontendLog);
@@ -115,14 +138,42 @@ public class TelemetryHelper {
     SqlExecutionEvent executionEvent =
         new SqlExecutionEvent()
             .setDriverStatementType(DatabricksThreadContextHolder.getStatementType())
-            .setRetryCount(DatabricksThreadContextHolder.getRetryCount())
-            .setChunkId(DatabricksThreadContextHolder.getChunkId());
+            .setRetryCount(DatabricksThreadContextHolder.getRetryCount());
     exportLatencyLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         executionTime,
         executionEvent,
         DatabricksThreadContextHolder.getStatementId(),
         DatabricksThreadContextHolder.getSessionId());
+  }
+
+  public static void exportChunkLatencyTelemetry(ChunkDetails chunkDetails, String statementId) {
+    if (chunkDetails == null) {
+      return;
+    }
+
+    IDatabricksConnectionContext connectionContext =
+        DatabricksThreadContextHolder.getConnectionContext();
+    if (connectionContext == null) {
+      return;
+    }
+
+    SqlExecutionEvent sqlExecutionEvent = new SqlExecutionEvent().setChunkDetails(chunkDetails);
+
+    TelemetryEvent telemetryEvent =
+        new TelemetryEvent()
+            .setSqlOperation(sqlExecutionEvent)
+            .setDriverConnectionParameters(getDriverConnectionParameter(connectionContext));
+
+    TelemetryFrontendLog telemetryFrontendLog =
+        new TelemetryFrontendLog()
+            .setFrontendLogEventId(getEventUUID())
+            .setContext(getLogContext())
+            .setEntry(new FrontendLogEntry().setSqlDriverLog(telemetryEvent));
+
+    TelemetryClientFactory.getInstance()
+        .getTelemetryClient(connectionContext)
+        .exportEvent(telemetryFrontendLog);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -231,7 +231,6 @@ public class TelemetryHelper {
             .setNonProxyHosts(StringUtil.split(connectionContext.getNonProxyHosts()))
             .setHttpConnectionPoolSize(connectionContext.getHttpConnectionPoolSize())
             .setEnableSeaHybridResults(connectionContext.isSqlExecHybridResultsEnabled())
-            .setEnableComplexSupport(connectionContext.isComplexDatatypeSupportEnabled())
             .setAllowSelfSignedSupport(connectionContext.allowSelfSignedCerts())
             .setUseSystemTrustStore(connectionContext.useSystemTrustStore())
             .setRowsFetchedPerBlock(connectionContext.getRowsFetchedPerBlock())

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
@@ -4,6 +4,8 @@ import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -154,5 +156,24 @@ public class ChunkLatencyHandler {
     String statementIdStr = statementId.toString();
     statementTrackers.remove(statementIdStr);
     LOGGER.trace("Cleared tracking for statement {}", statementIdStr);
+  }
+
+  /**
+   * Gets all pending chunk details and clears the trackers. This method is called when the
+   * connection/client is being closed.
+   *
+   * @return a map of statement ID to ChunkDetails for all pending statements
+   */
+  public Map<String, ChunkDetails> getAllPendingChunkDetails() {
+    if (statementTrackers.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    LOGGER.trace(
+        "Retrieved {} pending chunk details for telemetry export", statementTrackers.size());
+
+    Map<String, ChunkDetails> pendingDetails = statementTrackers;
+    statementTrackers.clear();
+    return pendingDetails;
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
@@ -172,7 +172,7 @@ public class ChunkLatencyHandler {
     LOGGER.trace(
         "Retrieved {} pending chunk details for telemetry export", statementTrackers.size());
 
-    Map<String, ChunkDetails> pendingDetails = statementTrackers;
+    Map<String, ChunkDetails> pendingDetails = new ConcurrentHashMap<>(statementTrackers);
     statementTrackers.clear();
     return pendingDetails;
   }

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandler.java
@@ -1,0 +1,158 @@
+package com.databricks.jdbc.telemetry.latency;
+
+import com.databricks.jdbc.dbclient.impl.common.StatementId;
+import com.databricks.jdbc.log.JdbcLogger;
+import com.databricks.jdbc.log.JdbcLoggerFactory;
+import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handler for tracking chunk-related latency metrics for Databricks JDBC driver. This class manages
+ * per-statement chunk details and provides logic for data collection.
+ */
+public class ChunkLatencyHandler {
+
+  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ChunkLatencyHandler.class);
+
+  // Singleton instance for global access
+  private static final ChunkLatencyHandler INSTANCE = new ChunkLatencyHandler();
+
+  // Per-statement latency tracking using ChunkDetails
+  private final ConcurrentHashMap<String, ChunkDetails> statementTrackers =
+      new ConcurrentHashMap<>();
+
+  private ChunkLatencyHandler() {
+    // Private constructor for singleton
+  }
+
+  public static ChunkLatencyHandler getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Initialize tracking for a statement with the total number of chunks.
+   *
+   * @param statementId the statement ID
+   * @param totalChunks the total number of chunks in the result set
+   */
+  public void initializeStatement(StatementId statementId, long totalChunks) {
+    if (statementId == null) {
+      LOGGER.trace("Statement ID is null, skipping initialization");
+      return;
+    }
+    statementTrackers.put(statementId.toString(), new ChunkDetails(totalChunks));
+    LOGGER.trace(
+        "Initialized chunk tracking for statement {} with {} total chunks",
+        statementId.toString(),
+        totalChunks);
+  }
+
+  /**
+   * Records the latency for downloading a chunk and updates metrics.
+   *
+   * @param statementId the statement ID
+   * @param chunkIndex the index of the chunk being downloaded
+   * @param latencyMillis the time taken to download the chunk in milliseconds
+   */
+  public void recordChunkDownloadLatency(String statementId, long chunkIndex, long latencyMillis) {
+    if (statementId == null) {
+      LOGGER.trace("Statement ID is null, skipping chunk latency recording");
+      return;
+    }
+
+    ChunkDetails chunkDetails =
+        statementTrackers.computeIfAbsent(statementId, k -> new ChunkDetails(0));
+
+    // Record initial chunk latency (first chunk downloaded)
+    if (chunkIndex == 0) {
+      chunkDetails.setInitialChunkLatencyMillis(latencyMillis);
+    }
+
+    // Update slowest chunk latency
+    Long currentSlowest = chunkDetails.getSlowestChunkLatencyMillis();
+    if (currentSlowest == null || latencyMillis > currentSlowest) {
+      chunkDetails.setSlowestChunkLatencyMillis(latencyMillis);
+    }
+
+    // Add to sum of all chunk download times
+    Long currentSum = chunkDetails.getSumChunksDownloadTimeMillis();
+    if (currentSum == null) {
+      currentSum = 0L;
+    }
+    chunkDetails.setSumChunksDownloadTimeMillis(currentSum + latencyMillis);
+
+    LOGGER.trace(
+        "Recorded chunk {} latency: {}ms for statement {}", chunkIndex, latencyMillis, statementId);
+  }
+
+  /**
+   * Records when a chunk is iterated/consumed by the result set.
+   *
+   * @param statementId the statement ID
+   * @param chunkIndex the index of the chunk being iterated
+   */
+  public void recordChunkIteration(String statementId, long chunkIndex) {
+    if (statementId == null) {
+      return;
+    }
+
+    ChunkDetails chunkDetails = statementTrackers.get(statementId);
+    if (chunkDetails != null) {
+      Long currentIterated = chunkDetails.getTotalChunksIterated();
+      if (currentIterated == null) {
+        currentIterated = 0L;
+      }
+      chunkDetails.setTotalChunksIterated(currentIterated + 1);
+      LOGGER.trace("Recorded chunk {} iteration for statement {}", chunkIndex, statementId);
+    }
+  }
+
+  /**
+   * Gets the collected chunk details for a statement without removing the tracker.
+   *
+   * @param statementId the statement ID
+   * @return the ChunkDetails object or null if no tracker found
+   */
+  public ChunkDetails getChunkDetails(String statementId) {
+    if (statementId == null) {
+      return null;
+    }
+
+    return statementTrackers.get(statementId);
+  }
+
+  /**
+   * Gets the collected chunk details and removes the tracker from memory (cleanup).
+   *
+   * @param statementId the statement ID
+   * @return the ChunkDetails object or null if no tracker found
+   */
+  public ChunkDetails getChunkDetailsAndCleanup(String statementId) {
+    if (statementId == null) {
+      return null;
+    }
+
+    ChunkDetails chunkDetails = statementTrackers.remove(statementId);
+    if (chunkDetails == null) {
+      LOGGER.trace("No chunk latency telemetry found for statement {}", statementId);
+      return null;
+    }
+    return chunkDetails;
+  }
+
+  /**
+   * Clears tracking data for a statement (useful for cleanup).
+   *
+   * @param statementId the statement ID to clear tracking for
+   */
+  public void clearStatement(StatementId statementId) {
+    if (statementId == null) {
+      LOGGER.trace("Statement ID is null, skipping cleanup");
+      return;
+    }
+
+    String statementIdStr = statementId.toString();
+    statementTrackers.remove(statementIdStr);
+    LOGGER.trace("Cleared tracking for statement {}", statementIdStr);
+  }
+}

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandlerTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/ChunkLatencyHandlerTest.java
@@ -1,0 +1,394 @@
+package com.databricks.jdbc.telemetry.latency;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.databricks.jdbc.dbclient.impl.common.StatementId;
+import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ChunkLatencyHandlerTest {
+
+  @Mock private StatementId mockStatementId;
+
+  private ChunkLatencyHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = ChunkLatencyHandler.getInstance();
+    // Clear any existing state
+    handler.getAllPendingChunkDetails(); // This clears the internal map
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Clean up any remaining state
+    handler.getAllPendingChunkDetails();
+  }
+
+  @Test
+  void testGetInstance_ReturnsSameInstance() {
+    ChunkLatencyHandler instance1 = ChunkLatencyHandler.getInstance();
+    ChunkLatencyHandler instance2 = ChunkLatencyHandler.getInstance();
+    assertSame(instance1, instance2);
+  }
+
+  @Test
+  void testInitializeStatement_ValidStatementId() {
+    when(mockStatementId.toString()).thenReturn("test-statement-1");
+
+    handler.initializeStatement(mockStatementId, 5);
+
+    ChunkDetails details = handler.getChunkDetails("test-statement-1");
+    assertNotNull(details);
+    assertEquals(5L, details.getTotalChunksPresent());
+    assertEquals(0L, details.getTotalChunksIterated());
+    assertEquals(0L, details.getSumChunksDownloadTimeMillis());
+  }
+
+  @Test
+  void testInitializeStatement_NullStatementId() {
+    // Should not throw exception
+    assertDoesNotThrow(() -> handler.initializeStatement(null, 5));
+
+    // Should not create any entries
+    Map<String, ChunkDetails> pending = handler.getAllPendingChunkDetails();
+    assertTrue(pending.isEmpty());
+  }
+
+  @Test
+  void testRecordChunkDownloadLatency_NullStatementId() {
+    // Should not throw exception
+    assertDoesNotThrow(() -> handler.recordChunkDownloadLatency(null, 0, 100));
+
+    // Should not create any entries
+    Map<String, ChunkDetails> pending = handler.getAllPendingChunkDetails();
+    assertTrue(pending.isEmpty());
+  }
+
+  @Test
+  void testRecordChunkDownloadLatency_FirstChunk() {
+    String statementId = "test-statement-1";
+
+    handler.recordChunkDownloadLatency(statementId, 0, 150);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(150L, details.getInitialChunkLatencyMillis());
+    assertEquals(150L, details.getSlowestChunkLatencyMillis());
+    assertEquals(150L, details.getSumChunksDownloadTimeMillis());
+  }
+
+  @Test
+  void testRecordChunkDownloadLatency_SubsequentChunks() {
+    String statementId = "test-statement-1";
+
+    // Record first chunk
+    handler.recordChunkDownloadLatency(statementId, 0, 100);
+    // Record second chunk with higher latency
+    handler.recordChunkDownloadLatency(statementId, 1, 200);
+    // Record third chunk with lower latency
+    handler.recordChunkDownloadLatency(statementId, 2, 75);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(100L, details.getInitialChunkLatencyMillis()); // First chunk only
+    assertEquals(200L, details.getSlowestChunkLatencyMillis()); // Highest latency
+    assertEquals(375L, details.getSumChunksDownloadTimeMillis()); // Sum of all
+  }
+
+  @Test
+  void testRecordChunkDownloadLatency_CreatesNewChunkDetailsIfNotExists() {
+    String statementId = "test-statement-1";
+
+    handler.recordChunkDownloadLatency(statementId, 1, 100);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(0L, details.getTotalChunksPresent()); // Default when auto-created
+    assertNull(details.getInitialChunkLatencyMillis()); // Not first chunk
+    assertEquals(100L, details.getSlowestChunkLatencyMillis());
+    assertEquals(100L, details.getSumChunksDownloadTimeMillis());
+  }
+
+  @Test
+  void testRecordChunkIteration_NullStatementId() {
+    // Should not throw exception
+    assertDoesNotThrow(() -> handler.recordChunkIteration(null, 0));
+
+    // Should not create any entries
+    Map<String, ChunkDetails> pending = handler.getAllPendingChunkDetails();
+    assertTrue(pending.isEmpty());
+  }
+
+  @Test
+  void testRecordChunkIteration_ValidStatementId() {
+    String statementId = "test-statement-1";
+    when(mockStatementId.toString()).thenReturn(statementId);
+
+    // Initialize statement first
+    handler.initializeStatement(mockStatementId, 3);
+
+    // Record iterations
+    handler.recordChunkIteration(statementId, 0);
+    handler.recordChunkIteration(statementId, 1);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(2L, details.getTotalChunksIterated());
+  }
+
+  @Test
+  void testRecordChunkIteration_NonExistentStatementId() {
+    String statementId = "non-existent-statement";
+
+    // Should not throw exception
+    assertDoesNotThrow(() -> handler.recordChunkIteration(statementId, 0));
+
+    // Should not create new entry
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNull(details);
+  }
+
+  @Test
+  void testGetChunkDetails_NullStatementId() {
+    ChunkDetails details = handler.getChunkDetails(null);
+    assertNull(details);
+  }
+
+  @Test
+  void testGetChunkDetails_ValidStatementId() {
+    String statementId = "test-statement-1";
+    when(mockStatementId.toString()).thenReturn(statementId);
+
+    handler.initializeStatement(mockStatementId, 5);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(5L, details.getTotalChunksPresent());
+
+    // Should still be available after get (not cleaned up)
+    ChunkDetails detailsAgain = handler.getChunkDetails(statementId);
+    assertNotNull(detailsAgain);
+    assertSame(details, detailsAgain);
+  }
+
+  @Test
+  void testGetChunkDetailsAndCleanup_NullStatementId() {
+    ChunkDetails details = handler.getChunkDetailsAndCleanup(null);
+    assertNull(details);
+  }
+
+  @Test
+  void testGetChunkDetailsAndCleanup_ValidStatementId() {
+    String statementId = "test-statement-1";
+    when(mockStatementId.toString()).thenReturn(statementId);
+
+    handler.initializeStatement(mockStatementId, 5);
+
+    ChunkDetails details = handler.getChunkDetailsAndCleanup(statementId);
+    assertNotNull(details);
+    assertEquals(5L, details.getTotalChunksPresent());
+
+    // Should be cleaned up after get
+    ChunkDetails detailsAgain = handler.getChunkDetails(statementId);
+    assertNull(detailsAgain);
+  }
+
+  @Test
+  void testGetChunkDetailsAndCleanup_NonExistentStatementId() {
+    String statementId = "non-existent-statement";
+
+    ChunkDetails details = handler.getChunkDetailsAndCleanup(statementId);
+    assertNull(details);
+  }
+
+  @Test
+  void testClearStatement_NullStatementId() {
+    // Should not throw exception
+    assertDoesNotThrow(() -> handler.clearStatement(null));
+  }
+
+  @Test
+  void testClearStatement_ValidStatementId() {
+    String statementId = "test-statement-1";
+    when(mockStatementId.toString()).thenReturn(statementId);
+
+    handler.initializeStatement(mockStatementId, 5);
+
+    // Verify it exists
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+
+    // Clear it
+    handler.clearStatement(mockStatementId);
+
+    // Verify it's gone
+    ChunkDetails detailsAfterClear = handler.getChunkDetails(statementId);
+    assertNull(detailsAfterClear);
+  }
+
+  @Test
+  void testGetAllPendingChunkDetails_EmptyTrackers() {
+    Map<String, ChunkDetails> pendingDetails = handler.getAllPendingChunkDetails();
+    assertTrue(pendingDetails.isEmpty());
+  }
+
+  @Test
+  void testGetAllPendingChunkDetails_WithTrackers() {
+    String statementId1 = "test-statement-1";
+    String statementId2 = "test-statement-2";
+
+    StatementId mockStatementId1 = mock(StatementId.class);
+    StatementId mockStatementId2 = mock(StatementId.class);
+    when(mockStatementId1.toString()).thenReturn(statementId1);
+    when(mockStatementId2.toString()).thenReturn(statementId2);
+
+    handler.initializeStatement(mockStatementId1, 3);
+    handler.initializeStatement(mockStatementId2, 5);
+
+    // Verify data exists before calling getAllPendingChunkDetails
+    assertNotNull(handler.getChunkDetails(statementId1));
+    assertNotNull(handler.getChunkDetails(statementId2));
+
+    Map<String, ChunkDetails> pendingDetails = handler.getAllPendingChunkDetails();
+
+    assertEquals(2, pendingDetails.size());
+    assertTrue(pendingDetails.containsKey(statementId1));
+    assertTrue(pendingDetails.containsKey(statementId2));
+    assertEquals(3L, pendingDetails.get(statementId1).getTotalChunksPresent());
+    assertEquals(5L, pendingDetails.get(statementId2).getTotalChunksPresent());
+
+    // Verify trackers are cleared after getting all pending details
+    Map<String, ChunkDetails> pendingDetailsAfter = handler.getAllPendingChunkDetails();
+    assertTrue(pendingDetailsAfter.isEmpty());
+  }
+
+  @Test
+  void testComplexScenario() {
+    String statementId = "test-statement-complex";
+    StatementId mockStatementIdComplex = mock(StatementId.class);
+    when(mockStatementIdComplex.toString()).thenReturn(statementId);
+
+    // Initialize statement
+    handler.initializeStatement(mockStatementIdComplex, 10);
+
+    // Record some chunk download latencies
+    handler.recordChunkDownloadLatency(statementId, 0, 100); // First chunk
+    handler.recordChunkDownloadLatency(statementId, 1, 250); // Slowest chunk
+    handler.recordChunkDownloadLatency(statementId, 2, 150); // Regular chunk
+
+    // Record some chunk iterations
+    handler.recordChunkIteration(statementId, 0);
+    handler.recordChunkIteration(statementId, 1);
+    handler.recordChunkIteration(statementId, 2);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+
+    // Verify all metrics are correctly calculated
+    assertEquals(10L, details.getTotalChunksPresent());
+    assertEquals(3L, details.getTotalChunksIterated());
+    assertEquals(100L, details.getInitialChunkLatencyMillis());
+    assertEquals(250L, details.getSlowestChunkLatencyMillis());
+    assertEquals(500L, details.getSumChunksDownloadTimeMillis());
+
+    // Clean up
+    ChunkDetails cleanedDetails = handler.getChunkDetailsAndCleanup(statementId);
+    assertNotNull(cleanedDetails);
+    assertSame(details, cleanedDetails);
+
+    // Verify cleanup
+    ChunkDetails afterCleanup = handler.getChunkDetails(statementId);
+    assertNull(afterCleanup);
+  }
+
+  @Test
+  void testConcurrentAccess() {
+    String statementId1 = "concurrent-statement-1";
+    String statementId2 = "concurrent-statement-2";
+
+    // This test verifies that the ConcurrentHashMap is used correctly
+    // and doesn't throw ConcurrentModificationException
+
+    handler.recordChunkDownloadLatency(statementId1, 0, 100);
+    handler.recordChunkDownloadLatency(statementId2, 0, 200);
+
+    ChunkDetails details1 = handler.getChunkDetails(statementId1);
+    ChunkDetails details2 = handler.getChunkDetails(statementId2);
+
+    assertNotNull(details1);
+    assertNotNull(details2);
+    assertEquals(100L, details1.getSlowestChunkLatencyMillis());
+    assertEquals(200L, details2.getSlowestChunkLatencyMillis());
+
+    // Get all pending details should return both
+    Map<String, ChunkDetails> allPending = handler.getAllPendingChunkDetails();
+    assertEquals(2, allPending.size());
+  }
+
+  @Test
+  void testSlowstChunkLatencyUpdate() {
+    String statementId = "test-slowest-chunk";
+
+    // Record chunks with increasing latency
+    handler.recordChunkDownloadLatency(statementId, 0, 50);
+    handler.recordChunkDownloadLatency(statementId, 1, 100);
+    handler.recordChunkDownloadLatency(statementId, 2, 75);
+    handler.recordChunkDownloadLatency(statementId, 3, 200); // New slowest
+    handler.recordChunkDownloadLatency(statementId, 4, 25);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertNotNull(details);
+    assertEquals(50L, details.getInitialChunkLatencyMillis()); // First chunk
+    assertEquals(200L, details.getSlowestChunkLatencyMillis()); // Slowest chunk
+    assertEquals(450L, details.getSumChunksDownloadTimeMillis()); // Sum: 50+100+75+200+25
+  }
+
+  @Test
+  void testSumChunksDownloadTimeAccumulation() {
+    String statementId = "test-sum-chunks";
+
+    // Record multiple chunks and verify sum accumulation
+    handler.recordChunkDownloadLatency(statementId, 0, 10);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertEquals(10L, details.getSumChunksDownloadTimeMillis());
+
+    handler.recordChunkDownloadLatency(statementId, 1, 20);
+    assertEquals(30L, details.getSumChunksDownloadTimeMillis());
+
+    handler.recordChunkDownloadLatency(statementId, 2, 15);
+    assertEquals(45L, details.getSumChunksDownloadTimeMillis());
+  }
+
+  @Test
+  void testChunkIterationAccumulation() {
+    String statementId = "test-iteration-accumulation";
+    StatementId mockStatementIdIter = mock(StatementId.class);
+    when(mockStatementIdIter.toString()).thenReturn(statementId);
+
+    // Initialize statement
+    handler.initializeStatement(mockStatementIdIter, 5);
+
+    ChunkDetails details = handler.getChunkDetails(statementId);
+    assertEquals(0L, details.getTotalChunksIterated());
+
+    // Record iterations one by one
+    handler.recordChunkIteration(statementId, 0);
+    assertEquals(1L, details.getTotalChunksIterated());
+
+    handler.recordChunkIteration(statementId, 1);
+    assertEquals(2L, details.getTotalChunksIterated());
+
+    handler.recordChunkIteration(statementId, 2);
+    assertEquals(3L, details.getTotalChunksIterated());
+  }
+}


### PR DESCRIPTION
## Description
- Currently we don't have mechanism to detect issues on cloud-fetch in our driver. This PR adds latency details on telemetry.
- Add chunkID field when chunk download fails. 
- I have subtly removed the dependency on threadLocal for chunkID. (We are planning to eventually removing this)

## Testing
- Tested locally.

## Additional Notes to the Reviewer
- This is the 1st PR out of 2 PRs on latency telemetry. 

NO_CHANGELOG=true