### PR TITLE
Add proper parsing of Variant fields when they are nested inside Structure fields

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
@@ -124,6 +124,19 @@ public class ComplexDataTypeParser {
     if (expectedType.startsWith(DatabricksTypeUtil.MAP)) {
       return parseToMap(node, expectedType);
     }
+    if (expectedType.equalsIgnoreCase(DatabricksTypeUtil.VARIANT)) {
+      // For VARIANT, the node contains escaped JSON string, we need to unescape it
+      // node.asText() gives us the content: "{\"nestedKey\":\"nestedValue\"}"
+      // We want to return: {"nestedKey":"nestedValue"}
+      String jsonText = node.asText();
+      try {
+        // Parse and re-serialize to unescape the JSON
+        return JsonUtil.getMapper().readTree(jsonText);
+      } catch (Exception e) {
+        // If parsing fails, return the original text
+        return jsonText;
+      }
+    }
     return convertPrimitive(node.asText(), expectedType);
   }
 

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStruct.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStruct.java
@@ -5,6 +5,7 @@ import com.databricks.jdbc.exception.DatabricksDriverException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
@@ -125,6 +126,9 @@ public class DatabricksStruct implements Struct {
           return Time.valueOf(value.toString());
         case DatabricksTypeUtil.BINARY:
           return value instanceof byte[] ? value : value.toString().getBytes();
+        case DatabricksTypeUtil.VARIANT:
+          // For VARIANT, preserve JsonNode objects as-is, otherwise convert to string
+          return value instanceof JsonNode ? value : value.toString();
         case DatabricksTypeUtil.STRING:
         default:
           return value.toString();
@@ -185,6 +189,9 @@ public class DatabricksStruct implements Struct {
       if (val == null) {
         // JSON-like null
         sb.append("null");
+      } else if (val instanceof JsonNode) {
+        // VARIANT fields represented as JsonNode - preserve JSON structure without quotes
+        sb.append(val.toString());
       } else if (val instanceof String) {
         // Strings get quoted
         sb.append("\"").append(val).append("\"");


### PR DESCRIPTION
## Description
https://github.com/databricks/databricks-jdbc/issues/1006
Problem
It looks like currently databricks-jdbc-oss driver is only able to recognise nested Variant fields as a String:
E.g. for the Structure field looking like "object": {"field1":"object_value","field2":{"nestedKey":"nestedValue"}}, where field2 is Variant, resultSet.getObject() returns:
Simba's version : "object": "{\"field1\":\"object_value\",\"field2\":{\"nestedKey\":\"nestedValue\"}}" (the whole structure is preserved as is)
OSS version: "object": "{\"field1\":\"object_value\",\"field2\":\"{\"nestedKey\":\"nestedValue\"}\"}" (note the extra quotes around field2 value)

## Testing
JUnit

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

