### PR TITLE
Deprecate v3.0.4 and update changelog details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,10 @@
 
 ---
 
-## [v3.0.4] - 2025-11-12
+## [v3.0.4] - 2025-11-12: DEPRECATED, Use v3.0.5 instead
 
 ### Added
-- Added support for geospatial data types.
+- Added support for geospatial data types. (Use v3.0.5+ for OGC compliant WKB support)
 - Added support for telemetry log levels, which can be controlled via the connection parameter `TelemetryLogLevel`. This allows users to configure the verbosity of telemetry logging from OFF to TRACE.
 - Added full support for JDBC transaction control methods in Databricks. Transaction support in Databricks is currently available as a Private Preview. The `IgnoreTransactions` connection parameter can be set to `1` to disable or no-op transaction control methods.
 - Added a new config attribute `DisableOauthRefreshToken` to control whether refresh tokens are requested in OAuth exchanges. By default, the driver does not include the `offline_access` scope. If `offline_access` is explicitly provided by the user, it is preserved and not removed.


### PR DESCRIPTION
Updated version v3.0.4 to be marked as deprecated and added a note to use v3.0.5 instead. Added additional details for geospatial data type support.

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
NO_CHANGELOG=true
