### PR TITLE
[Bug] Fix link expiry for Thrift

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadService.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkLinkDownloadService.java
@@ -119,6 +119,12 @@ public class ChunkLinkDownloadService<T extends AbstractArrowResultChunk> {
       // SEA doesn't give all chunk links, so better to trigger download chain as soon as possible
       LOGGER.info("Auto-triggering download chain for SEA client type");
       triggerNextBatchDownload();
+    } else if (session.getConnectionContext().getClientType() == DatabricksClientType.THRIFT) {
+      // For Thrift client, futures should be completed immediately as links are fetched eagerly
+      // TODO (jayantsing-db): Add test coverage
+      for (long i = 0; i < totalChunks; i++) {
+        chunkIndexToLinkFuture.get(i).complete(chunkIndexToChunksMap.get(i).chunkLink);
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Thrift client fetches external links eagerly. Link download service has support to check for link expiry when client code gets the link. However, link expiry check expects the link future to be done (signifying that the link has been downloaded once).

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

