### PR TITLE
Empty schema to null

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -157,7 +157,12 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
               DatabricksDriverErrorCode.CONNECTION_ERROR);
         }
       }
-      return new DatabricksConnectionContext(url, hostValue, portValue, schema, propertiesMap);
+      return new DatabricksConnectionContext(
+          url,
+          hostValue,
+          portValue,
+          Objects.equals(schema, EMPTY_STRING) ? null : schema,
+          propertiesMap);
     } else {
       // Should never reach here, since we have already checked for url validity
       throw new DatabricksValidationException("Connection Context invalid state error");

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -154,6 +154,17 @@ class DatabricksConnectionContextTest {
   }
 
   @Test
+  public void testEmptySchemaConvertedToNull() throws DatabricksSQLException {
+    String urlWithEmptySchema =
+        "jdbc:databricks://sample-host.18.azuredatabricks.net:9999/;ssl=1;AuthMech=3;"
+            + "httpPath=/sql/1.0/warehouses/999999999;LogLevel=debug;LogPath=./test1;auth_flow=2";
+    DatabricksConnectionContext connectionContext =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(urlWithEmptySchema, properties);
+    assertNull(connectionContext.getSchema());
+  }
+
+  @Test
   public void testParseValidBasicUrl() throws DatabricksSQLException {
     // test default AuthMech
     Properties props = new Properties();


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Origin: com.databricks.sql.hive.thriftserver.DatabricksJdbcDialectTestSuite in runtime/Spark fails because the JDBC URL looks like `jdbc:databricks://sample-host.18.azuredatabricks.net:9999/;`. Note the empty string between the last slash and semi-colon. When parsing JDBC URL, we look for a schema entry between last slash (if present) and semi-colon. If it is empty, we should make it to null. 

## Testing
<!-- Describe how the changes have been tested-->
- Unit test
- com.databricks.sql.hive.thriftserver.DatabricksJdbcDialectTestSuite

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

