### PR TITLE
Fix log argument formatting

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
@@ -1503,8 +1503,9 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
     LOGGER.debug(
-        "public ResultSet getSchemas(String catalog = %s, String schemaPattern = %s)",
-        catalog, schemaPattern);
+        "public ResultSet getSchemas(String catalog = {}, String schemaPattern = {})",
+        catalog,
+        schemaPattern);
     throwExceptionIfConnectionIsClosed();
 
     return session.getDatabricksMetadataClient().listSchemas(session, catalog, schemaPattern);

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -546,7 +546,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
 
   @Override
   public void setStatementId(StatementId statementId) {
-    LOGGER.debug("void setStatementId {%s}", statementId);
+    LOGGER.debug("void setStatementId(Statement statementId = {})", statementId);
     this.statementId = statementId;
   }
 

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/AbstractArrowResultChunk.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/AbstractArrowResultChunk.java
@@ -227,8 +227,12 @@ public abstract class AbstractArrowResultChunk {
       stateMachine.transition(targetStatus);
     } catch (DatabricksParsingException e) {
       LOGGER.warn(
-          "Failed to transition to state [%s] from state [%s] for chunk [%d] and statement [%s]. Stack trace: %s",
-          targetStatus, getStatus(), chunkIndex, statementId, ExceptionUtils.getStackTrace(e));
+          "Failed to transition to state [{}] from state [{}] for chunk [{}] and statement [{}]. Stack trace: {}",
+          targetStatus,
+          getStatus(),
+          chunkIndex,
+          statementId,
+          ExceptionUtils.getStackTrace(e));
     }
   }
 
