### PR TITLE
Fix timestamp omitting nanos

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
@@ -1394,9 +1394,11 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
       useCal.set(Calendar.HOUR_OF_DAY, ldt.getHour());
       useCal.set(Calendar.MINUTE, ldt.getMinute());
       useCal.set(Calendar.SECOND, ldt.getSecond());
-      useCal.set(Calendar.MILLISECOND, timestamp.getNanos() / 1_000_000);
+      useCal.set(Calendar.MILLISECOND, 0);
 
-      return new Timestamp(useCal.getTimeInMillis());
+      var ts = new Timestamp(useCal.getTimeInMillis());
+      ts.setNanos(timestamp.getNanos());
+      return ts;
     }
     return timestamp;
   }

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
@@ -172,10 +172,8 @@ public class ArrowToJavaObjectConverter {
       // timestamp_ntz result is returned as local date time
       return Timestamp.valueOf((LocalDateTime) object);
     }
-    // Divide by 1000 since we need to convert from microseconds to milliseconds.
-    Instant instant =
-        Instant.ofEpochMilli(
-            object instanceof Integer ? ((int) object) / 1000 : ((long) object) / 1000);
+    long timeMicros = object instanceof Integer ? ((int) object) : ((long) object);
+    Instant instant = Instant.ofEpochSecond(timeMicros / 1000_000, (timeMicros % 1000_000) * 1000);
     ZoneId zoneId = getZoneIdFromTimeZoneOpt(timeZoneOpt);
     LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, zoneId);
     return Timestamp.valueOf(localDateTime);

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
@@ -454,7 +454,7 @@ public class DatabricksResultSetTest {
   void testGetTimestamp() throws SQLException {
     DatabricksResultSet resultSet = getResultSet(StatementState.SUCCEEDED, null);
     int columnIndex = 5;
-    String expectedTimestampString = "2023-01-01 12:30:00";
+    String expectedTimestampString = "2023-01-01 12:30:00.123456789";
     // Test using timestamp object
     Timestamp expectedTimestamp = Timestamp.valueOf(expectedTimestampString);
     when(resultSet.getObject(columnIndex)).thenReturn(expectedTimestamp);
@@ -470,9 +470,10 @@ public class DatabricksResultSetTest {
     // Test with Calendar argument
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Tokyo"));
     // Asia/Tokyo is GMT+9
-    assertEquals(
-        new Timestamp(OffsetDateTime.parse("2023-01-01T12:30:00+09:00").toEpochSecond() * 1000),
-        resultSet.getTimestamp(columnIndex, calendar));
+    var expectedTimestampWithTz =
+        new Timestamp(OffsetDateTime.parse("2023-01-01T12:30:00+09:00").toEpochSecond() * 1000);
+    expectedTimestampWithTz.setNanos(123456789);
+    assertEquals(expectedTimestampWithTz, resultSet.getTimestamp(columnIndex, calendar));
 
     // Test with null Calendar argument
     assertEquals(expectedTimestamp, resultSet.getTimestamp(columnIndex, null));

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
@@ -227,7 +227,7 @@ public class ArrowToJavaObjectConverterTest {
 
   @Test
   public void testTimestampNTZConversion() throws SQLException {
-    long timestamp = 1704054600000000L;
+    long timestamp = 1704054601234567L;
 
     TimeStampMicroVector timestampMicroVector =
         new TimeStampMicroVector("timestampMicroVector", this.bufferAllocator);
@@ -384,7 +384,7 @@ public class ArrowToJavaObjectConverterTest {
 
   @Test
   public void testTimestampConversion() throws SQLException {
-    long timestamp = 1704054600000000L;
+    long timestamp = 1704054601234567L;
     String timeZone = "Asia/Tokyo";
     TimeStampMicroTZVector timeStampMicroTZVector =
         new TimeStampMicroTZVector("timeStampMicroTzVector", this.bufferAllocator, timeZone);
@@ -401,7 +401,9 @@ public class ArrowToJavaObjectConverterTest {
   private static Timestamp getTimestampAdjustedToTimeZone(long timestampMicro, String timeZone) {
     Instant instant = Instant.ofEpochMilli(timestampMicro / 1000);
     LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.of(timeZone));
-    return Timestamp.valueOf(localDateTime);
+    var ts = Timestamp.valueOf(localDateTime);
+    ts.setNanos((int) (timestampMicro % 1000_000) * 1000);
+    return ts;
   }
 
   @Test


### PR DESCRIPTION
## Description
When fetching data from a table with timestamp values with microseconds JDBC driver truncates the microseconds and only returns milliseconds.

## Testing
Covered by the existing unit tests.

## Additional Notes to the Reviewer
-

