### PR TITLE
[PECOBLR-991] fix `Statment.getUpdateCount` 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,6 @@
 ### Fixed
 - Fixed state leaking issue in thrift client.
 - Fixed timestamp values returning only milliseconds instead of the full nanosecond precision.
-- Fixed Statment.getUpdateCount() for DML queries.
+- Fixed Statement.getUpdateCount() for DML queries.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,5 +11,6 @@
 ### Fixed
 - Fixed state leaking issue in thrift client.
 - Fixed timestamp values returning only milliseconds instead of the full nanosecond precision.
+- Fixed Statment.getUpdateCount() for DML queries.
 ---
 *Note: When making changes, please add your change under the appropriate section with a brief description.* 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Fixes https://github.com/databricks/databricks-jdbc/issues/1019

Problem:
DatabricksStatement violates this condition as per jdbc spec.
```
There are no more results when the following is true:


     // stmt is a Statement object
     ((stmt.getMoreResults() == false) && (stmt.getUpdateCount() == -1))
```

Repro:
Execute an insert statement.
Try to iterate through the results and terminate with the above condition.

As per current driver behavior, getUpdateCount() will return number of rows updated irrespective of whether getMoreResults is called or not.

Solution:
add a state var `noMoreResults` to track whether we have a active result set or not. Since, we do not support multiple result set, this state will be set to true on the first `getMoreResults()` call.


## Testing
<!-- Describe how the changes have been tested-->
Manual test
unit tests


## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

