### PR TITLE
Fixed unimplemented methods in DatabricksConnection for methods which has default input by users

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -324,9 +324,13 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public Statement createStatement(
       int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
+    if (resultSetType != ResultSet.TYPE_FORWARD_ONLY
+        || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
+        || resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
+    }
+    return createStatement();
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -328,7 +328,7 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
         || resultSetConcurrency != ResultSet.CONCUR_READ_ONLY
         || resultSetHoldability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
       throw new DatabricksSQLFeatureNotImplementedException(
-          "Not implemented in DatabricksConnection - createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)");
+          "Databricks OSS JDBC only supports resultSetType as ResultSet.TYPE_FORWARD_ONLY, resultSetConcurrency as ResultSet.CONCUR_READ_ONLY and resultSetHoldability as ResultSet.CLOSE_CURSORS_AT_COMMIT");
     }
     return createStatement();
   }

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
@@ -353,9 +353,24 @@ public class DatabricksConnectionTest {
         () -> connection.prepareStatement(SQL, 1, 1, 1));
     assertThrows(
         DatabricksSQLFeatureNotSupportedException.class, () -> connection.prepareStatement(SQL, 1));
+    // Test createStatement with default values succeeds
+    assertDoesNotThrow(
+        () -> {
+          connection.createStatement(
+              ResultSet.TYPE_FORWARD_ONLY,
+              ResultSet.CONCUR_READ_ONLY,
+              ResultSet.CLOSE_CURSORS_AT_COMMIT);
+        });
+
+    // Test createStatement with non-default values throws exception
     assertThrows(
         DatabricksSQLFeatureNotImplementedException.class,
-        () -> connection.createStatement(1, 1, 1));
+        () -> {
+          connection.createStatement(
+              ResultSet.TYPE_SCROLL_INSENSITIVE,
+              ResultSet.CONCUR_READ_ONLY,
+              ResultSet.CLOSE_CURSORS_AT_COMMIT);
+        });
     assertThrows(
         DatabricksSQLFeatureNotImplementedException.class, () -> connection.setSavepoint("1"));
     assertThrows(DatabricksSQLFeatureNotImplementedException.class, connection::setSavepoint);


### PR DESCRIPTION
## Description
Added a check in the parameterized createStatement function to check if the parameters match the default value before throwing the error.

## Testing

- Tested Locally

Related tickets:
[PECOBLR-665](https://databricks.atlassian.net/browse/PECOBLR-665)

NO_CHANGELOG=true

[PECOBLR-665]: https://databricks.atlassian.net/browse/PECOBLR-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