### PR TITLE
parameterised flush to check batch size for force flush calls

### DIFF
--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
@@ -230,10 +230,10 @@ public class TelemetryClientTest {
       // Verify it's still in the batch (shouldn't have been flushed yet since timer was reset)
       assertEquals(1, client.getCurrentSize());
 
-      // Wait another 8 seconds (still less than full interval from last flush)
+      // Wait another 5 seconds (still less than full interval from last flush)
       // NOTE: Ideally flush should happen just after 3 seconds but considering the thread switch
       // timings adding a buffer of 6 more seconds
-      Thread.sleep(8000);
+      Thread.sleep(5000);
 
       // Verify it's  flushed
       assertEquals(0, client.getCurrentSize());

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryClientTest.java
@@ -218,6 +218,9 @@ public class TelemetryClientTest {
           new TelemetryFrontendLog()
               .setFrontendLogEventId("event2")); // This should trigger flush due to batch size
 
+      // assert that the flush occurred
+      assertEquals(0, client.getCurrentSize());
+
       // Wait 2 seconds (less than the flush interval)
       Thread.sleep(2000);
 
@@ -227,11 +230,13 @@ public class TelemetryClientTest {
       // Verify it's still in the batch (shouldn't have been flushed yet since timer was reset)
       assertEquals(1, client.getCurrentSize());
 
-      // Wait another 2 seconds (still less than full interval from last flush)
-      Thread.sleep(2000);
+      // Wait another 8 seconds (still less than full interval from last flush)
+      // NOTE: Ideally flush should happen just after 3 seconds but considering the thread switch
+      // timings adding a buffer of 6 more seconds
+      Thread.sleep(8000);
 
-      // Verify it's still not flushed
-      assertEquals(1, client.getCurrentSize());
+      // Verify it's  flushed
+      assertEquals(0, client.getCurrentSize());
 
     } finally {
       // Clean up resources


### PR DESCRIPTION
## Description
Current implementation of telemetry is not 100% thread safe. For a complex thread switch scenario it can flush the batch without having full size in it.

Detail -
Thread A adds to the batch making size N - 1 ( assuming eventsBatchSize === N )
[Context Switch] Thread B adds to the batch making size N
Both Thread A & Thread B verifies that they need to flush and try to flush the events
Thread B flushes the batch
[Context Switch] Thread C adds new event to the Batch
[Context Switch] Thread A enters the flush block and checks eventBatch is not empty and ends up flushing just 1 event.



## Testing
Existing Test Unit.

## Additional Notes to the Reviewer
NA
NO_CHANGELOG=true
