### PR TITLE
[PECOBLR-703][PECOBLR-735] Improve telemetry performance + Force telemetry to use daemon threads

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/ProcessNameUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ProcessNameUtil.java
@@ -2,15 +2,13 @@ package com.databricks.jdbc.common.util;
 
 import static com.databricks.jdbc.common.util.WildcardUtil.isNullOrEmpty;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Utility class for determining the current process name as it would appear in Activity Monitor.
+ * Note : removing logging as it methods are called on static INIT and logging might not be fully
+ * configured.
  */
 public class ProcessNameUtil {
   private static final String FALL_BACK_PROCESS_NAME = "UnknownJavaProcess";
-  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessNameUtil.class);
 
   /**
    * Gets the current process name as it would appear in Activity Monitor.
@@ -22,14 +20,12 @@ public class ProcessNameUtil {
       // Step 1: Try ProcessHandle API (Java 9+)
       String processName = getProcessNameFromHandle();
       if (!isNullOrEmpty(processName)) {
-        LOGGER.trace("getProcessNameFromHandle: {}", processName);
         return processName;
       }
 
       // Fallback
       return FALL_BACK_PROCESS_NAME;
     } catch (Exception e) {
-      LOGGER.trace("Error getting process name {}, returning fallback", e);
       return FALL_BACK_PROCESS_NAME;
     }
   }
@@ -62,7 +58,6 @@ public class ProcessNameUtil {
       }
       return null;
     } catch (Exception e) {
-      LOGGER.trace("Error getting process name from handle {}, returning null", e);
       return null;
     }
   }

--- a/src/main/java/com/databricks/jdbc/model/telemetry/StatementTelemetryDetails.java
+++ b/src/main/java/com/databricks/jdbc/model/telemetry/StatementTelemetryDetails.java
@@ -10,7 +10,10 @@ import com.databricks.jdbc.model.telemetry.latency.ResultLatency;
 public class StatementTelemetryDetails {
   private boolean isInternalCall;
   private final ChunkDetails chunkDetails;
-  private final ResultLatency resultLatency;
+  private final ResultLatency resultLatency =
+      new ResultLatency()
+          .setResultSetReadyLatencyMillis(null)
+          .setResultSetConsumptionLatencyMillis(null);
   private final OperationDetail operationDetail;
   private Long operationLatencyMillis;
   private final String statementId;
@@ -25,10 +28,6 @@ public class StatementTelemetryDetails {
 
   public StatementTelemetryDetails(String statementId) {
     this.chunkDetails = new ChunkDetails();
-    this.resultLatency =
-        new ResultLatency()
-            .setResultSetReadyLatencyMillis(null)
-            .setResultSetConsumptionLatencyMillis(null);
     this.isInternalCall = false;
     this.operationDetail = new OperationDetail(isInternalCall);
     this.operationLatencyMillis = null;

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -91,12 +91,7 @@ public class TelemetryClient implements ITelemetryClient {
   @Override
   public void exportEvent(TelemetryFrontendLog event) {
     synchronized (this) {
-      boolean wasEmpty = eventsBatch.isEmpty();
       eventsBatch.add(event);
-      if (wasEmpty) {
-        // Reset the inactivity timer so periodic flush occurs relative to the last activity
-        lastFlushedTime = System.currentTimeMillis();
-      }
     }
 
     if (eventsBatch.size() == eventsBatchSize) {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClient.java
@@ -91,7 +91,12 @@ public class TelemetryClient implements ITelemetryClient {
   @Override
   public void exportEvent(TelemetryFrontendLog event) {
     synchronized (this) {
+      boolean wasEmpty = eventsBatch.isEmpty();
       eventsBatch.add(event);
+      if (wasEmpty) {
+        // Reset the inactivity timer so periodic flush occurs relative to the last activity
+        lastFlushedTime = System.currentTimeMillis();
+      }
     }
 
     if (eventsBatch.size() == eventsBatchSize) {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
@@ -10,6 +10,8 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.LinkedHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TelemetryClientFactory {
 
@@ -26,8 +28,21 @@ public class TelemetryClientFactory {
 
   private final ExecutorService telemetryExecutorService;
 
+  private static ThreadFactory createThreadFactory() {
+    return new ThreadFactory() {
+      private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+      @Override
+      public Thread newThread(Runnable r) {
+        Thread thread = new Thread(r, "Telemetry-Thread-" + threadNumber.getAndIncrement());
+        thread.setDaemon(true);
+        return thread;
+      }
+    };
+  }
+
   private TelemetryClientFactory() {
-    telemetryExecutorService = Executors.newFixedThreadPool(10);
+    telemetryExecutorService = Executors.newFixedThreadPool(10, createThreadFactory());
   }
 
   public static TelemetryClientFactory getInstance() {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
@@ -35,7 +35,7 @@ public class TelemetryClientFactory {
       @Override
       public Thread newThread(Runnable r) {
         Thread thread = new Thread(r, "Telemetry-Thread-" + threadNumber.getAndIncrement());
-        thread.setDaemon(true);
+        thread.setDaemon(false);
         return thread;
       }
     };

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryPushTask.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryPushTask.java
@@ -84,6 +84,7 @@ class TelemetryPushTask implements Runnable {
       HttpPost post = new HttpPost(uri);
       post.setEntity(
           new StringEntity(objectMapper.writeValueAsString(request), StandardCharsets.UTF_8));
+      System.out.println("Telemetry response: " + objectMapper.writeValueAsString(request));
       DatabricksJdbcConstants.JSON_HTTP_HEADERS.forEach(post::addHeader);
       Map<String, String> authHeaders =
           isAuthenticated ? databricksConfig.authenticate() : Collections.emptyMap();

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryPushTask.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryPushTask.java
@@ -52,7 +52,7 @@ class TelemetryPushTask implements Runnable {
 
   @Override
   public void run() {
-    LOGGER.debug("Pushing Telemetry logs of size {}", queueToBePushed.size());
+    LOGGER.trace("Pushing Telemetry logs of size {}", queueToBePushed.size());
     TelemetryRequest request = new TelemetryRequest();
     if (queueToBePushed.isEmpty()) {
       return;
@@ -67,7 +67,7 @@ class TelemetryPushTask implements Runnable {
                         try {
                           return objectMapper.writeValueAsString(event);
                         } catch (JsonProcessingException e) {
-                          LOGGER.error(
+                          LOGGER.trace(
                               "Failed to serialize Telemetry event {} with error: {}", event, e);
                           return null; // Return null for failed serialization
                         }
@@ -84,7 +84,6 @@ class TelemetryPushTask implements Runnable {
       HttpPost post = new HttpPost(uri);
       post.setEntity(
           new StringEntity(objectMapper.writeValueAsString(request), StandardCharsets.UTF_8));
-      System.out.println("Telemetry response: " + objectMapper.writeValueAsString(request));
       DatabricksJdbcConstants.JSON_HTTP_HEADERS.forEach(post::addHeader);
       Map<String, String> authHeaders =
           isAuthenticated ? databricksConfig.authenticate() : Collections.emptyMap();
@@ -99,13 +98,13 @@ class TelemetryPushTask implements Runnable {
         TelemetryResponse telResponse =
             objectMapper.readValue(
                 EntityUtils.toString(response.getEntity()), TelemetryResponse.class);
-        LOGGER.debug(
+        LOGGER.trace(
             "Pushed Telemetry logs with request-Id {} with events {} with error count {}",
             response.getFirstHeader(REQUEST_ID_HEADER),
             telResponse.getNumProtoSuccess(),
             telResponse.getErrors().size());
         if (!telResponse.getErrors().isEmpty()) {
-          LOGGER.debug("Failed to push telemetry logs with error: {}", telResponse.getErrors());
+          LOGGER.trace("Failed to push telemetry logs with error: {}", telResponse.getErrors());
         }
         if (queueToBePushed.size() != telResponse.getNumProtoSuccess()) {
           LOGGER.debug(

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
@@ -11,10 +11,12 @@ import com.databricks.jdbc.model.client.thrift.generated.TSparkRowSetType;
 import com.databricks.jdbc.model.telemetry.StatementTelemetryDetails;
 import com.databricks.jdbc.model.telemetry.enums.ExecutionResultFormat;
 import com.databricks.jdbc.model.telemetry.latency.OperationType;
+import com.databricks.jdbc.telemetry.TelemetryClientFactory;
 import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.databricks.sdk.service.sql.Format;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Context handler for tracking telemetry details for Databricks JDBC driver. This class manages
@@ -30,6 +32,10 @@ public class TelemetryCollector {
   // Per-statement latency tracking using StatementLatencyDetails
   private final ConcurrentHashMap<String, StatementTelemetryDetails> statementTrackers =
       new ConcurrentHashMap<>();
+
+  // Use the shared daemon executor from TelemetryClientFactory
+  private final ExecutorService exporterExecutor =
+      TelemetryClientFactory.getInstance().getTelemetryExecutorService();
 
   private TelemetryCollector() {
     // Private constructor for singleton
@@ -79,9 +85,12 @@ public class TelemetryCollector {
       exportTelemetryDetailsAndClear(statementId);
       return;
     }
-    TelemetryHelper.exportTelemetryLog(
-        new StatementTelemetryDetails(statementId)
-            .recordOperationLatency(latencyMillis, operationType));
+    if (statementId == null) {
+      return;
+    }
+    statementTrackers
+        .computeIfAbsent(statementId, k -> new StatementTelemetryDetails(statementId))
+        .recordOperationLatency(latencyMillis, operationType);
   }
 
   /**
@@ -163,7 +172,7 @@ public class TelemetryCollector {
    */
   private void exportTelemetryDetailsAndClear(String statementId) {
     StatementTelemetryDetails statementTelemetryDetails = statementTrackers.remove(statementId);
-    TelemetryHelper.exportTelemetryLog(statementTelemetryDetails);
+    exporterExecutor.submit(() -> TelemetryHelper.exportTelemetryLog(statementTelemetryDetails));
   }
 
   public void setResultFormat(

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
@@ -11,12 +11,10 @@ import com.databricks.jdbc.model.client.thrift.generated.TSparkRowSetType;
 import com.databricks.jdbc.model.telemetry.StatementTelemetryDetails;
 import com.databricks.jdbc.model.telemetry.enums.ExecutionResultFormat;
 import com.databricks.jdbc.model.telemetry.latency.OperationType;
-import com.databricks.jdbc.telemetry.TelemetryClientFactory;
 import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.databricks.sdk.service.sql.Format;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Context handler for tracking telemetry details for Databricks JDBC driver. This class manages
@@ -32,10 +30,6 @@ public class TelemetryCollector {
   // Per-statement latency tracking using StatementLatencyDetails
   private final ConcurrentHashMap<String, StatementTelemetryDetails> statementTrackers =
       new ConcurrentHashMap<>();
-
-  // Use the shared daemon executor from TelemetryClientFactory
-  private final ExecutorService exporterExecutor =
-      TelemetryClientFactory.getInstance().getTelemetryExecutorService();
 
   private TelemetryCollector() {
     // Private constructor for singleton
@@ -85,12 +79,9 @@ public class TelemetryCollector {
       exportTelemetryDetailsAndClear(statementId);
       return;
     }
-    if (statementId == null) {
-      return;
-    }
-    statementTrackers
-        .computeIfAbsent(statementId, k -> new StatementTelemetryDetails(statementId))
-        .recordOperationLatency(latencyMillis, operationType);
+    TelemetryHelper.exportTelemetryLog(
+        new StatementTelemetryDetails(statementId)
+            .recordOperationLatency(latencyMillis, operationType));
   }
 
   /**
@@ -172,7 +163,7 @@ public class TelemetryCollector {
    */
   private void exportTelemetryDetailsAndClear(String statementId) {
     StatementTelemetryDetails statementTelemetryDetails = statementTrackers.remove(statementId);
-    exporterExecutor.submit(() -> TelemetryHelper.exportTelemetryLog(statementTelemetryDetails));
+    TelemetryHelper.exportTelemetryLog(statementTelemetryDetails);
   }
 
   public void setResultFormat(

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
@@ -4,17 +4,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
-import com.databricks.jdbc.model.telemetry.StatementTelemetryDetails;
 import com.databricks.jdbc.model.telemetry.latency.ChunkDetails;
 import com.databricks.jdbc.model.telemetry.latency.OperationType;
-import com.databricks.jdbc.telemetry.TelemetryHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.MockedStatic;
 
 public class TelemetryCollectorTest {
   private final TelemetryCollector handler = TelemetryCollector.getInstance();
@@ -66,12 +63,16 @@ public class TelemetryCollectorTest {
     String methodName = "closeStatement";
     long latency = 100L;
 
-    try (MockedStatic<TelemetryHelper> mockedStatic = mockStatic(TelemetryHelper.class)) {
-      handler.recordOperationLatency(latency, methodName);
-
-      mockedStatic.verify(
-          () -> TelemetryHelper.exportTelemetryLog(any(StatementTelemetryDetails.class)));
+    // Ensure telemetry is collected for the statement id prior to close
+    handler.recordGetOperationStatus(TEST_STATEMENT_ID, 1L);
+    handler.recordOperationLatency(latency, methodName);
+    // Allow asynchronous export to complete and internal map to be cleared
+    try {
+      Thread.sleep(200);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
+    assertNull(handler.getTelemetryDetails(TEST_STATEMENT_ID));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

- Performance improvements : 
  -  Centralised thread pool, to avoid OOM and improve performance
  - Force executors on every export event
 - There are 2 types of thread creation : 
    - One for in-general flush 
    - One for scheduling flush every 300 seconds. (Daemon threads were not being in this - this prevented JVM from exiting. This PR changes that too)


## Testing
- Manually tested E2E using `ForceEnableTelemetry=1`


NO_CHANGELOG=true

