### PR TITLE
Fix passing of encoded userAgent string in BITool+ Add system configuration in every telemetry request

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,5 +14,6 @@ AbstractArrowResultChunk
 - Fixed Statement.getUpdateCount to return -1 for non-DML queries.
 - Fixed Statement.setMaxRows(0) to be interepeted as no limit.
 - Fixed retry behaviour to not throw an exception when there is no retry-after header for 503 and 429 status codes.
+- Fixed encoded UserAgent parsing in BI tools.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -23,6 +23,7 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.jdbc.telemetry.TelemetryClientFactory;
+import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.*;
 import java.util.*;
@@ -58,6 +59,7 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
     DatabricksThreadContextHolder.setConnectionContext(connectionContext);
     this.session = new DatabricksSession(connectionContext, testDatabricksClient);
     UserAgentManager.setUserAgent(connectionContext);
+    TelemetryHelper.updateTelemetryAppName(connectionContext, null);
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
@@ -9,7 +9,6 @@ import com.databricks.jdbc.common.CompressionCodec;
 import com.databricks.jdbc.common.DatabricksClientType;
 import com.databricks.jdbc.common.DatabricksJdbcUrlParams;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
-import com.databricks.jdbc.common.util.UserAgentManager;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
 import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
 import com.databricks.jdbc.dbclient.impl.sqlexec.DatabricksEmptyMetadataClient;
@@ -21,6 +20,7 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksTemporaryRedirectException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
+import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimedProcessor;
 import com.databricks.sdk.support.ToStringer;
 import com.google.common.annotations.VisibleForTesting;
