### PR TITLE
Fixed ResultSetMetadata for SEA inline mode

### DIFF
--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,5 +1,5 @@
 {
   "freeze": true,
   "reason": "Releasing JDBC - 16th Sep",
-  "allow_list": ["jayantsing-db/default-max-rows-per-block"]
+  "allow_list": ["jayantsing-db/default-max-rows-per-block", "msrathore-db/ResultSetMetadataFix"]
 }

--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,5 +1,5 @@
 {
   "freeze": true,
   "reason": "Releasing JDBC - 16th Sep",
-  "allow_list": ["jayantsing-db/default-max-rows-per-block", "msrathore-db/ResultSetMetadataFix"]
+  "allow_list": ["jayantsing-db/default-max-rows-per-block", "ResultSetMetadataFix"]
 }

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -108,7 +108,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
               .columnTypeClassName(DatabricksTypeUtil.getColumnTypeClassName(columnTypeName))
               .columnType(columnType)
               .columnTypeText(
-                  metadataResultSetBuilder.stripBaseTypeName(
+                  metadataResultSetBuilder.stripTypeName(
                       columnInfo
                           .getTypeText())) // store base type eg. DECIMAL instead of DECIMAL(7,2)
               .typePrecision(precision)

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -413,6 +413,37 @@ public class DatabricksResultSetMetaDataTest {
     assertFalse(metaData.getIsCloudFetchUsed());
   }
 
+  @Test
+  public void testSEAInlineComplexType() throws SQLException {
+    ResultManifest resultManifest = new ResultManifest();
+    resultManifest.setTotalRowCount(1L);
+    ResultSchema schema = new ResultSchema();
+    schema.setColumnCount(3L);
+
+    ColumnInfo arrayColumn = getColumn("array_col", ColumnInfoTypeName.ARRAY, "ARRAY<INT>");
+    ColumnInfo structColumn =
+        getColumn("struct_col", ColumnInfoTypeName.STRUCT, "STRUCT<field1:INT,field2:STRING>");
+    ColumnInfo mapColumn = getColumn("map_col", ColumnInfoTypeName.MAP, "MAP<STRING,INT>");
+
+    schema.setColumns(List.of(arrayColumn, structColumn, mapColumn));
+    resultManifest.setSchema(schema);
+
+    DatabricksResultSetMetaData metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
+
+    assertEquals("ARRAY<INT>", metaData.getColumnTypeName(1));
+    assertEquals("STRUCT<field1:INT,field2:STRING>", metaData.getColumnTypeName(2));
+    assertEquals("MAP<STRING,INT>", metaData.getColumnTypeName(3));
+
+    assertEquals("array_col", metaData.getColumnName(1));
+    assertEquals("struct_col", metaData.getColumnName(2));
+    assertEquals("map_col", metaData.getColumnName(3));
+
+    assertEquals(Types.ARRAY, metaData.getColumnType(1));
+    assertEquals(Types.STRUCT, metaData.getColumnType(2));
+    assertEquals(Types.VARCHAR, metaData.getColumnType(3));
+  }
+
   private void verifyDefaultMetadataProperties(
       DatabricksResultSetMetaData metaData, StatementType type) throws SQLException {
     for (int i = 1; i <= metaData.getColumnCount(); i++) {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
For SEA this type is parsed later using a function. So we need not strip the base type here. So reverted the code to use stripTypeName instead. But the stripTypeName function isn't correct either since it will incorrectly convert ARRAY<DECIMAL(10,2)> to ARRAY<DECIMAL and later parse it incorrectly.  
## Testing
<!-- Describe how the changes have been tested-->
Tested the SQL smoke test locally
## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
NO_CHANGELOG=true
