### PR TITLE
Removing EPL and GPL License library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,10 +484,6 @@
                   <shadedPattern>com.databricks.internal.io</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>jakarta.servlet</pattern>
-                  <shadedPattern>com.databricks.internal.jakarta.servlet</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>net.jpountz</pattern>
                   <shadedPattern>com.databricks.internal.jpountz</shadedPattern>
                 </relocation>
@@ -533,6 +529,7 @@
                   <excludes>
                     <exclude>edu/**</exclude>
                     <exclude>javax/**</exclude>
+                    <exclude>jakarta/**</exclude>
                     <exclude>net/jcip/**</exclude>
                     <exclude>oauth/**</exclude>
                   </excludes>


### PR DESCRIPTION
## Description
Removing the libraries that have licensing issues when included in the OSS project

- Removed jakarta servlet from the final jar as it is required only by wiremock


`
NO_CHANGELOG=true
`