### PR TITLE
parameterised flush to check batch size for force flush calls

### DIFF
--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -95,9 +95,8 @@ public class TelemetryClient implements ITelemetryClient {
   }
 
   /**
-   *
-   * @param forceFlush - Flushes the eventsBatch for all size variations if forceFlush,
-   *                   otherwise only flushes if  eventsBatch size has breached
+   * @param forceFlush - Flushes the eventsBatch for all size variations if forceFlush, otherwise
+   *     only flushes if eventsBatch size has breached
    */
   private void flush(boolean forceFlush) {
     synchronized (this) {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -68,7 +68,7 @@ public class TelemetryClient implements ITelemetryClient {
   private void periodicFlush() {
     long now = System.currentTimeMillis();
     if (now - lastFlushedTime >= flushIntervalMillis) {
-      flush();
+      flush(true);
     }
   }
 
@@ -78,8 +78,8 @@ public class TelemetryClient implements ITelemetryClient {
       eventsBatch.add(event);
     }
 
-    if (eventsBatch.size() == eventsBatchSize) {
-      flush();
+    if (isBatchFull()) {
+      flush(false);
     }
   }
 
@@ -87,16 +87,16 @@ public class TelemetryClient implements ITelemetryClient {
   public void close() {
     // Export any pending latency telemetry before flushing
     TelemetryCollector.getInstance().exportAllPendingTelemetryDetails();
-    flush();
+    flush(true);
     if (flushTask != null) {
       flushTask.cancel(false);
     }
     scheduledExecutorService.shutdown();
   }
 
-  private void flush() {
+  private void flush(boolean forceFlush) {
     synchronized (this) {
-      if (!eventsBatch.isEmpty()) {
+      if (!forceFlush ? isBatchFull() : !eventsBatch.isEmpty()) {
         List<TelemetryFrontendLog> logsToBeFlushed = eventsBatch;
         executorService.submit(
             new TelemetryPushTask(logsToBeFlushed, isAuthEnabled, context, databricksConfig));
@@ -104,6 +104,10 @@ public class TelemetryClient implements ITelemetryClient {
       }
       lastFlushedTime = System.currentTimeMillis();
     }
+  }
+
+  private boolean isBatchFull() {
+    return eventsBatch.size() >= eventsBatchSize;
   }
 
   int getCurrentSize() {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -94,6 +94,11 @@ public class TelemetryClient implements ITelemetryClient {
     scheduledExecutorService.shutdown();
   }
 
+  /**
+   *
+   * @param forceFlush - Flushes the eventsBatch for all size variations if forceFlush,
+   *                   otherwise only flushes if  eventsBatch size has breached
+   */
   private void flush(boolean forceFlush) {
     synchronized (this) {
       if (!forceFlush ? isBatchFull() : !eventsBatch.isEmpty()) {

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
@@ -218,7 +218,7 @@ public class TelemetryClientTest {
           new TelemetryFrontendLog()
               .setFrontendLogEventId("event2")); // This should trigger flush due to batch size
 
-      //assert that the flush occurred
+      // assert that the flush occurred
       assertEquals(0, client.getCurrentSize());
 
       // Wait 2 seconds (less than the flush interval)
@@ -231,7 +231,8 @@ public class TelemetryClientTest {
       assertEquals(1, client.getCurrentSize());
 
       // Wait another 8 seconds (still less than full interval from last flush)
-      //NOTE: Ideally flush should happen just after 3 seconds but considering the thread switch timings adding a buffer of 5 more seconds
+      // NOTE: Ideally flush should happen just after 3 seconds but considering the thread switch
+      // timings adding a buffer of 6 more seconds
       Thread.sleep(8000);
 
       // Verify it's still not flushed

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
@@ -230,11 +230,12 @@ public class TelemetryClientTest {
       // Verify it's still in the batch (shouldn't have been flushed yet since timer was reset)
       assertEquals(1, client.getCurrentSize());
 
-      // Wait another 2 seconds (still less than full interval from last flush)
-      Thread.sleep(2000);
+      // Wait another 8 seconds (still less than full interval from last flush)
+      //NOTE: Ideally flush should happen just after 3 seconds but considering the thread switch timings adding a buffer of 5 more seconds
+      Thread.sleep(8000);
 
       // Verify it's still not flushed
-      assertEquals(1, client.getCurrentSize());
+      assertEquals(0, client.getCurrentSize());
 
     } finally {
       // Clean up resources

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
@@ -218,6 +218,9 @@ public class TelemetryClientTest {
           new TelemetryFrontendLog()
               .setFrontendLogEventId("event2")); // This should trigger flush due to batch size
 
+      //assert that the flush occurred
+      assertEquals(0, client.getCurrentSize());
+
       // Wait 2 seconds (less than the flush interval)
       Thread.sleep(2000);
 


### PR DESCRIPTION
## Description
Current implementation of telemetry is not 100% thread safe. For a complex thread switch scenario it can flush the batch without having full size in it. 

Detail - 
Thread A adds to the batch making size N - 1 ( assuming eventsBatchSize === N )
[Context Switch] Thread B adds to the batch making size N
Both Thread A & Thread B verifies that they need to flush and try to flush the events
Thread B flushes the batch
[Context Switch] Thread C adds new event to the Batch
[Context Switch] Thread A enters the flush block and checks eventBatch is not empty and ends up flushing just 1 event. 

## Testing
Existing Test Unit. 

## Additional Notes to the Reviewer
Fix: For schedule & close connection call we still flush everything from the batch if it is not empty but for non force calls we only flush if the batch has breached the threshold. 

NO_CHANGELOG=true
