### PR TITLE
Make StreamingChunkProvider the default chunk provider

### DIFF
--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -190,8 +190,8 @@ public enum DatabricksJdbcUrlParams {
       "EnableTokenFederation", "Enable token federation for authentication", "1"),
   ENABLE_STREAMING_CHUNK_PROVIDER(
       "EnableStreamingChunkProvider",
-      "Enable streaming chunk provider for result fetching (experimental)",
-      "0"),
+      "Enable streaming chunk provider for result fetching",
+      "1"),
   LINK_PREFETCH_WINDOW(
       "LinkPrefetchWindow",
       "Number of chunk links to prefetch ahead of consumption. "

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResultTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResultTest.java
@@ -478,15 +478,14 @@ public class ArrowStreamResultTest {
 
   @Test
   public void testStreamingChunkProviderEnabledForSeaResult() throws Exception {
-    // Enable StreamingChunkProvider via connection property
+    // StreamingChunkProvider is enabled by default
     Properties props = new Properties();
-    props.setProperty("EnableStreamingChunkProvider", "1");
     IDatabricksConnectionContext connectionContext =
         DatabricksConnectionContextFactory.create(JDBC_URL, props);
 
     assertTrue(
         connectionContext.isStreamingChunkProviderEnabled(),
-        "StreamingChunkProvider should be enabled via property");
+        "StreamingChunkProvider should be enabled by default");
 
     DatabricksSession localSession = new DatabricksSession(connectionContext, mockedSdkClient);
 
@@ -518,14 +517,15 @@ public class ArrowStreamResultTest {
 
   @Test
   public void testStreamingChunkProviderDisabledUsesRemoteChunkProvider() throws Exception {
-    // Default properties - StreamingChunkProvider disabled
+    // Explicitly disable StreamingChunkProvider to use RemoteChunkProvider
     Properties props = new Properties();
+    props.setProperty("EnableStreamingChunkProvider", "0");
     IDatabricksConnectionContext connectionContext =
         DatabricksConnectionContextFactory.create(JDBC_URL, props);
 
     assertFalse(
         connectionContext.isStreamingChunkProviderEnabled(),
-        "StreamingChunkProvider should be disabled by default");
+        "StreamingChunkProvider should be disabled when explicitly set to 0");
 
     DatabricksSession localSession = new DatabricksSession(connectionContext, mockedSdkClient);
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-jdbc/pull/1173/files) to review incremental changes.
- [**stack/streaming-chunk-provider-default**](https://github.com/databricks/databricks-jdbc/pull/1173) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1173/files)]
  - [stack/remove-remote-chunk-provider](https://github.com/databricks/databricks-jdbc/pull/1174) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1174/files/aab5871cbfed35de494856f425d23da589654672..386d27fac02086c77f29bc093de58f2a6d1c792e)]

---------
Change EnableStreamingChunkProvider default value from 0 to 1, making
StreamingChunkProvider the default for result fetching. This removes
the experimental label as the implementation is now production-ready.

- Update DatabricksJdbcUrlParams default from "0" to "1"
- Update ArrowStreamResultTest to verify default behavior
- Test that explicitly disabling still uses RemoteChunkProvider

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
