### PR TITLE
JDBC Client Driver Logger not being configured correctly

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
@@ -19,8 +19,8 @@ public class LoggingUtil {
       throws IOException {
     if (LOGGER instanceof JulLogger && System.getProperty(JAVA_UTIL_LOGGING_CONFIG_FILE) == null) {
       // Only configure JUL logger if it's not already configured via external properties file
-      LOGGER.info("Setting up JUL logger");
       JulLogger.initLogger(toJulLevel(level), logDir, logFileSizeMB * 1024 * 1024, logFileCount);
+      LOGGER.info("Setting up JUL logger");
     }
   }
 


### PR DESCRIPTION
## Description
JDBC client driver is present in a different namespace than the general codebase and due to this when we configure loglevel we only configure the root logger in the `com.databricks.jdbc` chain but the Driver falls in the `com.databricks.client.jdbc` chain and hence was not configured properly

## Testing
Manual testing to view logs in file and console settings


