### PR TITLE
Fix logging not being suppressed when LogLevel.OFF is configured

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/LoggingUtil.java
@@ -17,12 +17,14 @@ public class LoggingUtil {
 
   public static void setupLogger(String logDir, int logFileSizeMB, int logFileCount, LogLevel level)
       throws IOException {
-    if (level == LogLevel.OFF) {
-      // Skip handler initialization to avoid AccessDeniedException in restricted environments
-      return;
-    }
     if (LOGGER instanceof JulLogger && System.getProperty(JAVA_UTIL_LOGGING_CONFIG_FILE) == null) {
       // Only configure JUL logger if it's not already configured via external properties file
+      if (level == LogLevel.OFF) {
+        // Initialize logger with OFF level to properly suppress all output.
+        // Without this, JUL falls back to default behavior and logs warnings to console.
+        JulLogger.initLogger(Level.OFF, JulLogger.STDOUT, 0, 0);
+        return;
+      }
       JulLogger.initLogger(toJulLevel(level), logDir, logFileSizeMB * 1024 * 1024, logFileCount);
       LOGGER.info("Setting up JUL logger");
     }

--- a/src/test/java/com/databricks/jdbc/common/util/LoggingUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/LoggingUtilTest.java
@@ -20,8 +20,9 @@ public class LoggingUtilTest {
 
   @Test
   void testSetupLoggerWithOffLevel() {
-    // When log level is OFF, setupLogger should return early without initializing handlers
-    // This should not throw an exception even if the log path is not writable
+    // When log level is OFF, setupLogger initializes logger with Level.OFF to suppress all output.
+    // It uses STDOUT to avoid file system access issues in restricted environments.
+    // This should not throw an exception even if the log path is not writable.
     assertDoesNotThrow(() -> LoggingUtil.setupLogger("/", 1, 1, LogLevel.OFF));
     assertDoesNotThrow(() -> LoggingUtil.setupLogger("/invalid/path", 1, 1, LogLevel.OFF));
   }


### PR DESCRIPTION
## Description
NO_CHANGELOG=true
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
When LogLevel.OFF was set, setupLogger() returned early without configuring the JUL logger. This caused Java's default logging behavior to kick in, resulting in deprecation warnings (e.g., ignoreTransactions warnings) being logged to console despite logging being disabled.

Now properly initializes the logger with Level.OFF to suppress all output while using STDOUT to avoid file system access issues in restricted environments.

Fixes #1158

## Testing
<!-- Describe how the changes have been tested-->
Manual testing

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

