### PR TITLE
[Bugfix] Fix backward incompatible change in SDK : browser auth flow

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/ClientConfigurator.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/ClientConfigurator.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -196,6 +197,8 @@ public class ClientConfigurator {
         .setAuthType(DatabricksJdbcConstants.U2M_AUTH_TYPE)
         .setHost(host)
         .setClientId(clientId)
+        .setOAuthBrowserAuthTimeout(
+            Duration.ofHours(1)) // TODO : add a browser timeout connection config
         .setClientSecret(connectionContext.getClientSecret())
         .setOAuthRedirectUrl(redirectUrl);
 

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/ClientConfiguratorTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/ClientConfiguratorTest.java
@@ -25,6 +25,7 @@ import com.databricks.sdk.core.oauth.ExternalBrowserCredentialsProvider;
 import com.databricks.sdk.core.utils.Cloud;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -453,6 +454,7 @@ public class ClientConfiguratorTest {
     assertEquals("browser-client-id", config.getClientId());
     assertEquals("browser-client-secret", config.getClientSecret());
     assertEquals(List.of("scope1", "scope2"), config.getScopes());
+    assertEquals(Duration.ofHours(1), config.getOAuthBrowserAuthTimeout());
     assertEquals("http://localhost:" + testPort, config.getOAuthRedirectUrl());
     assertEquals(DatabricksJdbcConstants.U2M_AUTH_TYPE, config.getAuthType());
   }


### PR DESCRIPTION
## Description
- This is a breaking change for browser based auth, this PR fixes it.

## Testing
- E2E manual testing
- Added a Unit test too

## Additional Notes to the Reviewer
- I am only fixing the bleeding issue as part of this PR. And not the long term context flag addition in the driver. Added a TODO for the same.
- Additional context : https://docs.google.com/document/d/17wkI_I16_k6Igl0QPDWZkgbg-7VApebyO4D1yVeXfpM/edit?tab=t.0#heading=h.ig8zh4bt1u8z 

NO_CHANGELOG=true