@@ -266,7 +266,7 @@ public class DatabricksSession implements IDatabricksSession {
 
     // If application name is being set, update both telemetry and user agent
     if (name.equalsIgnoreCase(DatabricksJdbcUrlParams.APPLICATION_NAME.getParamName())) {
-      UserAgentManager.updateUserAgentAndTelemetry(connectionContext, value);
+      TelemetryHelper.updateTelemetryAppName(connectionContext, value);
     }
 
     clientInfoProperties.put(name, value);

--- a/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
+++ b/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
@@ -1,11 +1,14 @@
 package com.databricks.jdbc.common.util;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.log.JdbcLogger;
+import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.sdk.core.UserAgent;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
 public class UserAgentManager {
+  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(UserAgentManager.class);
   private static final String SDK_USER_AGENT = "databricks-sdk-java";
   private static final String JDBC_HTTP_USER_AGENT = "databricks-jdbc-http";
   private static final String DEFAULT_USER_AGENT = "DatabricksJDBCDriverOSS";
@@ -23,7 +26,10 @@ public class UserAgentManager {
     // Set the base product and client info
     UserAgent.withProduct(DEFAULT_USER_AGENT, DriverUtil.getDriverVersion());
     UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, connectionContext.getClientUserAgent());
-    if (connectionContext.getCustomerUserAgent() != null) {
+    if (connectionContext.getCustomerUserAgent() == null) {
+      return;
+    }
+    try {
       String decodedUA =
           URLDecoder.decode(
               connectionContext.getCustomerUserAgent(),
@@ -32,6 +38,11 @@ public class UserAgentManager {
       String customerName = (i < 0) ? decodedUA : decodedUA.substring(0, i);
       String customerVersion = (i < 0) ? VERSION_FILLER : decodedUA.substring(i + 1);
       UserAgent.withOtherInfo(customerName, UserAgent.sanitize(customerVersion));
+    } catch (Exception e) {
+      LOGGER.debug(
+          "Failed to set user agent for customer userAgent entry {}, Error {}",
+          connectionContext.getCustomerUserAgent(),
+          e);
     }
   }
 

--- a/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
+++ b/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
@@ -1,9 +1,6 @@
 package com.databricks.jdbc.common.util;
 
-import static com.databricks.jdbc.common.util.WildcardUtil.isNullOrEmpty;
-
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
-import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.databricks.sdk.core.UserAgent;
 
 public class UserAgentManager {
@@ -13,7 +10,6 @@ public class UserAgentManager {
   private static final String CLIENT_USER_AGENT_PREFIX = "Java";
   public static final String USER_AGENT_SEA_CLIENT = "SQLExecHttpClient";
   public static final String USER_AGENT_THRIFT_CLIENT = "THttpClient";
-  private static final String APP_NAME_SYSTEM_PROPERTY = "app.name";
   private static final String VERSION_FILLER = "version";
 
   /**
@@ -26,59 +22,11 @@ public class UserAgentManager {
     UserAgent.withProduct(DEFAULT_USER_AGENT, DriverUtil.getDriverVersion());
     UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, connectionContext.getClientUserAgent());
 
-    // Update application name for both telemetry and user agent
-    updateUserAgentAndTelemetry(connectionContext, null);
-  }
-
-  /**
-   * Determines the application name using a fallback mechanism: 1. useragententry url param 2.
-   * applicationname url param 3. client info property "applicationname" 4. System property app.name
-   *
-   * @param connectionContext The connection context
-   * @param clientInfoAppName The application name from client info properties, can be null
-   * @return The determined application name or null if none is found
-   */
-  static String determineApplicationName(
-      IDatabricksConnectionContext connectionContext, String clientInfoAppName) {
-    // First check URL params
-    String appName = connectionContext.getCustomerUserAgent();
-    if (!isNullOrEmpty(appName)) {
-      return appName;
-    }
-
-    // Then check application name URL param
-    appName = connectionContext.getApplicationName();
-    if (!isNullOrEmpty(appName)) {
-      return appName;
-    }
-
-    // Then check client info property
-    if (!isNullOrEmpty(clientInfoAppName)) {
-      return clientInfoAppName;
-    }
-
-    // Finally check system property
-    return System.getProperty(APP_NAME_SYSTEM_PROPERTY);
-  }
-
-  /**
-   * Updates both the telemetry client app name and HTTP user agent headers. To be called during
-   * connection initialization and when app name changes.
-   *
-   * @param connectionContext The connection context
-   * @param clientInfoAppName Optional client info app name, can be null
-   */
-  public static void updateUserAgentAndTelemetry(
-      IDatabricksConnectionContext connectionContext, String clientInfoAppName) {
-    String appName = determineApplicationName(connectionContext, clientInfoAppName);
-    if (!isNullOrEmpty(appName)) {
-      // Update telemetry
-      TelemetryHelper.updateClientAppName(appName);
-
-      // Update HTTP user agent
-      int i = appName.indexOf('/');
-      String customerName = (i < 0) ? appName : appName.substring(0, i);
-      String customerVersion = (i < 0) ? VERSION_FILLER : appName.substring(i + 1);
+    String inputUserAgent = connectionContext.getCustomerUserAgent();
+    if (inputUserAgent != null) {
+      int i = inputUserAgent.indexOf('/');
+      String customerName = (i < 0) ? inputUserAgent : inputUserAgent.substring(0, i);
+      String customerVersion = (i < 0) ? VERSION_FILLER : inputUserAgent.substring(i + 1);
       UserAgent.withOtherInfo(customerName, UserAgent.sanitize(customerVersion));
     }
   }

--- a/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
+++ b/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
@@ -2,6 +2,8 @@ package com.databricks.jdbc.common.util;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.sdk.core.UserAgent;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class UserAgentManager {
   private static final String SDK_USER_AGENT = "databricks-sdk-java";
@@ -21,12 +23,14 @@ public class UserAgentManager {
     // Set the base product and client info
     UserAgent.withProduct(DEFAULT_USER_AGENT, DriverUtil.getDriverVersion());
     UserAgent.withOtherInfo(CLIENT_USER_AGENT_PREFIX, connectionContext.getClientUserAgent());
-
-    String inputUserAgent = connectionContext.getCustomerUserAgent();
-    if (inputUserAgent != null) {
-      int i = inputUserAgent.indexOf('/');
-      String customerName = (i < 0) ? inputUserAgent : inputUserAgent.substring(0, i);
-      String customerVersion = (i < 0) ? VERSION_FILLER : inputUserAgent.substring(i + 1);
+    if (connectionContext.getCustomerUserAgent() != null) {
+      String decodedUA =
+          URLDecoder.decode(
+              connectionContext.getCustomerUserAgent(),
+              StandardCharsets.UTF_8); // This is for encoded userAgentString
+      int i = decodedUA.indexOf('/');
+      String customerName = (i < 0) ? decodedUA : decodedUA.substring(0, i);
+      String customerVersion = (i < 0) ? VERSION_FILLER : decodedUA.substring(i + 1);
       UserAgent.withOtherInfo(customerName, UserAgent.sanitize(customerVersion));
     }
   }

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -30,6 +30,7 @@ public class TelemetryHelper {
   // Cache to store unique DriverConnectionParameters for each connectionUuid
   private static final ConcurrentHashMap<String, DriverConnectionParameters>
       connectionParameterCache = new ConcurrentHashMap<>();
+  private static final String APP_NAME_SYSTEM_PROPERTY = "app.name";
 
   @VisibleForTesting
   static final String TELEMETRY_FEATURE_FLAG_NAME =
@@ -53,12 +54,6 @@ public class TelemetryHelper {
 
   public static DriverSystemConfiguration getDriverSystemConfiguration() {
     return DRIVER_SYSTEM_CONFIGURATION;
-  }
-
-  public static void updateClientAppName(String clientAppName) {
-    if (!isNullOrEmpty(clientAppName)) {
-      DRIVER_SYSTEM_CONFIGURATION.setClientAppName(clientAppName);
-    }
   }
 
   public static boolean isTelemetryAllowedForConnection(IDatabricksConnectionContext context) {
@@ -308,5 +303,51 @@ public class TelemetryHelper {
       default:
         return OperationType.TYPE_UNSPECIFIED;
     }
+  }
+
+  /**
+   * Sets/updates client app name in telemetry
+   *
+   * @param connectionContext The connection context
+   * @param clientInfoAppName The application name from client info properties, can be null
+   */
+  public static void updateTelemetryAppName(
+      IDatabricksConnectionContext connectionContext, String clientInfoAppName) {
+    String appName = determineApplicationName(connectionContext, clientInfoAppName);
+    if (!isNullOrEmpty(appName)) {
+      DRIVER_SYSTEM_CONFIGURATION.setClientAppName(appName);
+    }
+  }
+
+  /**
+   * Determines the application name using a fallback mechanism: 1. useragententry url param 2.
+   * applicationname url param 3. client info property "applicationname" 4. System property app.name
+   *
+   * @param connectionContext The connection context
+   * @param clientInfoAppName The application name from client info properties, can be null
+   * @return The determined application name or null if none is found
+   */
+  @VisibleForTesting
+  static String determineApplicationName(
+      IDatabricksConnectionContext connectionContext, String clientInfoAppName) {
+    // First check URL params
+    String appName = connectionContext.getCustomerUserAgent();
+    if (!isNullOrEmpty(appName)) {
+      return appName;
+    }
+
+    // Then check application name URL param
+    appName = connectionContext.getApplicationName();
+    if (!isNullOrEmpty(appName)) {
+      return appName;
+    }
+
+    // Then check client info property
+    if (!isNullOrEmpty(clientInfoAppName)) {
+      return clientInfoAppName;
+    }
+
+    // Finally check system property
+    return System.getProperty(APP_NAME_SYSTEM_PROPERTY);
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -88,6 +88,7 @@ public class TelemetryHelper {
     }
     TelemetryEvent telemetryEvent =
         new TelemetryEvent()
+            .setDriverSystemConfiguration(DRIVER_SYSTEM_CONFIGURATION)
             .setDriverConnectionParameters(getDriverConnectionParameter(connectionContext))
             .setSessionId(DatabricksThreadContextHolder.getSessionId())
             .setDriverErrorInfo(errorInfo) // This is only set for failure logs

--- a/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
@@ -1,9 +1,8 @@
 package com.databricks.jdbc.common.util;
 
 import static com.databricks.jdbc.TestConstants.*;
-import static com.databricks.jdbc.common.util.UserAgentManager.determineApplicationName;
+import static com.databricks.jdbc.common.util.UserAgentManager.USER_AGENT_SEA_CLIENT;
 import static com.databricks.jdbc.common.util.UserAgentManager.getUserAgentString;
-import static com.databricks.jdbc.common.util.UserAgentManager.updateUserAgentAndTelemetry;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -12,14 +11,10 @@ import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.telemetry.TelemetryHelper;
 import java.util.Properties;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -42,88 +37,14 @@ public class UserAgentManagerTest {
     telemetryHelperMock.close();
   }
 
-  private static Stream<Arguments> provideApplicationNameTestCases() {
-    return Stream.of(
-        // Test case 1: UserAgentEntry takes precedence
-        Arguments.of(
-            "MyUserAgent",
-            "AppNameValue",
-            "ClientInfoApp",
-            "MyUserAgent",
-            "When useragententry is set"),
-        // Test case 2: ApplicationName is used when UserAgentEntry is null
-        Arguments.of(
-            null,
-            "AppNameValue",
-            "ClientInfoApp",
-            "AppNameValue",
-            "When useragententry is not set but applicationname is"),
-        // Test case 3: ClientInfo is used when both UserAgentEntry and ApplicationName are null
-        Arguments.of(
-            null,
-            null, // applicationName
-            "ClientInfoApp",
-            "ClientInfoApp",
-            "When URL params are not set but client info is provided"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("provideApplicationNameTestCases")
-  public void testDetermineApplicationName(
-      String customerUserAgent,
-      String applicationName,
-      String clientInfoApp,
-      String expectedResult) {
-    // Setup only necessary stubs
-    Mockito.lenient().when(connectionContext.getCustomerUserAgent()).thenReturn(customerUserAgent);
-    Mockito.lenient().when(connectionContext.getApplicationName()).thenReturn(applicationName);
-
-    // Execute
-    String result = determineApplicationName(connectionContext, clientInfoApp);
-
-    // Verify
-    assertEquals(expectedResult, result);
-  }
-
   @Test
-  public void testDetermineApplicationName_WithSystemProperty() {
-    // When falling back to system property
-    when(connectionContext.getCustomerUserAgent()).thenReturn(null);
-    when(connectionContext.getApplicationName()).thenReturn(null);
-
-    System.setProperty("app.name", "SystemPropApp");
-    try {
-      String result = determineApplicationName(connectionContext, null);
-      assertEquals("SystemPropApp", result);
-    } finally {
-      System.clearProperty("app.name");
-    }
-  }
-
-  @Test
-  public void testUpdateUserAgentAndTelemetry() {
-    // Test that both telemetry and user agent are updated
+  public void testUpdateUserAgent() {
+    // Test that user agent is updated
     when(connectionContext.getCustomerUserAgent()).thenReturn("TestApp");
-    //    when(UserAgent.sanitize("version")).thenReturn("version");
-
-    updateUserAgentAndTelemetry(connectionContext, null);
-
-    telemetryHelperMock.verify(() -> TelemetryHelper.updateClientAppName("TestApp"));
+    when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
+    UserAgentManager.setUserAgent(connectionContext);
     String userAgent = getUserAgentString();
     assertTrue(userAgent.contains("TestApp/version"));
-  }
-
-  @Test
-  public void testUpdateUserAgentAndTelemetry_WithVersion() {
-    // Test with app name containing version
-    when(connectionContext.getCustomerUserAgent()).thenReturn("MyApp/1.2.3");
-    //    when(UserAgent.sanitize("1.2.3")).thenReturn("1.2.3");
-
-    updateUserAgentAndTelemetry(connectionContext, null);
-
-    telemetryHelperMock.verify(() -> TelemetryHelper.updateClientAppName("MyApp/1.2.3"));
-    String userAgent = getUserAgentString();
-    assertTrue(userAgent.contains("MyApp/1.2.3"));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
@@ -58,6 +58,16 @@ public class UserAgentManagerTest {
   }
 
   @Test
+  public void testIncorrectUserAgentDoesNotThrowException() {
+    // Test that user agent is updated
+    when(connectionContext.getCustomerUserAgent()).thenReturn("DBeaver    25.1.4.202508031529");
+    when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
+    UserAgentManager.setUserAgent(connectionContext);
+    String userAgent = getUserAgentString();
+    assertFalse(userAgent.contains("DBeaver/25.1.4.202508031529"));
+  }
+
+  @Test
   void testUserAgentSetsClientCorrectly() throws DatabricksSQLException {
     // Thrift with all-purpose cluster
     IDatabricksConnectionContext connectionContext =

--- a/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
@@ -48,6 +48,16 @@ public class UserAgentManagerTest {
   }
 
   @Test
+  public void testEncodedUserAgent() {
+    // Test that user agent is updated
+    when(connectionContext.getCustomerUserAgent()).thenReturn("DBeaver%2F25.1.4.202508031529");
+    when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
+    UserAgentManager.setUserAgent(connectionContext);
+    String userAgent = getUserAgentString();
+    assertTrue(userAgent.contains("DBeaver/25.1.4.202508031529"));
+  }
+
+  @Test
   void testUserAgentSetsClientCorrectly() throws DatabricksSQLException {
     // Thrift with all-purpose cluster
     IDatabricksConnectionContext connectionContext =

--- a/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/UserAgentManagerTest.java
@@ -39,7 +39,7 @@ public class UserAgentManagerTest {
 
   @Test
   public void testUpdateUserAgent() {
-    // Test that user agent is updated
+    // Test that user agent is updated even without a version
     when(connectionContext.getCustomerUserAgent()).thenReturn("TestApp");
     when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
     UserAgentManager.setUserAgent(connectionContext);
@@ -49,22 +49,32 @@ public class UserAgentManagerTest {
 
   @Test
   public void testEncodedUserAgent() {
-    // Test that user agent is updated
-    when(connectionContext.getCustomerUserAgent()).thenReturn("DBeaver%2F25.1.4.202508031529");
+    // Test that user agent is updated even if it is encoded
+    when(connectionContext.getCustomerUserAgent())
+        .thenReturn("DBeaverEncoded%2F25.1.4.202508031529");
     when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
     UserAgentManager.setUserAgent(connectionContext);
     String userAgent = getUserAgentString();
-    assertTrue(userAgent.contains("DBeaver/25.1.4.202508031529"));
+    assertTrue(userAgent.contains("DBeaverEncoded/25.1.4.202508031529"));
   }
 
   @Test
   public void testIncorrectUserAgentDoesNotThrowException() {
-    // Test that user agent is updated
-    when(connectionContext.getCustomerUserAgent()).thenReturn("DBeaver    25.1.4.202508031529");
+    when(connectionContext.getCustomerUserAgent()).thenReturn("DBeaverInvalid~25.1.4.202508031529");
     when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
     UserAgentManager.setUserAgent(connectionContext);
     String userAgent = getUserAgentString();
-    assertFalse(userAgent.contains("DBeaver/25.1.4.202508031529"));
+    assertFalse(userAgent.contains("DBeaverInvalid"));
+  }
+
+  @Test
+  public void testUserAgentWithSlash() {
+    // Test that user agent with added version is updated
+    when(connectionContext.getCustomerUserAgent()).thenReturn("MyAppSlash/25.1.4.202508031529");
+    when(connectionContext.getClientUserAgent()).thenReturn(USER_AGENT_SEA_CLIENT);
+    UserAgentManager.setUserAgent(connectionContext);
+    String userAgent = getUserAgentString();
+    assertTrue(userAgent.contains("MyAppSlash/25.1.4.202508031529"));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.telemetry;
 
 import static com.databricks.jdbc.TestConstants.*;
 import static com.databricks.jdbc.common.safe.FeatureFlagTestUtil.enableFeatureFlagForTesting;
+import static com.databricks.jdbc.telemetry.TelemetryHelper.determineApplicationName;
 import static com.databricks.jdbc.telemetry.TelemetryHelper.isTelemetryAllowedForConnection;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -25,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -142,9 +144,10 @@ public class TelemetryHelperTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  @ValueSource(strings = {"test-app", "my-application", "databricks-jdbc"})
+  @ValueSource(
+      strings = {"test-app", "my-application", "databricks-jdbc", "DBeaver 25.1.4.202508031529"})
   void testUpdateClientAppName(String appName) {
-    assertDoesNotThrow(() -> TelemetryHelper.updateClientAppName(appName));
+    assertDoesNotThrow(() -> TelemetryHelper.updateTelemetryAppName(connectionContext, appName));
   }
 
   @Test
@@ -215,5 +218,63 @@ public class TelemetryHelperTest {
         new Object[] {"test-statement-id", 5L},
         new Object[] {null, null},
         new Object[] {null, 1L});
+  }
+
+  @Test
+  public void testDetermineApplicationName_WithSystemProperty() {
+    // When falling back to system property
+    when(connectionContext.getCustomerUserAgent()).thenReturn(null);
+    when(connectionContext.getApplicationName()).thenReturn(null);
+
+    System.setProperty("app.name", "SystemPropApp");
+    try {
+      String result = determineApplicationName(connectionContext, null);
+      assertEquals("SystemPropApp", result);
+    } finally {
+      System.clearProperty("app.name");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideApplicationNameTestCases")
+  public void testDetermineApplicationName(
+      String customerUserAgent,
+      String applicationName,
+      String clientInfoApp,
+      String expectedResult) {
+    // Setup only necessary stubs
+    Mockito.lenient().when(connectionContext.getCustomerUserAgent()).thenReturn(customerUserAgent);
+    Mockito.lenient().when(connectionContext.getApplicationName()).thenReturn(applicationName);
+
+    // Execute
+    String result = determineApplicationName(connectionContext, clientInfoApp);
+
+    // Verify
+    assertEquals(expectedResult, result);
+  }
+
+  private static Stream<Arguments> provideApplicationNameTestCases() {
+    return Stream.of(
+        // Test case 1: UserAgentEntry takes precedence
+        Arguments.of(
+            "MyUserAgent",
+            "AppNameValue",
+            "ClientInfoApp",
+            "MyUserAgent",
+            "When useragententry is set"),
+        // Test case 2: ApplicationName is used when UserAgentEntry is null
+        Arguments.of(
+            null,
+            "AppNameValue",
+            "ClientInfoApp",
+            "AppNameValue",
+            "When useragententry is not set but applicationname is"),
+        // Test case 3: ClientInfo is used when both UserAgentEntry and ApplicationName are null
+        Arguments.of(
+            null,
+            null, // applicationName
+            "ClientInfoApp",
+            "ClientInfoApp",
+            "When URL params are not set but client info is provided"));
   }
 }


### PR DESCRIPTION
## Description
- The intention of appName in telemetry is to understand BI tools using our driver. And we do not want that to break our UserAgent. This causes DBeaver to hang as it has a app name as `DBeaver%2F25.1.4.202508031529` (and encoded strings are not allowed in our userAgent check). This PR fixes that.
- To create dashboards, we need system configuration in every telemetry row. This PR also adds that.

## Testing
- Added unit tests
- Also tested manually using DBeaver Client

## Additional Notes to the Reviewer

- The userAgent is sent for all customers, and it may not be appropriate for us to send info like processName and appName as part of this. Moreover, UserAgent is supposed to be fixed for a JVM. The `unknown` string issue on thrift table will be addressed by telemetry now. (i.e., we will do a join between two tables to identify unknowns)

- BI tool Error that is fixed in this PR : 

<img width="812" height="21" alt="Screenshot 2025-08-14 at 4 42 33 PM" src="https://github.com/user-attachments/assets/77a3c01d-0306-4535-95da-67ae73ecc82e" />


