### PR TITLE
fix: struct metadata parsing for nested decimal fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -20,5 +20,6 @@
 - Fixed `ResultSet.getString` for Boolean columns in Metadata result set.
 - Fixed volume operations not completing unless the ResultSet is fully iterated.
 - Fixed `connection.getMetadata().getColumns()` to return the correct SQL data type code for complex type columns.
+- Fixed a bug in the JDBC driver's metadata parsing for nested decimal fields within struct types.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/src/main/java/com/databricks/jdbc/api/impl/MetadataParser.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/MetadataParser.java
@@ -1,16 +1,12 @@
 package com.databricks.jdbc.api.impl;
 
 import com.databricks.jdbc.exception.DatabricksDriverException;
-import com.databricks.jdbc.log.JdbcLogger;
-import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Utility class for parsing metadata descriptions into structured type mappings. */
 public class MetadataParser {
-
-  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(MetadataParser.class);
 
   /**
    * Parses STRUCT metadata to extract field types.

--- a/src/test/java/com/databricks/jdbc/api/impl/MetadataParserTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/MetadataParserTest.java
@@ -292,4 +292,61 @@ public class MetadataParserTest {
         exception.getMessage().contains("Invalid MAP metadata"),
         "Exception message should indicate invalid MAP metadata.");
   }
+
+  /**
+   * Test parsing of STRUCT metadata with DECIMAL precision and scale - regression test for
+   * parentheses handling.
+   */
+  @Test
+  @DisplayName("parseStructMetadata with DECIMAL precision and scale")
+  public void testParseStructMetadata_WithDecimalPrecisionScale() {
+    String metadata = "STRUCT<name:STRING, amount:DECIMAL(18,2)>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("name", "STRING");
+    expected.put("amount", "DECIMAL(18,2)");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with DECIMAL precision and scale should handle parentheses correctly.");
+  }
+
+  /**
+   * Test parsing of STRUCT metadata with multiple DECIMAL fields with different precision/scale.
+   */
+  @Test
+  @DisplayName("parseStructMetadata with multiple DECIMAL fields")
+  public void testParseStructMetadata_MultipleDecimalFields() {
+    String metadata = "STRUCT<id:INT, price:DECIMAL(10,2), amount:DECIMAL(18,4), name:STRING>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("id", "INT");
+    expected.put("price", "DECIMAL(10,2)");
+    expected.put("amount", "DECIMAL(18,4)");
+    expected.put("name", "STRING");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with multiple DECIMAL fields should handle all parentheses correctly.");
+  }
+
+  /** Test parsing of complex nested STRUCT with DECIMAL fields - comprehensive regression test. */
+  @Test
+  @DisplayName("parseStructMetadata with nested STRUCT containing DECIMAL")
+  public void testParseStructMetadata_NestedStructWithDecimal() {
+    String metadata =
+        "STRUCT<id:INT, financial:STRUCT<balance:DECIMAL(15,2), credit:DECIMAL(10,2)>, active:BOOLEAN>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("id", "INT");
+    expected.put("financial", "STRUCT<balance:DECIMAL(15,2), credit:DECIMAL(10,2)>");
+    expected.put("active", "BOOLEAN");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with nested STRUCT containing DECIMAL should preserve all type information.");
+  }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/MetadataParserTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/MetadataParserTest.java
@@ -349,4 +349,63 @@ public class MetadataParserTest {
         actual,
         "Parsed struct metadata with nested STRUCT containing DECIMAL should preserve all type information.");
   }
+
+  /** Test parsing of deeply nested STRUCT with multiple DECIMAL fields at different levels. */
+  @Test
+  @DisplayName("parseStructMetadata with deeply nested STRUCT and DECIMAL fields")
+  public void testParseStructMetadata_DeeplyNestedStructWithDecimals() {
+    String metadata =
+        "STRUCT<id:INT, account:STRUCT<balance:DECIMAL(18,4), details:STRUCT<fee:DECIMAL(5,2), rate:DECIMAL(10,6)>>, status:STRING>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("id", "INT");
+    expected.put(
+        "account",
+        "STRUCT<balance:DECIMAL(18,4), details:STRUCT<fee:DECIMAL(5,2), rate:DECIMAL(10,6)>>");
+    expected.put("status", "STRING");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with deeply nested STRUCT and DECIMAL fields should handle all levels correctly.");
+  }
+
+  /** Test parsing of STRUCT with mixed complex types and DECIMAL fields. */
+  @Test
+  @DisplayName("parseStructMetadata with mixed complex types and DECIMAL")
+  public void testParseStructMetadata_MixedComplexTypesWithDecimal() {
+    String metadata =
+        "STRUCT<id:INT, prices:ARRAY<DECIMAL(12,2)>, accounts:MAP<STRING, STRUCT<balance:DECIMAL(15,2)>>, summary:STRUCT<total:DECIMAL(20,4), count:INT>>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("id", "INT");
+    expected.put("prices", "ARRAY<DECIMAL(12,2)>");
+    expected.put("accounts", "MAP<STRING, STRUCT<balance:DECIMAL(15,2)>>");
+    expected.put("summary", "STRUCT<total:DECIMAL(20,4), count:INT>");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with mixed complex types and DECIMAL fields should handle all combinations correctly.");
+  }
+
+  /** Test parsing of STRUCT with other parenthesized types to ensure fix applies broadly. */
+  @Test
+  @DisplayName("parseStructMetadata with various parenthesized types")
+  public void testParseStructMetadata_VariousParenthesizedTypes() {
+    String metadata =
+        "STRUCT<id:INT, name:STRING, amount:DECIMAL(38,18), price:DECIMAL(10,2), active:BOOLEAN>";
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("id", "INT");
+    expected.put("name", "STRING");
+    expected.put("amount", "DECIMAL(38,18)");
+    expected.put("price", "DECIMAL(10,2)");
+    expected.put("active", "BOOLEAN");
+
+    Map<String, String> actual = MetadataParser.parseStructMetadata(metadata);
+    assertEquals(
+        expected,
+        actual,
+        "Parsed struct metadata with various parenthesized types should handle all type parameters correctly.");
+  }
 }


### PR DESCRIPTION
## Description
When parsing Struct<Decimal(10,20)>, the driver currently raises an exception: 
```
  java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
      at com.databricks.jdbc.api.impl.MetadataParser.parseStructMetadata(MetadataParser.java:30)
      at com.databricks.jdbc.api.impl.ComplexDataTypeParser.parseToStruct(ComplexDataTypeParser.java:104)
      at com.databricks.jdbc.api.impl.ComplexDataTypeParser.convertValueNode(ComplexDataTypeParser.java:131)
      at com.databricks.jdbc.api.impl.ComplexDataTypeParser.parseToArray(ComplexDataTypeParser.java:73)
```
This occurs because the current implementation does not expect nested comma's in datatypes. 
By tracking the Depth of the `()` characters, we can successfully parse complex datatypes.

Issue:
https://github.com/databricks/databricks-jdbc/issues/981

## Testing
Unit tests expanded and local testing done.

## Additional Notes to the Reviewer
This is a bug in the implementation of the MetaDataParser and is pretty direct to re-produce and correct.

