### PR TITLE
Added check for signature line in commit message as part of post commit script

### DIFF
--- a/scripts/githooks/post-commit
+++ b/scripts/githooks/post-commit
@@ -19,3 +19,19 @@ else
     echo "✓ Spotless checked: No further formatting changes needed after commit."
     echo
 fi
+
+# Check if the latest commit message contains a Signed-off-by: line
+if ! git log -1 --pretty=%B | grep -q "Signed-off-by:"; then
+    echo
+    echo "========================================================================"
+    echo "❗ WARNING: Your last commit is missing a Signed-off-by line."
+    echo "Please amend your commit with 'git commit -s --amend' to add it."
+    echo "========================================================================"
+    echo
+    # Optional: exit with error to fail the script
+    # exit 1
+else
+    echo
+    echo "✓ DCO check: Last commit includes a Signed-off-by line."
+    echo
+fi


### PR DESCRIPTION
## Description
Added check for signature line in commit message as part of post commit script

## Testing
<img width="622" height="330" alt="Screenshot 2025-08-20 at 12 33 08 PM" src="https://github.com/user-attachments/assets/6093ef88-a216-49b5-8a8b-5323c5ead3b0" />
<img width="629" height="248" alt="Screenshot 2025-08-20 at 12 34 12 PM" src="https://github.com/user-attachments/assets/498c7a5b-1e0a-47b6-aad4-b8b0272a347c" />


## Additional Notes to the Reviewer
Please check `setup-git-hooks.sh` to set up post commit script commands

