### PR TITLE
[PECOBLR-620] Fixed byteBufferToString function and added unit tests

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -324,13 +324,9 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public Statement createStatement(
       int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY
-        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
-        || resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
-      throw new DatabricksSQLFeatureNotImplementedException(
-          "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
-    }
-    return createStatement();
+
+    throw new DatabricksSQLFeatureNotImplementedException(
+        "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -324,9 +324,13 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public Statement createStatement(
       int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
+    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY
+        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
+        || resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
+    }
+    return createStatement();
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcConstants.java
@@ -66,6 +66,7 @@ public final class DatabricksJdbcConstants {
   public static final String VOLUME_OPERATION_STATUS_COLUMN_NAME = "operation_status";
   public static final String VOLUME_OPERATION_STATUS_SUCCEEDED = "SUCCEEDED";
   public static final int VOLUME_OPERATION_MAX_RETRIES = 3;
+  public static final int UUID_LENGTH = 16;
 
   public static final String ARROW_METADATA_KEY = "Spark:DataType:SqlName";
   public static final Map<String, String> ALLOWED_SESSION_CONF_TO_DEFAULT_VALUES_MAP =

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
@@ -6,6 +6,7 @@ import static com.databricks.jdbc.model.client.thrift.generated.TTypeId.*;
 
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
+import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.exception.DatabricksHttpException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
@@ -56,7 +57,8 @@ public class DatabricksThriftUtil {
 
   public static String byteBufferToString(ByteBuffer buffer) {
     ByteBuffer newBuffer = buffer.duplicate(); // This is to avoid a BufferUnderflowException
-    if (newBuffer.remaining() >= 16) {
+    // sessionId and guid are 16 bytes long
+    if (newBuffer.remaining() >= DatabricksJdbcConstants.UUID_LENGTH) {
       long mostSigBits = newBuffer.getLong();
       long leastSigBits = newBuffer.getLong();
       return new UUID(mostSigBits, leastSigBits).toString();
@@ -292,7 +294,7 @@ public class DatabricksThriftUtil {
   public static TOperationHandle getOperationHandle(StatementId statementId) {
     THandleIdentifier identifier = statementId.toOperationIdentifier();
     // This will help logging the statement-Id in readable format for debugging purposes
-    LOGGER.debug("getOperationHandle for statementId {%s}", statementId);
+    LOGGER.debug("getOperationHandle for statementId {%s}", byteBufferToString(identifier.guid));
     return new TOperationHandle()
         .setOperationId(identifier)
         .setOperationType(TOperationType.UNKNOWN);

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
@@ -57,7 +57,7 @@ public class DatabricksThriftUtil {
 
   public static String byteBufferToString(ByteBuffer buffer) {
     ByteBuffer newBuffer = buffer.duplicate(); // This is to avoid a BufferUnderflowException
-    // sessionId and guid are 16 bytes long
+    // sessionId and statementID have guid which are 16 bytes long
     if (newBuffer.remaining() >= DatabricksJdbcConstants.UUID_LENGTH) {
       long mostSigBits = newBuffer.getLong();
       long leastSigBits = newBuffer.getLong();

--- a/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
@@ -44,6 +44,20 @@ public class DatabricksThriftUtilTest {
   }
 
   @Test
+  void testByteBufferToStringWith16Bytes() {
+    DatabricksThriftUtil helper = new DatabricksThriftUtil();
+    long mostSigBits = 987654321L;
+    long leastSigBits = 123456789L;
+    ByteBuffer buffer = ByteBuffer.allocate(16); // 16 bytes = 2 * Long.BYTES
+    buffer.putLong(mostSigBits);
+    buffer.putLong(leastSigBits);
+    buffer.flip();
+    String result = helper.byteBufferToString(buffer);
+    String expectedUUID = new UUID(mostSigBits, leastSigBits).toString();
+    assertEquals(expectedUUID, result);
+  }
+
+  @Test
   void testVerifySuccessStatus() {
     assertDoesNotThrow(
         () ->

--- a/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
+import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import com.databricks.jdbc.exception.DatabricksHttpException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.model.client.thrift.generated.*;
@@ -44,11 +45,11 @@ public class DatabricksThriftUtilTest {
   }
 
   @Test
-  void testByteBufferToStringWith16Bytes() {
+  void testByteBufferToStringWithUuidLengthBytes() {
     DatabricksThriftUtil helper = new DatabricksThriftUtil();
     long mostSigBits = 987654321L;
     long leastSigBits = 123456789L;
-    ByteBuffer buffer = ByteBuffer.allocate(16); // 16 bytes = 2 * Long.BYTES
+    ByteBuffer buffer = ByteBuffer.allocate(DatabricksJdbcConstants.UUID_LENGTH);
     buffer.putLong(mostSigBits);
     buffer.putLong(leastSigBits);
     buffer.flip();


### PR DESCRIPTION
## Description
Fixed byteBufferToString function: The function assumed the byteBuffer size to be a Long and resulted in buggy output for size 16. This resulted in buggy value of sessionId and some logging statements.
Removed the extra logged statementId.

## Testing

- Tested locally

Related tickets:
[PECOBLR-620](https://databricks.atlassian.net/browse/PECOBLR-620)

[PECOBLR-620]: https://databricks.atlassian.net/browse/PECOBLR-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


`NO_CHANGELOG=true`