### PR TITLE
read release overriding from pr description

### DIFF
--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   freeze-check:
-    runs-on: ubuntu-latest
-
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - name: Check out repository

--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   freeze-check:
-    runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-latest
 
 
     steps:

--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   freeze-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
 
     steps:
       - name: Check out repository
@@ -14,6 +17,22 @@ jobs:
 
       - name: Set up jq
         run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Fetch PR message
+        id: pr-message
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use the GitHub API to fetch the PR message
+          pr_message=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body')
+          
+          # Sanitize the PR message to avoid code injection, keeping the equal sign
+          sanitized_pr_message=$(echo "$pr_message" | sed 's/[^a-zA-Z0-9._/-=]/_/g')
+          
+          # Store the sanitized PR message
+          echo "$sanitized_pr_message" > pr_message.txt
+          echo "$sanitized_pr_message"
+          
 
       - name: Enforce branch freeze logic
         shell: bash
@@ -23,38 +42,29 @@ jobs:
         run: |
           CONFIG_FILE="development/.release-freeze.json"
 
+        # 1. Check for explicit override flag in PR message
+          pr_message=$(cat pr_message.txt)               
+          if echo "$pr_message" | grep -q "OVERRIDE_FREEZE=true"; then
+            echo "✅ OVERRIDE_FREEZE=true found in PR message. Freeze override permitted."
+          exit 0
+          fi
+          
+        # 2. Proceed with freeze checks  
           if [[ ! -f "$CONFIG_FILE" ]]; then
             echo "✅ No release config file - passing check."
             exit 0
           fi
 
+          
           FREEZE=$(jq '.freeze' "$CONFIG_FILE")
 
           if [[ "$FREEZE" != "true" ]]; then
             echo "✅ Freeze is off - passing check."
             exit 0
           fi
-
-          ALLOW_LIST=( $(jq -r '.allow_list[]' "$CONFIG_FILE") )
-
-          BRANCH="$PR_BRANCH"
-          ALLOWED=0
-
-          # Check for exact branch name in allow_list
-          for ENTRY in $(jq -r '.allow_list[]' "$CONFIG_FILE"); do
-            if [[ "$BRANCH" == "$ENTRY" ]]; then
-              ALLOWED=1
-              break
-            fi
-          done
-
-          if [[ "$ALLOWED" == "1" ]]; then
-            echo "✅ Branch '$BRANCH' is in allow_list. Passing check."
-            exit 0
-          else
-            echo "❌ Release freeze is ACTIVE!"
-            REASON=$(jq -r '.reason' "$CONFIG_FILE")
-            echo "Reason: $REASON"
-            echo "Branch '$BRANCH' is NOT permitted to merge under current freeze rules."
-            exit 1
-          fi
+        
+        
+        # 3. Freeze is ON and no override flag. Block PR.
+          echo "Release freeze is ACTIVE! Branch '${PR_BRANCH}' is NOT permitted to merge."
+          echo "To override, add OVERRIDE_FREEZE=true to your PR description."
+          exit 1

--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -30,7 +30,6 @@ jobs:
           # Store the sanitized PR message
           echo "$sanitized_pr_message" > pr_message.txt
           echo "$sanitized_pr_message"
-          
 
       - name: Enforce branch freeze logic
         shell: bash
@@ -44,7 +43,7 @@ jobs:
           pr_message=$(cat pr_message.txt)               
           if echo "$pr_message" | grep -q "OVERRIDE_FREEZE=true"; then
             echo "✅ OVERRIDE_FREEZE=true found in PR message. Freeze override permitted."
-          exit 0
+            exit 0
           fi
           
         # 2. Proceed with freeze checks  

--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -39,14 +39,14 @@ jobs:
         run: |
           CONFIG_FILE="development/.release-freeze.json"
 
-        # 1. Check for explicit override flag in PR message
+          # 1. Check for explicit override flag in PR message
           pr_message=$(cat pr_message.txt)               
           if echo "$pr_message" | grep -q "OVERRIDE_FREEZE=true"; then
             echo "✅ OVERRIDE_FREEZE=true found in PR message. Freeze override permitted."
             exit 0
           fi
           
-        # 2. Proceed with freeze checks  
+          # 2. Proceed with freeze checks  
           if [[ ! -f "$CONFIG_FILE" ]]; then
             echo "✅ No release config file - passing check."
             exit 0

--- a/.github/workflows/releaseFreeze.yml
+++ b/.github/workflows/releaseFreeze.yml
@@ -40,28 +40,26 @@ jobs:
           CONFIG_FILE="development/.release-freeze.json"
 
           # 1. Check for explicit override flag in PR message
-          pr_message=$(cat pr_message.txt)               
+          pr_message=$(cat pr_message.txt)
           if echo "$pr_message" | grep -q "OVERRIDE_FREEZE=true"; then
             echo "✅ OVERRIDE_FREEZE=true found in PR message. Freeze override permitted."
             exit 0
           fi
-          
-          # 2. Proceed with freeze checks  
+
+          # 2. Proceed with freeze checks
           if [[ ! -f "$CONFIG_FILE" ]]; then
             echo "✅ No release config file - passing check."
             exit 0
           fi
 
-          
           FREEZE=$(jq '.freeze' "$CONFIG_FILE")
 
           if [[ "$FREEZE" != "true" ]]; then
             echo "✅ Freeze is off - passing check."
             exit 0
           fi
-        
-        
-        # 3. Freeze is ON and no override flag. Block PR.
+
+          # 3. Freeze is ON and no override flag. Block PR.
           echo "Release freeze is ACTIVE! Branch '${PR_BRANCH}' is NOT permitted to merge."
           echo "To override, add OVERRIDE_FREEZE=true to your PR description."
           exit 1

--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,5 +1,4 @@
 {
-  "freeze": true,
-  "reason": "Releasing JDBC - 16th Sep",
-  "allow_list": ["samikshya-chand_data/n"]
+  "freeze": false,
+  "reason": ""
 }


### PR DESCRIPTION
## Description
1. Reverting release flag to false
2. Making over ride release check to PR description instead from allow branch list
3. This helps dev to not add explicitly commit to the PR they want to get merged during a running release

## Testing
Git hub runners. 

## Additional Notes to the Reviewer
NO_CHANGELOG=true

