### PR TITLE
[PECOBLR-860] Bugfix : volume operation

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,5 +18,6 @@
 ### Fixed
 - Integrated Azure U2M flow into driver for improved stability.
 - Fixed `ResultSet.getString` for Boolean columns in Metadata result set.
+- Fixed volume operations not completing unless the ResultSet is fully iterated.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 


### PR DESCRIPTION
## Description
- The bug
  - Current JDBC Repo has a bug, in which volume operations are not executed. 
  - Step to reproduce  : use a script to generate a large csv file (say 1.5GB), execute the PUT query - you won't be able to see the file uploaded.
  -  The customer would have to iterate through the resultSet for the volume operation to be completed. This is the workaround customers can use as of today : 
  
```
 ResultSet rs = con.createStatement()
            .executeQuery(
                "PUT 'test_csv_files/large_file.csv' INTO '/Volumes/testingcatalog/default/testvol/mytestfolder/test1'");

while(rs.next()){
 //Nothing
}
```

-  This PR fixes the above issue without the need of any hacky fix.



## Testing
- Tested locally

## Additional Notes to the Reviewer
- This needs to be added to the JDK8 branch as well, will raise a PR for the same

