### PR TITLE
Fixed stripTypeName function

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
@@ -499,11 +499,10 @@ public class MetadataResultSetBuilder {
     if (typeName == null) {
       return null;
     }
-    int typeArgumentIndex = typeName.indexOf('(');
-    if (typeArgumentIndex != -1) {
-      return typeName.substring(0, typeArgumentIndex);
+    boolean endsWithClosingBracket = typeName.endsWith(")");
+    if (endsWithClosingBracket) {
+      typeName = typeName.substring(0, typeName.lastIndexOf('('));
     }
-
     return typeName;
   }
 

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
@@ -121,7 +121,7 @@ public class MetadataResultSetBuilderTest {
         Arguments.of("VARCHAR", "VARCHAR"),
         Arguments.of("CHAR(255)", "CHAR"),
         Arguments.of("TEXT", "TEXT"),
-        Arguments.of("VARCHAR(", "VARCHAR"),
+        Arguments.of("VARCHAR()", "VARCHAR"),
         Arguments.of("VARCHAR(100,200)", "VARCHAR"),
         Arguments.of("CHAR(123)", "CHAR"),
         Arguments.of("ARRAY<DOUBLE>", "ARRAY<DOUBLE>"),
@@ -131,7 +131,8 @@ public class MetadataResultSetBuilderTest {
         Arguments.of("MAP<STRING,INT>(50)", "MAP<STRING,INT>"),
         Arguments.of(null, null),
         Arguments.of("", ""),
-        Arguments.of("INTEGER(10,5)", "INTEGER"));
+        Arguments.of("INTEGER(10,5)", "INTEGER"),
+        Arguments.of("ARRAY<DECIMAL(10,2)>", "ARRAY<DECIMAL(10,2)>"));
   }
 
   private static Stream<Arguments> stripBaseTypeNameArguments() {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Updated the stripTypeName function to strip the type only when it contains the close bracket in the end. This would parse ARRAY<DECIMAL(10,2)> correctly. 
## Testing
<!-- Describe how the changes have been tested-->
Added unit test
## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

[PECOBLR-951](https://databricks.atlassian.net/browse/PECOBLR-951)