### PR TITLE
Fixed getColumns function to return correct output for complex datatypes

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -108,7 +108,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
               .columnTypeClassName(DatabricksTypeUtil.getColumnTypeClassName(columnTypeName))
               .columnType(columnType)
               .columnTypeText(
-                  metadataResultSetBuilder.stripTypeName(
+                  metadataResultSetBuilder.stripBaseTypeName(
                       columnInfo
                           .getTypeText())) // store base type eg. DECIMAL instead of DECIMAL(7,2)
               .typePrecision(precision)


### PR DESCRIPTION

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Fixed getColumns function: SQL_DATATYPE, SQL_DATETIME_SUB, DATA_TYPE, TYPE_NAME,BUFFER_LENGTH. Used StripBaseTypeName instead of StripTypeName to fix the incorrect values in case of complex datatypes. 

## Testing
<!-- Describe how the changes have been tested-->
Tested manually

## RELATED TICKETS AND DOCUMENTS
[PECOBLR-838
](https://databricks.atlassian.net/browse/PECOBLR-838)