### PR TITLE
Added case-insensitive column name support for JDBC ResultSet operations

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added DCO (Developer Certificate of Origin) check workflow for pull requests to ensure all commits are properly signed-off
 - Added support for SSL client certificate authentication via parameter: SSLTrustStoreProvider
+- Added case-insensitive column name support for JDBC ResultSet operations
 
 ### Updated
 - 

--- a/src/main/java/com/databricks/jdbc/api/impl/CaseInsensitiveImmutableMap.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/CaseInsensitiveImmutableMap.java
@@ -1,0 +1,46 @@
+package com.databricks.jdbc.api.impl;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+/**
+ * Internal utility class for case-insensitive immutable maps. Keys are normalized to lowercase
+ * during construction for efficient case-insensitive lookups.
+ */
+class CaseInsensitiveImmutableMap<V> {
+  private final ImmutableMap<String, V> delegate;
+
+  private CaseInsensitiveImmutableMap(ImmutableMap<String, V> delegate) {
+    this.delegate = delegate;
+  }
+
+  public static <V> CaseInsensitiveImmutableMap<V> copyOf(Map<String, V> map) {
+    ImmutableMap<String, V> normalizedMap =
+        map.entrySet().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    entry -> entry.getKey().toLowerCase(), Map.Entry::getValue));
+
+    return new CaseInsensitiveImmutableMap<>(normalizedMap);
+  }
+
+  public V get(String key) {
+    return delegate.get(key.toLowerCase());
+  }
+
+  public V getOrDefault(String key, V defaultValue) {
+    return delegate.getOrDefault(key.toLowerCase(), defaultValue);
+  }
+
+  public boolean containsKey(String key) {
+    return delegate.containsKey(key.toLowerCase());
+  }
+
+  public int size() {
+    return delegate.size();
+  }
+
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+}

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -25,7 +25,6 @@ import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.sdk.service.sql.ColumnInfo;
 import com.databricks.sdk.service.sql.ColumnInfoTypeName;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -44,7 +43,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
   private final StatementId statementId;
   private IDatabricksConnectionContext ctx;
   private final ImmutableList<ImmutableDatabricksColumn> columns;
-  private final ImmutableMap<String, Integer> columnNameIndex;
+  private final CaseInsensitiveImmutableMap<Integer> columnNameIndex;
   private final long totalRows;
   private Long chunkCount;
   private final boolean isCloudFetchUsed;
@@ -127,7 +126,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
       }
     }
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = resultManifest.getTotalRowCount();
     this.chunkCount = resultManifest.getTotalChunkCount();
     this.isCloudFetchUsed = usesExternalLinks;
@@ -213,7 +212,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
       }
     }
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = rows;
     this.chunkCount = chunkCount;
     this.isCloudFetchUsed = getIsCloudFetchFromManifest(resultManifest);
@@ -263,7 +262,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     }
 
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
   }
@@ -315,7 +314,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
       columnNameToIndexMap.putIfAbsent(columnNames.get(i), i + 1);
     }
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
   }
@@ -373,7 +372,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
       columnNameToIndexMap.putIfAbsent(columnNames.get(i), i + 1);
     }
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
   }
@@ -450,7 +449,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.isCloudFetchUsed = false;
     this.totalRows = -1;
     this.columns = columnsBuilder.build();
-    this.columnNameIndex = ImmutableMap.copyOf(columnNameToIndexMap);
+    this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     ;
   }
 

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -99,6 +99,7 @@ public class DatabricksResultSetMetaDataTest {
     assertEquals("col5", metaData.getColumnName(4));
     assertEquals(10, metaData.getTotalRows());
     assertEquals(2, metaData.getColumnNameIndex("col2"));
+    assertEquals(2, metaData.getColumnNameIndex("COL2"));
 
     metaData =
         new DatabricksResultSetMetaData(
@@ -271,6 +272,7 @@ public class DatabricksResultSetMetaDataTest {
     assertEquals("testCol", metaData.getColumnName(1));
     assertEquals(1, metaData.getTotalRows());
     assertEquals(1, metaData.getColumnNameIndex("testCol"));
+    assertEquals(1, metaData.getColumnNameIndex("TESTCol"));
     assertEquals(Types.OTHER, metaData.getColumnType(1));
     assertEquals("java.lang.String", metaData.getColumnClassName(1));
     assertEquals(VARIANT, metaData.getColumnTypeName(1));


### PR DESCRIPTION
## Description
Added case-insensitive column name support for JDBC ResultSet operations

## Testing
Tested the changes using unit tests and the entire flow locally

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

