### PR TITLE
Move from OSSRH to maven central publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,9 @@
 name: Release
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
-  # workflow_dispatch:
-  #   inputs:
-  #     release_tag:
-  #       description: 'v1.0.8-oss'
-  #       required: true
-
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -19,10 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # ref: "v1.0.8-oss"
-          ref: ${{ github.event.pull_request.head.sha }}
-#          ref: ${{ github.event.inputs.release_tag }}
 
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
@@ -48,7 +38,7 @@ jobs:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
-      # - name: Create GitHub release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: target/*.jar
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_SECRET }}
         with:
           java-version: 11
           server-id: central
@@ -44,7 +44,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_SECRET }}
 
       # - name: Create GitHub release
       #   uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,14 @@ jobs:
 
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_SECRET }}
         with:
           java-version: 11
           server-id: central
           distribution: "adopt"
-          server-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          server-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Configure GPG
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
         with:
           java-version: 11
           server-id: central
           distribution: "adopt"
           server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
+          server-password: MAVEN_CENTRAL_SECRET
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
@@ -44,7 +44,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
 
       # - name: Create GitHub release
       #   uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,17 +34,17 @@ jobs:
           java-version: 11
           server-id: central
           distribution: "adopt"
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_SECRET
+          server-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          server-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to the Maven Central Repository
         run: mvn -Prelease -X --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_SECRET }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
       # - name: Create GitHub release
       #   uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/setup-java@v4
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         with:
           java-version: 11
           server-id: central
@@ -43,8 +43,8 @@ jobs:
         run: mvn -Prelease -X --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
       # - name: Create GitHub release
       #   uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 name: Release
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
+  # workflow_dispatch:
+  #   inputs:
+  #     release_tag:
+  #       description: 'v1.0.8-oss'
+  #       required: true
+
 
 jobs:
   publish:
@@ -13,19 +19,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # ref: "v1.0.8-oss"
+          ref: ${{ github.event.pull_request.head.sha }}
+#          ref: ${{ github.event.inputs.release_tag }}
 
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         with:
           java-version: 11
-          server-id: ossrh
+          server-id: central
           distribution: "adopt"
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
@@ -33,10 +43,10 @@ jobs:
         run: mvn -Prelease --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: target/*.jar
+      # - name: Create GitHub release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Publish to the Maven Central Repository
-        run: mvn -Prelease --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+        run: mvn -Prelease -X --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Configure GPG
+        run: |
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          gpg-connect-agent reloadagent /bye
+
       - name: Publish to the Maven Central Repository
         run: mvn -Prelease -X --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           gpg-connect-agent reloadagent /bye
 
       - name: Publish to the Maven Central Repository
-        run: mvn -Prelease -X --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+        run: mvn -Prelease --batch-mode deploy -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -647,22 +647,24 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-          
-                <configuration>
-                  <!-- Prevent gpg from using pinentry programs -->
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                  <!-- Custom reduced pom file for fat jar -->
-                  <pomFile>${project.basedir}/uber-minimal-pom.xml</pomFile>
-                  <sources>${project.build.directory}/${project.build.finalName}-sources.jar</sources>
-                  <javadoc>${project.build.directory}/${project.build.finalName}-javadoc.jar</javadoc>
-                  <files>${project.build.directory}/${project.build.finalName}-thin.jar</files>
-                  <types>jar</types>
-                  <classifiers>thin</classifiers>
-                </configuration>
-                <executions>
+            <configuration>
+              <gpgArguments>
+                <arg>--batch</arg>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+                <arg>--no-tty</arg>
+                <arg>--yes</arg>
+              </gpgArguments>
+              <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+              <!-- Custom reduced pom file for fat jar -->
+              <pomFile>${project.basedir}/uber-minimal-pom.xml</pomFile>
+              <sources>${project.build.directory}/${project.build.finalName}-sources.jar</sources>
+              <javadoc>${project.build.directory}/${project.build.finalName}-javadoc.jar</javadoc>
+              <files>${project.build.directory}/${project.build.finalName}-thin.jar</files>
+              <types>jar</types>
+              <classifiers>thin</classifiers>
+            </configuration>
+            <executions>
               <execution>
                 <id>sign-artifacts</id>
                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,7 @@
             <configuration>
              <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -629,7 +629,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.8.0</version>
             <configuration>
               <doclint>none</doclint>
               <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
@@ -647,17 +647,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-            <executions>
-              <execution>
-                <goals>
-                  <!-- Refer: https://maven.apache.org/plugins/maven-gpg-plugin/sign-and-deploy-file-mojo.html -->
-                  <goal>sign-and-deploy-file</goal>
-                </goals>
-                <phase>deploy</phase>
+          
                 <configuration>
-                  <file>${project.build.directory}/${project.build.finalName}.jar</file>
-                  <repositoryId>ossrh</repositoryId>
-                  <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
                   <!-- Prevent gpg from using pinentry programs -->
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>
@@ -671,47 +662,28 @@
                   <types>jar</types>
                   <classifiers>thin</classifiers>
                 </configuration>
+                <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>2.8.2</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
             <configuration>
-              <skip>true</skip>
+             <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
-<!--          <plugin>-->
-<!--            <groupId>org.sonatype.plugins</groupId>-->
-<!--            <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--            <version>1.6.13</version>-->
-<!--            <extensions>true</extensions>-->
-<!--            <configuration>-->
-<!--              <serverId>ossrh</serverId>-->
-<!--              <nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
-<!--              <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-<!--              <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>-->
-<!--            </configuration>-->
-<!--            <executions>-->
-<!--              <execution>-->
-<!--                <id>nexus-deploy</id>-->
-<!--                <phase>deploy</phase>-->
-<!--                <goals>-->
-<!--                  <goal>close</goal>-->
-<!--                  <goal>release</goal>-->
-<!--                </goals>-->
-<!--              </execution>-->
-<!--            </executions>-->
-<!--          </plugin>-->
         </plugins>
       </build>
-      <distributionManagement>
-        <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-      </distributionManagement>
     </profile>
   </profiles>
 </project>

--- a/uber-minimal-pom.xml
+++ b/uber-minimal-pom.xml
@@ -33,10 +33,4 @@
     <system>GitHub Issues</system>
     <url>https://github.com/databricks/databricks-jdbc/issues</url>
   </issueManagement>
-  <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 </project>


### PR DESCRIPTION
## Description
Moved the jar publishing action from the legacy OSSRH/Sonatype deployment approach to the new Maven Central Publishing and updated GitHub Actions workflow. 

More context - https://central.sonatype.org/news/20250326_ossrh_sunset/

## Plugin and Dependency Updates
Upgraded `maven-source-plugin` to version 3.3.1 (from 3.3.0).
Upgraded `maven-javadoc-plugin` to version 3.8.0 (from 3.6.0).

## Testing
Released the v1.0.8-oss using this action

## Additional Notes to the Reviewer
NA

`NO_CHANGELOG=true`

