### PR TITLE
Default value of RowsFetchedPerBlock changed to 100K

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -123,7 +123,7 @@ public enum DatabricksJdbcUrlParams {
   ROWS_FETCHED_PER_BLOCK(
       "RowsFetchedPerBlock",
       "The maximum number of rows that a query returns at a time.",
-      "2000000"), // works only for inline results.
+      "100000"), // works only for inline results.
   AZURE_WORKSPACE_RESOURCE_ID(
       "azure_workspace_resource_id", "Resource ID of Azure Databricks workspace"),
   AZURE_TENANT_ID("AzureTenantId", "Azure tenant ID"),


### PR DESCRIPTION
## Description
RowsFetchedPerBlock denotes the max rows that JDBC buffers in memory when running in Arrow disabled inline mode. 100K default captures typical use cases with an efficient balance between execution time and memory usage.

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

