### PR TITLE
Add Thrift statement-Id in debug logs, needed as we don't have enough logs in error cases

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
@@ -77,8 +77,18 @@ public class DatabricksThriftUtil {
 
   public static void verifySuccessStatus(TStatus status, String errorContext)
       throws DatabricksHttpException {
+    verifySuccessStatus(status, errorContext, null);
+  }
+
+  public static void verifySuccessStatus(TStatus status, String errorContext, String statementId)
+      throws DatabricksHttpException {
     if (!SUCCESS_STATUS_LIST.contains(status.getStatusCode())) {
-      String errorMessage = "Error thrift response received. " + errorContext;
+      String errorMessage =
+          statementId != null
+              ? String.format(
+                  "Error thrift response received [%s] for statementId [%s]",
+                  errorContext, statementId)
+              : String.format("Error thrift response received [%s]", errorContext);
       LOGGER.error(errorMessage);
       throw new DatabricksHttpException(errorMessage, status.getSqlState());
     }
@@ -320,22 +330,31 @@ public class DatabricksThriftUtil {
   }
 
   public static void checkDirectResultsForErrorStatus(
-      TSparkDirectResults directResults, String context) throws DatabricksHttpException {
+      TSparkDirectResults directResults, String context, String statementId)
+      throws DatabricksHttpException {
     if (directResults.isSetOperationStatus()) {
-      LOGGER.debug("direct result operation status being verified for success response");
-      verifySuccessStatus(directResults.getOperationStatus().getStatus(), context);
+      LOGGER.debug(
+          "direct result operation status being verified for success response for statementId {%s}",
+          statementId);
+      verifySuccessStatus(directResults.getOperationStatus().getStatus(), context, statementId);
     }
     if (directResults.isSetResultSetMetadata()) {
-      LOGGER.debug("direct results metadata being verified for success response");
-      verifySuccessStatus(directResults.getResultSetMetadata().getStatus(), context);
+      LOGGER.debug(
+          "direct results metadata being verified for success response for statementId {%s}",
+          statementId);
+      verifySuccessStatus(directResults.getResultSetMetadata().getStatus(), context, statementId);
     }
     if (directResults.isSetCloseOperation()) {
-      LOGGER.debug("direct results close operation verified for success response");
-      verifySuccessStatus(directResults.getCloseOperation().getStatus(), context);
+      LOGGER.debug(
+          "direct results close operation verified for success response for statementId {%s}",
+          statementId);
+      verifySuccessStatus(directResults.getCloseOperation().getStatus(), context, statementId);
     }
     if (directResults.isSetResultSet()) {
-      LOGGER.debug("direct result set being verified for success response");
-      verifySuccessStatus(directResults.getResultSet().getStatus(), context);
+      LOGGER.debug(
+          "direct result set being verified for success response for statementId {%s}",
+          statementId);
+      verifySuccessStatus(directResults.getResultSet().getStatus(), context, statementId);
     }
   }
 }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/StatementId.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/StatementId.java
@@ -8,6 +8,7 @@ import com.databricks.jdbc.exception.DatabricksDriverException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.client.thrift.generated.THandleIdentifier;
+import com.databricks.jdbc.model.client.thrift.generated.TOperationHandle;
 import java.util.Objects;
 
 /** A Statement-Id identifier to uniquely identify an executed statement */
@@ -75,6 +76,14 @@ public class StatementId {
   /** Returns a SQL Exec statement handle for the given StatementId */
   public String toSQLExecStatementId() {
     return guid;
+  }
+
+  /**
+   * Returns a loggable statement Id for the given Thrift operation handle. This is used for logging
+   * purposes to avoid logging sensitive information.
+   */
+  public static String loggableStatementId(TOperationHandle operationHandle) {
+    return new StatementId(operationHandle.getOperationId()).toSQLExecStatementId();
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
@@ -223,6 +223,11 @@ final class DatabricksThriftAccessor {
       checkResponseForErrors(response);
 
       StatementId statementId = new StatementId(response.getOperationHandle().operationId);
+      LOGGER.debug(
+          String.format(
+              "Executed statement for statementId [%s] in session [%s]",
+              statementId.toSQLExecStatementId(), session.getSessionId()));
+
       DatabricksThreadContextHolder.setStatementId(statementId);
       if (parentStatement != null) {
         parentStatement.setStatementId(statementId);
@@ -288,9 +293,11 @@ final class DatabricksThriftAccessor {
 
     TGetOperationStatusResp statusResp = null;
     if (response.isSetDirectResults()) {
-      checkDirectResultsForErrorStatus(response.getDirectResults(), response.toString());
+      checkDirectResultsForErrorStatus(
+          response.getDirectResults(), response.toString(), statementId.toSQLExecStatementId());
       statusResp = response.getDirectResults().getOperationStatus();
-      checkOperationStatusForErrors(statusResp);
+      checkOperationStatusForErrors(
+          statusResp, StatementId.loggableStatementId(response.getOperationHandle()));
     }
 
     TimeoutHandler timeoutHandler = getTimeoutHandler(response, timeoutInSeconds);
@@ -307,7 +314,7 @@ final class DatabricksThriftAccessor {
 
       // Polling for operation status
       statusResp = getOperationStatus(statusReq, statementId);
-      checkOperationStatusForErrors(statusResp);
+      checkOperationStatusForErrors(statusResp, statementId.toSQLExecStatementId());
       // Save some time if sleep isn't required by breaking.
       if (!shouldContinuePolling(statusResp)) {
         break;
@@ -364,6 +371,10 @@ final class DatabricksThriftAccessor {
       }
     }
     StatementId statementId = new StatementId(response.getOperationHandle().operationId);
+    LOGGER.debug(
+        String.format(
+            "Executed statement in async for statementId [%s] in session [%s]",
+            statementId.toSQLExecStatementId(), session.getSessionId()));
     DatabricksThreadContextHolder.setStatementId(statementId);
     if (parentStatement != null) {
       parentStatement.setStatementId(statementId);
@@ -379,7 +390,8 @@ final class DatabricksThriftAccessor {
       IDatabricksStatementInternal parentStatement,
       IDatabricksSession session)
       throws SQLException {
-    LOGGER.debug("Operation handle {}", operationHandle);
+    LOGGER.debug(
+        "getStatementResult for StatementId {}", StatementId.loggableStatementId(operationHandle));
 
     long getStatementResultStartTime = System.nanoTime();
     StatementId statementId = new StatementId(operationHandle.getOperationId());
@@ -492,7 +504,8 @@ final class DatabricksThriftAccessor {
       int maxRowsPerBlock,
       boolean fetchMetadata)
       throws DatabricksHttpException {
-    verifySuccessStatus(responseStatus, context);
+    String statementId = StatementId.loggableStatementId(operationHandle);
+    verifySuccessStatus(responseStatus, context, statementId);
     TFetchResultsReq request =
         new TFetchResultsReq()
             .setOperationHandle(operationHandle)
@@ -519,7 +532,8 @@ final class DatabricksThriftAccessor {
         response.getStatus(),
         String.format(
             "Error while fetching results Request {%s}. TFetchResultsResp {%s}. ",
-            request, response));
+            request, response),
+        statementId);
     return response;
   }
 
@@ -628,18 +642,25 @@ final class DatabricksThriftAccessor {
     // Get the operation status from direct results if present
     TGetOperationStatusResp statusResp = null;
     FResp directResultsField = response.fieldForId(directResultsFieldId);
-    if (response.isSet(directResultsField)) {
-      TSparkDirectResults directResults =
-          (TSparkDirectResults) response.getFieldValue(directResultsField);
-      checkDirectResultsForErrorStatus(directResults, contextDescription);
-      statusResp = directResults.getOperationStatus();
-      checkOperationStatusForErrors(statusResp);
-    }
 
     // Get the operation handle from the response
     FResp operationHandleField = response.fieldForId(operationHandleFieldId);
     TOperationHandle operationHandle =
-        (TOperationHandle) response.getFieldValue(operationHandleField);
+        response.isSet(operationHandleField)
+            ? (TOperationHandle) response.getFieldValue(operationHandleField)
+            : null;
+    String statementId =
+        (operationHandle != null) ? StatementId.loggableStatementId(operationHandle) : "null";
+
+    if (response.isSet(directResultsField)) {
+      TSparkDirectResults directResults =
+          (TSparkDirectResults) response.getFieldValue(directResultsField);
+      checkDirectResultsForErrorStatus(directResults, contextDescription, statementId);
+      statusResp = directResults.getOperationStatus();
+      checkOperationStatusForErrors(statusResp, statementId);
+    }
+
+    LOGGER.debug("Poll for operation status for statementId: {}", statementId);
 
     // Polling until query operation state is finished
     TGetOperationStatusReq statusReq =
@@ -648,7 +669,7 @@ final class DatabricksThriftAccessor {
             .setGetProgressUpdate(false);
     while (shouldContinuePolling(statusResp)) {
       statusResp = getThriftClient().GetOperationStatus(statusReq);
-      checkOperationStatusForErrors(statusResp);
+      checkOperationStatusForErrors(statusResp, statementId);
     }
 
     if (hasResultDataInDirectResults(response)) {
@@ -687,13 +708,15 @@ final class DatabricksThriftAccessor {
     }
   }
 
-  private void checkOperationStatusForErrors(TGetOperationStatusResp statusResp)
+  private void checkOperationStatusForErrors(TGetOperationStatusResp statusResp, String statementId)
       throws DatabricksSQLException {
     if (statusResp != null
         && statusResp.isSetOperationState()
         && isErrorOperationState(statusResp.getOperationState())) {
       String errorMsg =
-          String.format("Operation failed with error: %s", statusResp.getErrorMessage());
+          String.format(
+              "Operation failed with error: [%s] for statement [%s], with response [%s]",
+              statusResp.getErrorMessage(), statementId, statusResp);
       LOGGER.error(errorMsg);
       throw new DatabricksSQLException(errorMsg, statusResp.getSqlState());
     }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftAccessor.java
@@ -224,9 +224,9 @@ final class DatabricksThriftAccessor {
 
       StatementId statementId = new StatementId(response.getOperationHandle().operationId);
       LOGGER.debug(
-          String.format(
-              "Executed statement for statementId [%s] in session [%s]",
-              statementId.toSQLExecStatementId(), session.getSessionId()));
+          "Executed statement for statementId {} in session {}",
+          statementId.toSQLExecStatementId(),
+          session.getSessionId());
 
       DatabricksThreadContextHolder.setStatementId(statementId);
       if (parentStatement != null) {

--- a/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DatabricksThriftUtilTest.java
@@ -321,7 +321,10 @@ public class DatabricksThriftUtilTest {
   @ParameterizedTest
   @MethodSource("thriftDirectResultSets")
   public void testCheckDirectResultsForErrorStatus(TSparkDirectResults response) {
-    assertDoesNotThrow(() -> checkDirectResultsForErrorStatus(response, TEST_STRING));
+    assertDoesNotThrow(
+        () ->
+            checkDirectResultsForErrorStatus(
+                response, TEST_STRING, TEST_STATEMENT_ID.toSQLExecStatementId()));
   }
 
   @Test


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

Added Thrift statement-Id in debug logs for error scenarios and also as soon as they are available. The idea is to better debug issues by identifying the statement-Id in case of errors.

## Testing
<!-- Describe how the changes have been tested-->


## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

NO_CHANGELOG=true