@@ -265,7 +269,7 @@ public abstract class AbstractArrowResultChunk {
     } catch (InterruptedException e) {
       LOGGER.error(
           e,
-          "Chunk download interrupted for chunk index %s and statement %s",
+          "Chunk download interrupted for chunk index {} and statement {}",
           chunkIndex,
           statementId);
       Thread.currentThread().interrupt();
@@ -283,11 +287,11 @@ public abstract class AbstractArrowResultChunk {
    */
   protected void initializeData(InputStream inputStream)
       throws DatabricksSQLException, IOException {
-    LOGGER.debug("Parsing data for chunk index %s and statement %s", chunkIndex, statementId);
+    LOGGER.debug("Parsing data for chunk index {} and statement {}", chunkIndex, statementId);
     ArrowData arrowData = getRecordBatchList(inputStream, rootAllocator, statementId, chunkIndex);
     recordBatchList = arrowData.getValueVectors();
     arrowMetadata = arrowData.getMetadata();
-    LOGGER.debug("Data parsed for chunk index %s and statement %s", chunkIndex, statementId);
+    LOGGER.debug("Data parsed for chunk index {} and statement {}", chunkIndex, statementId);
     setStatus(ChunkStatus.PROCESSING_SUCCEEDED);
   }
 
@@ -322,7 +326,7 @@ public abstract class AbstractArrowResultChunk {
       // release resources if thread is interrupted when reading arrow data
       LOGGER.error(
           e,
-          "Data parsing interrupted for chunk index [%s] and statement [%s]. Error [%s]",
+          "Data parsing interrupted for chunk index [{}] and statement [{}]. Error [{}]",
           chunkIndex,
           statementId,
           e.getMessage());
@@ -365,8 +369,13 @@ public abstract class AbstractArrowResultChunk {
     long initReservation = rootAllocator.getInitReservation();
 
     LOGGER.debug(
-        "Chunk allocator stats Log - Event: %s, Chunk Index: %s, Allocated Memory: %s, Peak Memory: %s, Headroom: %s, Init Reservation: %s",
-        event, chunkIndex, allocatedMemory, peakMemory, headRoom, initReservation);
+        "Chunk allocator stats Log - Event: {}, Chunk Index: {}, Allocated Memory: {}, Peak Memory: {}, Headroom: {}, Init Reservation: {}",
+        event,
+        chunkIndex,
+        allocatedMemory,
+        peakMemory,
+        headRoom,
+        initReservation);
   }
 
   /** Releases all Arrow-related resources and clears the record batch list. */

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/AbstractRemoteChunkProvider.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/AbstractRemoteChunkProvider.java
@@ -283,8 +283,10 @@ public abstract class AbstractRemoteChunkProvider<T extends AbstractArrowResultC
     rowCount += DatabricksThriftUtil.getRowCount(resultData);
     for (TSparkArrowResultLink resultLink : resultData.getResultLinks()) {
       LOGGER.debug(
-          "Chunk information log - Row Offset: %s, Row Count: %s, Expiry Time: %s",
-          resultLink.getStartRowOffset(), resultLink.getRowCount(), resultLink.getExpiryTime());
+          "Chunk information log - Row Offset: {}, Row Count: {}, Expiry Time: {}",
+          resultLink.getStartRowOffset(),
+          resultLink.getRowCount(),
+          resultLink.getExpiryTime());
       chunkIndexMap.put(chunkCount, createChunk(statementId, chunkCount, resultLink));
       chunkCount++;
     }

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
@@ -146,8 +146,9 @@ public class ArrowResultChunk extends AbstractArrowResultChunk {
       headers.forEach(getRequest::addHeader);
     } else {
       LOGGER.debug(
-          "No encryption headers present for chunk index %s and statement %s",
-          chunkIndex, statementId);
+          "No encryption headers present for chunk index {} and statement {}",
+          chunkIndex,
+          statementId);
     }
   }
 

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ChunkDownloadTask.java
@@ -107,8 +107,9 @@ class ChunkDownloadTask implements DatabricksCallableTask {
         chunk.getChunkReadyFuture().complete(null); // complete the void future successfully
       } else {
         LOGGER.info(
-            "Uncaught exception during chunk download. Chunk index: %d, Error: %s",
-            chunk.getChunkIndex(), Arrays.toString(uncaughtException.getStackTrace()));
+            "Uncaught exception during chunk download. Chunk index: {}, Error: {}",
+            chunk.getChunkIndex(),
+            Arrays.toString(uncaughtException.getStackTrace()));
         // Status is set to DOWNLOAD_SUCCEEDED in the happy path. For any failure case,
         // explicitly set status to DOWNLOAD_FAILED here to ensure consistent error handling
         chunk.setStatus(ChunkStatus.DOWNLOAD_FAILED);

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/incubator/ArrowResultChunkV2.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/incubator/ArrowResultChunkV2.java
@@ -236,7 +236,7 @@ public class ArrowResultChunkV2 extends AbstractArrowResultChunk {
     if (currentAttempt < retryConfig.maxAttempts) {
       long delayMs = calculateBackoffDelay(currentAttempt, retryConfig);
       LOGGER.warn(
-          "Retryable error during %s for chunk %s (attempt %s/%s), retrying in %s ms. Error: %s",
+          "Retryable error during {} for chunk {} (attempt {}/{}), retrying in {} ms. Error: {}",
           phase.getDescription(),
           chunkIndex,
           currentAttempt,

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/incubator/StreamingResponseConsumer.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/incubator/StreamingResponseConsumer.java
@@ -112,7 +112,10 @@ class StreamingResponseConsumer extends AbstractBinResponseConsumer<byte[]> {
     double speedMBps = (chunk.bytesDownloaded / 1024.0 / 1024.0) / (durationMs / 1000.0);
 
     LOGGER.debug(
-        "Download stats for chunk %s: Size: %s MB, Duration: %s ms, Speed: %s MB/s",
-        chunk.getChunkIndex(), chunk.bytesDownloaded / 1024.0 / 1024.0, durationMs, speedMBps);
+        "Download stats for chunk {}: Size: {} MB, Duration: {} ms, Speed: {} MB/s",
+        chunk.getChunkIndex(),
+        chunk.bytesDownloaded / 1024.0 / 1024.0,
+        durationMs,
+        speedMBps);
   }
 }

--- a/src/main/java/com/databricks/jdbc/api/impl/volume/VolumeOperationProcessor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/volume/VolumeOperationProcessor.java
@@ -294,8 +294,9 @@ class VolumeOperationProcessor {
     try (CloseableHttpResponse response = databricksHttpClient.execute(httpGet)) {
       if (!HttpUtil.isSuccessfulHttpResponse(response)) {
         LOGGER.error(
-            "Failed to fetch content from volume with error {%s} for local file {%s}",
-            response.getStatusLine().getStatusCode(), localFilePath);
+            "Failed to fetch content from volume with error {} for local file {}",
+            response.getStatusLine().getStatusCode(),
+            localFilePath);
         status = VolumeOperationStatus.FAILED;
         errorMessage = "Failed to download file";
         return;
@@ -367,8 +368,9 @@ class VolumeOperationProcessor {
         status = VolumeOperationStatus.SUCCEEDED;
       } else {
         LOGGER.error(
-            "Failed to upload file {%s} with error code: {%s}",
-            localFilePath, response.getStatusLine().getStatusCode());
+            "Failed to upload file {} with error code: {}",
+            localFilePath,
+            response.getStatusLine().getStatusCode());
         // TODO: Add retries
         status = VolumeOperationStatus.FAILED;
         errorMessage =
@@ -413,7 +415,7 @@ class VolumeOperationProcessor {
         status = VolumeOperationStatus.SUCCEEDED;
       } else {
         LOGGER.error(
-            "Failed to delete volume with error code: {%s}",
+            "Failed to delete volume with error code: {}",
             response.getStatusLine().getStatusCode());
         status = VolumeOperationStatus.FAILED;
         errorMessage = "Failed to delete volume";

--- a/src/main/java/com/databricks/jdbc/auth/EncryptedFileTokenCache.java
+++ b/src/main/java/com/databricks/jdbc/auth/EncryptedFileTokenCache.java
@@ -75,7 +75,7 @@ public class EncryptedFileTokenCache implements TokenCache {
       file.setWritable(false, false);
       file.setWritable(true, true);
 
-      LOGGER.debug("Successfully saved encrypted token to cache: %s", cacheFile);
+      LOGGER.debug("Successfully saved encrypted token to cache: {}", cacheFile);
     } catch (Exception e) {
       throw new DatabricksException("Failed to save token cache: " + e.getMessage(), e);
     }
@@ -85,7 +85,7 @@ public class EncryptedFileTokenCache implements TokenCache {
   public Token load() {
     try {
       if (!Files.exists(cacheFile)) {
-        LOGGER.debug("No token cache file found at: %s", cacheFile);
+        LOGGER.debug("No token cache file found at: {}", cacheFile);
         return null;
       }
 
@@ -96,19 +96,19 @@ public class EncryptedFileTokenCache implements TokenCache {
       try {
         decodedContent = decrypt(fileContent);
       } catch (Exception e) {
-        LOGGER.debug("Failed to decrypt token cache: %s", e.getMessage());
+        LOGGER.debug("Failed to decrypt token cache: {}", e.getMessage());
         return null;
       }
 
       // Deserialize token from JSON
       String json = new String(decodedContent, StandardCharsets.UTF_8);
       Token token = mapper.readValue(json, Token.class);
-      LOGGER.debug("Successfully loaded encrypted token from cache: %s", cacheFile);
+      LOGGER.debug("Successfully loaded encrypted token from cache: {}", cacheFile);
       return token;
     } catch (Exception e) {
       // If there's any issue loading the token, return null
       // to allow a fresh token to be obtained
-      LOGGER.debug("Failed to load token from cache: %s", e.getMessage());
+      LOGGER.debug("Failed to load token from cache: {}", e.getMessage());
       return null;
     }
   }

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksThriftUtil.java
@@ -316,7 +316,7 @@ public class DatabricksThriftUtil {
   public static TOperationHandle getOperationHandle(StatementId statementId) {
     THandleIdentifier identifier = statementId.toOperationIdentifier();
     // This will help logging the statement-Id in readable format for debugging purposes
-    LOGGER.debug("getOperationHandle for statementId {%s}", byteBufferToString(identifier.guid));
+    LOGGER.debug("getOperationHandle for statementId {}", byteBufferToString(identifier.guid));
     return new TOperationHandle()
         .setOperationId(identifier)
         .setOperationType(TOperationType.UNKNOWN);
@@ -346,26 +346,25 @@ public class DatabricksThriftUtil {
       throws DatabricksHttpException {
     if (directResults.isSetOperationStatus()) {
       LOGGER.debug(
-          "direct result operation status being verified for success response for statementId {%s}",
+          "direct result operation status being verified for success response for statementId {}",
           statementId);
       verifySuccessStatus(directResults.getOperationStatus().getStatus(), context, statementId);
     }
     if (directResults.isSetResultSetMetadata()) {
       LOGGER.debug(
-          "direct results metadata being verified for success response for statementId {%s}",
+          "direct results metadata being verified for success response for statementId {}",
           statementId);
       verifySuccessStatus(directResults.getResultSetMetadata().getStatus(), context, statementId);
     }
     if (directResults.isSetCloseOperation()) {
       LOGGER.debug(
-          "direct results close operation verified for success response for statementId {%s}",
+          "direct results close operation verified for success response for statementId {}",
           statementId);
       verifySuccessStatus(directResults.getCloseOperation().getStatus(), context, statementId);
     }
     if (directResults.isSetResultSet()) {
       LOGGER.debug(
-          "direct result set being verified for success response for statementId {%s}",
-          statementId);
+          "direct result set being verified for success response for statementId {}", statementId);
       verifySuccessStatus(directResults.getResultSet().getStatus(), context, statementId);
     }
   }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
@@ -76,8 +76,10 @@ public class CommandBuilder {
 
   private String fetchSchemaSQL() {
     LOGGER.debug(
-        "Building command for fetching schema. Catalog %s, SchemaPattern %s and session context %s",
-        catalogName, schemaPattern, sessionContext);
+        "Building command for fetching schema. Catalog {}, SchemaPattern {} and session context {}",
+        catalogName,
+        schemaPattern,
+        sessionContext);
     String showSchemasSQL;
     if (WildcardUtil.isNullOrWildcard(catalogName)) {
       // SHOW SCHEMAS IN ALL CATALOGS
@@ -93,8 +95,11 @@ public class CommandBuilder {
 
   private String fetchTablesSQL() {
     LOGGER.debug(
-        "Building command for fetching tables. Catalog %s, SchemaPattern %s, TablePattern %s and session context %s",
-        catalogName, schemaPattern, tablePattern, sessionContext);
+        "Building command for fetching tables. Catalog {}, SchemaPattern {}, TablePattern {} and session context {}",
+        catalogName,
+        schemaPattern,
+        tablePattern,
+        sessionContext);
     String showTablesSQL;
     if (WildcardUtil.isNullOrWildcard(catalogName)) {
       // SHOW TABLES IN ALL CATALOGS

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataSdkClient.java
@@ -317,7 +317,7 @@ public class DatabricksMetadataSdkClient implements IDatabricksMetadataClient {
                   rows.add(schemaRow);
                 }
               } catch (SQLException e) {
-                LOGGER.warn("Error fetching schemas for catalog %s %s", c, e.getMessage());
+                LOGGER.warn("Error fetching schemas for catalog {} {}", c, e.getMessage());
               }
               return rows;
             },


### PR DESCRIPTION
## Description
It appears that `JdbcLogger` expects SLF4J formatted strings (i.e. `{}` rather than `%s`) given `JulLogger` already handles the reformatting of strings via [`slf4jToJavaFormat`](https://github.com/databricks/databricks-jdbc/blob/main/src/main/java/com/databricks/jdbc/log/JulLogger.java#L247). Log strings containing `%s` are not currently being formatted correctly, the `%s` appears in logs.