### PR TITLE
[PECOBLR-839] Fixed getString for boolean column

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,6 @@
 - Databricks SDK dependency upgraded to latest version 0.60.0
 
 ### Fixed
--
+- Fixed `ResultSet.getString` for Boolean columns in Metadata result set.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/BitConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/BitConverter.java
@@ -17,7 +17,17 @@ public class BitConverter implements ObjectConverter {
       return Boolean.parseBoolean((String) object);
     }
     throw new DatabricksSQLException(
-        "Unsupported type for conversion to BIT: " + object.getClass(),
+        "Unsupported type for conversion to BIT: " + (object == null ? "null" : object.getClass()),
         DatabricksDriverErrorCode.UNSUPPORTED_OPERATION);
+  }
+
+  @Override
+  public String toString(Object object) throws DatabricksSQLException {
+    if (object instanceof Boolean) {
+      return object.toString();
+    }
+    // For other types, fall back to the default behavior
+    throw new DatabricksSQLException(
+        "Unsupported String conversion operation", DatabricksDriverErrorCode.UNSUPPORTED_OPERATION);
   }
 }

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/BitConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/BitConverter.java
@@ -26,8 +26,9 @@ public class BitConverter implements ObjectConverter {
     if (object instanceof Boolean) {
       return object.toString();
     }
-    // For other types, fall back to the default behavior
     throw new DatabricksSQLException(
-        "Unsupported String conversion operation", DatabricksDriverErrorCode.UNSUPPORTED_OPERATION);
+        "Unsupported type for conversion to String: "
+            + (object == null ? "null" : object.getClass()),
+        DatabricksDriverErrorCode.UNSUPPORTED_OPERATION);
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/BitConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/BitConverterTest.java
@@ -28,12 +28,20 @@ public class BitConverterTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"not a boolean", "123", "test"})
-  public void testToStringWithUnsupportedStringTypes(String input) {
+  @CsvSource({
+    "null, null",
+    "Object, Object",
+    "int[], class [I",
+    "String[], class [Ljava.lang.String;"
+  })
+  public void testToStringWithUnsupportedTypes(String typeDescription, String expectedInMessage) {
+    Object input = getTestObject(typeDescription);
+
     DatabricksSQLException exception =
         assertThrows(DatabricksSQLException.class, () -> bitConverter.toString(input));
 
-    assertTrue(exception.getMessage().contains("Unsupported String conversion operation"));
+    assertTrue(exception.getMessage().contains("Unsupported type for conversion to String"));
+    assertTrue(exception.getMessage().contains(expectedInMessage));
     assertEquals("UNSUPPORTED_OPERATION", exception.getSQLState());
   }
 

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/BitConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/BitConverterTest.java
@@ -1,0 +1,119 @@
+package com.databricks.jdbc.api.impl.converters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.databricks.jdbc.exception.DatabricksSQLException;
+import org.junit.jupiter.api.Test;
+
+public class BitConverterTest {
+
+  private final BitConverter bitConverter = new BitConverter();
+
+  @Test
+  public void testToStringWithBooleanTrue() throws DatabricksSQLException {
+    assertEquals("true", bitConverter.toString(true));
+  }
+
+  @Test
+  public void testToStringWithBooleanFalse() throws DatabricksSQLException {
+    assertEquals("false", bitConverter.toString(false));
+  }
+
+  @Test
+  public void testToStringWithBooleanObject() throws DatabricksSQLException {
+    Boolean trueObject = Boolean.TRUE;
+    Boolean falseObject = Boolean.FALSE;
+
+    assertEquals("true", bitConverter.toString(trueObject));
+    assertEquals("false", bitConverter.toString(falseObject));
+  }
+
+  @Test
+  public void testToStringWithUnsupportedType() {
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> bitConverter.toString("not a boolean"));
+
+    assertTrue(exception.getMessage().contains("Unsupported String conversion operation"));
+    assertEquals("UNSUPPORTED_OPERATION", exception.getSQLState());
+  }
+
+  @Test
+  public void testToStringWithNumber() {
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> bitConverter.toString(123));
+
+    assertTrue(exception.getMessage().contains("Unsupported String conversion operation"));
+    assertEquals("UNSUPPORTED_OPERATION", exception.getSQLState());
+  }
+
+  @Test
+  public void testToBooleanWithBooleanTrue() throws DatabricksSQLException {
+    assertTrue(bitConverter.toBoolean(true));
+  }
+
+  @Test
+  public void testToBooleanWithBooleanFalse() throws DatabricksSQLException {
+    assertFalse(bitConverter.toBoolean(false));
+  }
+
+  @Test
+  public void testToBooleanWithBooleanObject() throws DatabricksSQLException {
+    Boolean trueObject = Boolean.TRUE;
+    Boolean falseObject = Boolean.FALSE;
+
+    assertTrue(bitConverter.toBoolean(trueObject));
+    assertFalse(bitConverter.toBoolean(falseObject));
+  }
+
+  @Test
+  public void testToBooleanWithNumberZero() throws DatabricksSQLException {
+    assertFalse(bitConverter.toBoolean(0));
+    assertFalse(bitConverter.toBoolean(0L));
+    assertFalse(bitConverter.toBoolean(0.0f));
+    assertFalse(bitConverter.toBoolean(0.0));
+  }
+
+  @Test
+  public void testToBooleanWithNumberNonZero() throws DatabricksSQLException {
+    assertTrue(bitConverter.toBoolean(1));
+    assertTrue(bitConverter.toBoolean(-1));
+    assertTrue(bitConverter.toBoolean(42L));
+    assertTrue(bitConverter.toBoolean(3.14f));
+    assertTrue(bitConverter.toBoolean(2.71));
+  }
+
+  @Test
+  public void testToBooleanWithStringTrue() throws DatabricksSQLException {
+    assertTrue(bitConverter.toBoolean("true"));
+    assertTrue(bitConverter.toBoolean("TRUE"));
+    assertTrue(bitConverter.toBoolean("True"));
+  }
+
+  @Test
+  public void testToBooleanWithStringFalse() throws DatabricksSQLException {
+    assertFalse(bitConverter.toBoolean("false"));
+    assertFalse(bitConverter.toBoolean("FALSE"));
+    assertFalse(bitConverter.toBoolean("False"));
+    assertFalse(bitConverter.toBoolean("anything else"));
+  }
+
+  @Test
+  public void testToBooleanWithUnsupportedType() {
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> bitConverter.toBoolean(new Object()));
+
+    assertTrue(exception.getMessage().contains("Unsupported type for conversion to BIT"));
+    assertTrue(exception.getMessage().contains("Object"));
+    assertEquals("UNSUPPORTED_OPERATION", exception.getSQLState());
+  }
+
+  @Test
+  public void testToBooleanWithNull() {
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> bitConverter.toBoolean(null));
+
+    assertTrue(exception.getMessage().contains("Unsupported type for conversion to BIT"));
+    assertTrue(exception.getMessage().contains("null"));
+    assertEquals("UNSUPPORTED_OPERATION", exception.getSQLState());
+  }
+}


### PR DESCRIPTION

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Added a toString function in BITConverter to fix getString for boolean columns. Fixed toBoolean to handle null. Added tests for both the functions of BITConverter
## Testing
<!-- Describe how the changes have been tested-->
Added unit tests
## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
Fixes #956 
