### PR TITLE
Added connection param of ignore transactions that allows users to mu…

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -120,9 +120,11 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public void setAutoCommit(boolean autoCommit) throws SQLException {
     if (!autoCommit) {
-      throw new DatabricksSQLFeatureNotSupportedException(
-          "In Databricks OSS JDBC, every SQL statement is committed immediately upon execution."
-              + " Setting autoCommit=false is not supported.");
+      if (!connectionContext.getIgnoreTransactions()) {
+        throw new DatabricksSQLFeatureNotSupportedException(
+            "In Databricks OSS JDBC, every SQL statement is committed immediately upon execution."
+                + " Setting autoCommit=false is not supported.");
+      }
     }
   }
 
@@ -136,15 +138,19 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public void commit() throws SQLException {
     LOGGER.debug("public void commit()");
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - commit()");
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - commit()");
+    }
   }
 
   @Override
   public void rollback() throws SQLException {
     LOGGER.debug("public void rollback()");
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - rollback()");
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - rollback()");
+    }
   }
 
   @Override
@@ -299,28 +305,39 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public Savepoint setSavepoint() throws SQLException {
     LOGGER.debug("public Savepoint setSavepoint()");
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - setSavepoint()");
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - setSavepoint()");
+    }
+    return null;
   }
 
   @Override
   public Savepoint setSavepoint(String name) throws SQLException {
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - setSavepoint(String name)");
+    LOGGER.debug("public Savepoint setSavepoint(String name = {})", name);
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - setSavepoint(String name)");
+    }
+    return null;
   }
 
   @Override
   public void rollback(Savepoint savepoint) throws SQLException {
     LOGGER.debug("public void rollback(Savepoint savepoint)");
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - rollback(Savepoint savepoint)");
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - rollback(Savepoint savepoint)");
+    }
   }
 
   @Override
   public void releaseSavepoint(Savepoint savepoint) throws SQLException {
     LOGGER.debug("public void releaseSavepoint(Savepoint savepoint)");
-    throw new DatabricksSQLFeatureNotImplementedException(
-        "Not implemented in DatabricksConnection - releaseSavepoint(Savepoint savepoint)");
+    if (!connectionContext.getIgnoreTransactions()) {
+      throw new DatabricksSQLFeatureNotImplementedException(
+          "Not implemented in DatabricksConnection - releaseSavepoint(Savepoint savepoint)");
+    }
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -1045,4 +1045,9 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   public boolean isBatchedInsertsEnabled() {
     return getParameter(DatabricksJdbcUrlParams.ENABLE_BATCHED_INSERTS).equals("1");
   }
+
+  @Override
+  public boolean getIgnoreTransactions() {
+    return getParameter(DatabricksJdbcUrlParams.IGNORE_TRANSACTIONS, "0").equals("1");
+  }
 }

--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
@@ -368,4 +368,7 @@ public interface IDatabricksConnectionContext {
 
   /** Returns whether batched INSERT optimization is enabled */
   boolean isBatchedInsertsEnabled();
+
+  /** Returns whether transaction-related method calls should be ignored */
+  boolean getIgnoreTransactions();
 }

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -162,7 +162,8 @@ public enum DatabricksJdbcUrlParams {
   ENABLE_SQL_VALIDATION_FOR_IS_VALID(
       "EnableSQLValidationForIsValid",
       "Enable SQL query execution for connection validation in isValid() method",
-      "0");
+      "0"),
+  IGNORE_TRANSACTIONS("IgnoreTransactions", "Ignore transaction-related method calls", "0");
 
   private final String paramName;
   private final String defaultValue;


### PR DESCRIPTION


## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
Allows user to mute the exceptions for transaction related methods. Earlier the driver was throwing an exception for transaction related methods. Now the users can use the parameter to ignore these exceptions for transaction methods.
## Testing
<!-- Describe how the changes have been tested-->
Unit tests added.
## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
[PECOBLR-931](https://databricks.atlassian.net/browse/PECOBLR-931)
