### PR TITLE
[PECOBLR-764] compute new telemetry details if absent from export errorlogs

### DIFF
--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -125,7 +125,6 @@ public class TelemetryHelper {
       String errorMessage,
       String statementId,
       Long chunkIndex) {
-    LOGGER.trace(String.format("Exporting databricks failure logs for statement   %s. errorName %s errorMessage %s", statementId, errorName, errorMessage));
     StatementTelemetryDetails telemetryDetails =
         TelemetryCollector.getInstance().getOrCreateTelemetryDetails(statementId);
     DriverErrorInfo errorInfo =

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -125,8 +125,9 @@ public class TelemetryHelper {
       String errorMessage,
       String statementId,
       Long chunkIndex) {
+    LOGGER.trace(String.format("Exporting databricks failure logs for statement   %s. errorName %s errorMessage %s", statementId, errorName, errorMessage));
     StatementTelemetryDetails telemetryDetails =
-        TelemetryCollector.getInstance().getTelemetryDetails(statementId);
+        TelemetryCollector.getInstance().getOrCreateTelemetryDetails(statementId);
     DriverErrorInfo errorInfo =
         new DriverErrorInfo().setErrorName(errorName).setStackTrace(errorMessage);
     exportTelemetryEvent(connectionContext, telemetryDetails, errorInfo, chunkIndex);

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
@@ -112,8 +112,7 @@ public class TelemetryCollector {
   }
 
   /**
-   * Gets the telemetry details for a statement if present
-   * Otherwise creates a new one and persist
+   * Gets the telemetry details for a statement if present Otherwise creates a new one and persist
    *
    * @param statementId the statement ID
    */
@@ -122,8 +121,8 @@ public class TelemetryCollector {
       LOGGER.trace("Statement ID is null, returning null telemetry details");
       return null;
     }
-    return statementTrackers
-            .computeIfAbsent(statementId, k -> new StatementTelemetryDetails(statementId));
+    return statementTrackers.computeIfAbsent(
+        statementId, k -> new StatementTelemetryDetails(statementId));
   }
 
   /**

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
@@ -112,6 +112,21 @@ public class TelemetryCollector {
   }
 
   /**
+   * Gets the telemetry details for a statement if present
+   * Otherwise creates a new one and persist
+   *
+   * @param statementId the statement ID
+   */
+  public StatementTelemetryDetails getOrCreateTelemetryDetails(String statementId) {
+    if (statementId == null) {
+      LOGGER.trace("Statement ID is null, returning null telemetry details");
+      return null;
+    }
+    return statementTrackers
+            .computeIfAbsent(statementId, k -> new StatementTelemetryDetails(statementId));
+  }
+
+  /**
    * Exports all pending telemetry details and clears the trackers. This method is called when the
    * connection/client is being closed.
    */

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
@@ -83,4 +83,32 @@ public class TelemetryCollectorTest {
             || operationType == OperationType.DELETE_SESSION;
     assertEquals(expected, handler.isCloseOperation(operationType));
   }
+
+  @Test
+  void testReturnsNullIfStatementIdIsNull() {
+    assertNull(handler.getOrCreateTelemetryDetails(null));
+  }
+
+  @Test
+  void testCreatesNewTelemetryDetailsIfAbsent() {
+    String statementId = TEST_STATEMENT_ID;
+    assertNull(handler.getTelemetryDetails(statementId));
+
+    StatementTelemetryDetails details = handler.getOrCreateTelemetryDetails(statementId);
+
+    assertNotNull(details);
+    assertEquals(statementId, details.getStatementId());
+    assertSame(details,handler.getTelemetryDetails(statementId));
+  }
+
+  @Test
+  void testReturnsExistingTelemetryDetailsIfPresent() {
+    String statementId = TEST_STATEMENT_ID;
+    handler.recordGetOperationStatus(statementId, 1000L);
+    assertNotNull(handler.getTelemetryDetails(statementId));
+    StatementTelemetryDetails existing = handler.getTelemetryDetails(statementId);
+    StatementTelemetryDetails result = handler.getOrCreateTelemetryDetails(statementId);
+    assertSame(existing, result);
+    assertEquals(statementId, result.getStatementId());
+  }
 }

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
@@ -98,7 +98,7 @@ public class TelemetryCollectorTest {
 
     assertNotNull(details);
     assertEquals(statementId, details.getStatementId());
-    assertSame(details,handler.getTelemetryDetails(statementId));
+    assertSame(details, handler.getTelemetryDetails(statementId));
   }
 
   @Test


### PR DESCRIPTION
## Description
In current code during an exception scenario the exportFailureLogs expects that the TelemetryCollector would already have statement details for the given statementId. But that is not true hence making this consistent with other method behaviour where we initialise a new instance of statementDetails. 

## Testing
Attaching test file with example details
1. Without connection close command
2. With connection close command

[closed_connection_command_0.txt](https://github.com/user-attachments/files/21729464/closed_connection_command_0.txt)
[closed_connection_command_1.txt](https://github.com/user-attachments/files/21729465/closed_connection_command_1.txt)


## Additional Notes to the [Reviewer]
NO_CHANGELOG=true

[closed_connection_command_1.txt](https://github.com/user-attachments/files/21729463/closed_connection_command_1.txt)
