### PR TITLE
Skip file path validation for delete operation from DatabricksUCVolumeClient

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,6 @@
 ### Updated
 
 ### Fixed
-
+- Fixed `DatabricksUCVolumeClient` delete to skip file path validation and remove redundant dependency on `VolumeOperationAllowedLocalPaths`.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/src/main/java/com/databricks/jdbc/api/impl/volume/DatabricksUCVolumeClient.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/volume/DatabricksUCVolumeClient.java
@@ -451,6 +451,9 @@ public class DatabricksUCVolumeClient implements IDatabricksVolumeClient {
     boolean isOperationSucceeded = false;
 
     try (Statement statement = connection.createStatement()) {
+      IDatabricksStatementInternal databricksStatement =
+          statement.unwrap(IDatabricksStatementInternal.class);
+      databricksStatement.allowInputStreamForVolumeOperation(true);
       try (ResultSet resultSet = statement.executeQuery(deleteObjectQuery)) {
         LOGGER.info("SQL query executed successfully");
         if (resultSet.next()) {

--- a/src/test/java/com/databricks/client/jdbc/DatabricksDriverExamples.java
+++ b/src/test/java/com/databricks/client/jdbc/DatabricksDriverExamples.java
@@ -12,7 +12,6 @@ import com.databricks.jdbc.api.impl.DatabricksConnectionContextFactory;
 import com.databricks.jdbc.api.impl.DatabricksResultSetMetaData;
 import com.databricks.jdbc.api.impl.volume.DatabricksVolumeClientFactory;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
-import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.model.client.filesystem.VolumePutResult;
 import com.databricks.sdk.service.sql.StatementState;
@@ -628,8 +627,6 @@ public class DatabricksDriverExamples {
 
     Connection con = DriverManager.getConnection(jdbcUrl, "token", DATABRICKS_TOKEN);
 
-    // Example setting an allowed ingestion path
-    con.setClientInfo(DatabricksJdbcConstants.ALLOWED_VOLUME_INGESTION_PATHS, "delete");
     System.out.println("Connection created.");
 
     var client = DatabricksVolumeClientFactory.getVolumeClient(con);
@@ -664,10 +661,6 @@ public class DatabricksDriverExamples {
                   "main", "jdbc_test_schema", "jdbc_test_volume", "test-stream.csv", false));
 
       // Delete object
-      // setting new connection without explicit VolumeOperationAllowedLocalPaths property set
-      con.close();
-      con = DriverManager.getConnection(jdbcUrl, "token", DATABRICKS_TOKEN);
-      client = DatabricksVolumeClientFactory.getVolumeClient(con);
       client.deleteObject("main", "jdbc_test_schema", "jdbc_test_volume", "test-stream.csv");
       System.out.println(
           "Object exists after deletion? "

--- a/src/test/java/com/databricks/client/jdbc/DatabricksDriverExamples.java
+++ b/src/test/java/com/databricks/client/jdbc/DatabricksDriverExamples.java
@@ -664,6 +664,10 @@ public class DatabricksDriverExamples {
                   "main", "jdbc_test_schema", "jdbc_test_volume", "test-stream.csv", false));
 
       // Delete object
+      // setting new connection without explicit VolumeOperationAllowedLocalPaths property set
+      con.close();
+      con = DriverManager.getConnection(jdbcUrl, "token", DATABRICKS_TOKEN);
+      client = DatabricksVolumeClientFactory.getVolumeClient(con);
       client.deleteObject("main", "jdbc_test_schema", "jdbc_test_volume", "test-stream.csv");
       System.out.println(
           "Object exists after deletion? "

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksUCVolumeClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksUCVolumeClientTest.java
@@ -487,6 +487,7 @@ public class DatabricksUCVolumeClientTest {
     DatabricksUCVolumeClient client = new DatabricksUCVolumeClient(connection);
 
     when(connection.createStatement()).thenReturn(statement);
+    when(statement.unwrap(IDatabricksStatementInternal.class)).thenReturn(databricksStatement);
     String deleteObjectQuery =
         String.format("REMOVE '/Volumes/%s/%s/%s/%s'", catalog, schema, volume, objectPath);
     when(statement.executeQuery(deleteObjectQuery)).thenReturn(resultSet);
@@ -510,6 +511,7 @@ public class DatabricksUCVolumeClientTest {
     DatabricksUCVolumeClient client = new DatabricksUCVolumeClient(connection);
 
     when(connection.createStatement()).thenReturn(statement);
+    when(statement.unwrap(IDatabricksStatementInternal.class)).thenReturn(databricksStatement);
     String deleteObjectQuery =
         String.format("REMOVE '/Volumes/%s/%s/%s/%s'", catalog, schema, volume, objectPath);
     when(statement.executeQuery(deleteObjectQuery))

--- a/src/test/java/com/databricks/jdbc/integration/e2e/UCVolumeInputStreamTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/e2e/UCVolumeInputStreamTests.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.databricks.jdbc.api.IDatabricksVolumeClient;
 import com.databricks.jdbc.api.impl.volume.DatabricksVolumeClientFactory;
-import com.databricks.jdbc.common.DatabricksJdbcConstants;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
@@ -66,7 +65,6 @@ public class UCVolumeInputStreamTests {
       inputStream.getContent().close();
 
       assertTrue(client.objectExists(VOL_CATALOG, VOL_SCHEMA, VOL_ROOT, VOLUME_FILE, false));
-      con.setClientInfo(DatabricksJdbcConstants.ALLOWED_VOLUME_INGESTION_PATHS, "delete");
       client.deleteObject(VOL_CATALOG, VOL_SCHEMA, VOL_ROOT, VOLUME_FILE);
       assertFalse(client.objectExists(VOL_CATALOG, VOL_SCHEMA, VOL_ROOT, VOLUME_FILE, false));
     } finally {


### PR DESCRIPTION
## Description
[This is a copy of the previous closed PR : #945  ]

Issue is that in DatabricksUCVolumeClient#deleteObject, we are not setting the allowInputStreamForVolumeOperation as true which we we are setting in other get/put operations for input stream.
This flag is being send as true even in DBFSVolumeClient#deleteObject or get/put for input streams.
Without this flag being set as true the validateLocalFilePath throws error in case allowed volume paths are not present.
By sending this flag the processor skips validation of file path.

## Testing
Explicitly removed this flag from connection in driver example to show that delete record will work without this flag being set.



## Additional Notes to the Reviewer
Will be adding another PR for actual feature gate which restricts using volume operations directly from jdbc url connection
