### PR TITLE
Fix azure u2m

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Fixed Bouncy Castle registration conflicts by using local provider instance instead of global security registration.
+- Fixed Azure U2M authentication issue.
 
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
@@ -92,7 +92,7 @@ public final class DatabricksJdbcConstants {
   public static final String IS_JDBC_TEST_ENV = "IS_JDBC_TEST_ENV";
   public static final String AWS_CLIENT_ID = "databricks-sql-jdbc";
   public static final String GCP_CLIENT_ID = "databricks-sql-jdbc";
-  public static final String AAD_CLIENT_ID = "96eecda7-19ea-49cc-abb5-240097d554f5";
+  public static final String AAD_CLIENT_ID = "databricks-sql-jdbc";
   public static final String GCP_GOOGLE_CREDENTIALS_AUTH_TYPE = "google-credentials";
   public static final String GCP_GOOGLE_ID_AUTH_TYPE = "google-id";
   public static final String DEFAULT_HTTP_EXCEPTION_SQLSTATE = "08000";

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -85,7 +85,7 @@ class DatabricksConnectionContextTest {
     assertEquals("https://sample-host.18.azuredatabricks.net:9999", connectionContext.getHostUrl());
     assertEquals("/sql/1.0/warehouses/9999999999", connectionContext.getHttpPath());
     assertEquals("passwd2", connectionContext.getToken());
-    assertEquals("96eecda7-19ea-49cc-abb5-240097d554f5", connectionContext.getClientId());
+    assertEquals("databricks-sql-jdbc", connectionContext.getClientId());
     assertEquals(7, connectionContext.parameters.size());
     assertEquals(CompressionCodec.LZ4_FRAME, connectionContext.getCompressionCodec());
     assertEquals(LogLevel.OFF, connectionContext.getLogLevel());


### PR DESCRIPTION
## Description
- The earlier client ID seems to be no longer working. Adding a short term fix on Azure U2M resolution. 

## Testing
- Tested using example : 
```
"jdbc:databricks://<azure workspace>:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=2;TokenCachePassPhrase=test;httpPath=/sql/1.0/warehouses/<warehouseID>;";

```

## Additional Notes to the Reviewer
- We had shared a custom JAR with the entire U2M flow re-written on our side, customer's issues seems to be resolved then. We will wait for OAuth to get back on the RCA, but I will just change the client ID for this PR. 

