### PR TITLE
Remove secrets from the FakeServiceTests

### DIFF
--- a/src/test/java/com/databricks/jdbc/integration/IntegrationTestUtil.java
+++ b/src/test/java/com/databricks/jdbc/integration/IntegrationTestUtil.java
@@ -18,6 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 /** Utility class to support integration tests * */
@@ -152,7 +153,7 @@ public class IntegrationTestUtil {
   }
 
   public static String getDatabricksToken() {
-    return System.getenv("DATABRICKS_TOKEN");
+    return Optional.ofNullable(System.getenv("DATABRICKS_TOKEN")).orElse("token");
   }
 
   public static String getDatabricksDogfoodToken() {
@@ -188,7 +189,7 @@ public class IntegrationTestUtil {
   }
 
   public static String getDatabricksUser() {
-    return System.getenv("DATABRICKS_USER");
+    return Optional.ofNullable(System.getenv("DATABRICKS_USER")).orElse("token");
   }
 
   public static Connection getValidJDBCConnection() throws SQLException {

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceConfigLoader.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/FakeServiceConfigLoader.java
@@ -19,6 +19,8 @@ public class FakeServiceConfigLoader {
 
   public static final String TEST_SCHEMA = "testschema";
 
+  public static final String HTTP_PATH_PROP = "httppath";
+
   private static final DatabricksJdbcConstants.FakeServiceType fakeServiceType =
       System.getenv("FAKE_SERVICE_TYPE") != null
           ? DatabricksJdbcConstants.FakeServiceType.valueOf(

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ErrorHandlingIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/ErrorHandlingIntegrationTests.java
@@ -8,6 +8,7 @@ import com.databricks.jdbc.common.DatabricksClientType;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksSQLFeatureNotSupportedException;
 import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
+import com.databricks.jdbc.integration.fakeservice.FakeServiceConfigLoader;
 import com.databricks.jdbc.integration.fakeservice.FakeServiceExtension;
 import java.sql.*;
 import org.junit.jupiter.api.AfterEach;
@@ -60,8 +61,8 @@ public class ErrorHandlingIntegrationTests extends AbstractFakeServiceIntegratio
             () ->
                 getConnection(
                     "jdbc:databricks://e2-wrongfood.staging.cloud.databricks.com:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath="
-                        + getDatabricksDogfoodHTTPPath()
-                        + ";"));
+                        + FakeServiceConfigLoader.getProperty(
+                            FakeServiceConfigLoader.HTTP_PATH_PROP)));
     assertTrue(
         e.getMessage().contains("Connection failure while using the OSS Databricks JDBC driver."));
   }

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/UCVolumeIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/UCVolumeIntegrationTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.jdbc.api.impl.volume.DatabricksUCVolumeClient;
 import com.databricks.jdbc.common.DatabricksJdbcUrlParams;
-import com.databricks.jdbc.integration.IntegrationTestUtil;
 import com.databricks.jdbc.integration.fakeservice.AbstractFakeServiceIntegrationTests;
 import com.databricks.jdbc.integration.fakeservice.FakeServiceConfigLoader;
 import com.databricks.jdbc.integration.fakeservice.FakeServiceExtension;
@@ -30,7 +29,7 @@ public class UCVolumeIntegrationTests extends AbstractFakeServiceIntegrationTest
   private Connection con;
   private static final String jdbcUrlTemplate =
       "jdbc:databricks://%s/default;transportMode=http;ssl=0;AuthMech=3;httpPath=%s";
-  private static final String HTTP_PATH = IntegrationTestUtil.getDatabricksDogfoodHTTPPath();
+  private static final String HTTP_PATH = "/sql/1.0/warehouses/791ba2a31c7fd70a";
   private static final String LOCAL_TEST_DIRECTORY = "/tmp";
 
   @BeforeEach


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
FakeService tests running in replay mode in CI do not need secrets. When generating stubs locally, replace with actual PAT or secrets.

## Testing
CI

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

