### PR TITLE
[PECOBLR-1575] cross catalog metadata operations in comparator

### DIFF
--- a/src/test/java/com/jayant/JDBCDriverComparisonTest.java
+++ b/src/test/java/com/jayant/JDBCDriverComparisonTest.java
@@ -174,7 +174,7 @@ public class JDBCDriverComparisonTest {
     return combined.stream();
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideSQLQueries")
   @DisplayName("Compare SQL Query Results")
   void compareSQLQueryResults(
@@ -197,7 +197,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideMetadataMethods")
   @DisplayName("Compare Metadata API Results")
   void compareMetadataResults(
@@ -227,7 +227,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideResultSetMethods")
   @DisplayName("Compare ResultSet API Results")
   void compareResultSetResults(
@@ -254,7 +254,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideResultSetMetaDataMethods")
   @DisplayName("Compare ResultSetMetaData API Results")
   void compareResultSetMetaDataResults(
@@ -283,7 +283,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideConnectionMethods")
   @DisplayName("Compare Connection API Results")
   void compareConnectionResults(

--- a/src/test/java/com/jayant/ResultSetComparator.java
+++ b/src/test/java/com/jayant/ResultSetComparator.java
@@ -22,11 +22,15 @@ public class ResultSetComparator {
     if (result1 instanceof ResultSet && result2 instanceof ResultSet) {
       ResultSet rs1 = (ResultSet) result1;
       ResultSet rs2 = (ResultSet) result2;
-      // Compare metadata
-      result.metadataDifferences = compareMetadata(rs1.getMetaData(), rs2.getMetaData());
+      try {
+        // Compare metadata
+        result.metadataDifferences = compareMetadata(rs1.getMetaData(), rs2.getMetaData());
 
-      // Compare data
-      result.dataDifferences = compareData(rs1, rs2);
+        // Compare data
+        result.dataDifferences = compareData(rs1, rs2);
+      } catch (SQLException e) {
+        result.dataDifferences.add("ResultSet iteration error: " + e.getMessage());
+      }
     } else if (!(result1 instanceof ResultSet) && !(result2 instanceof ResultSet)) {
       // Both are not of type ResultSet
       if (result1 == null || !resultIsSame(result1, result2)) {

--- a/src/test/java/com/jayant/testparams/DatabaseMetaDataTestParams.java
+++ b/src/test/java/com/jayant/testparams/DatabaseMetaDataTestParams.java
@@ -95,6 +95,87 @@ public class DatabaseMetaDataTestParams implements TestParams {
         Map.entry("getAttributes", 4),
         new String[] {"main", "tpcds_sf100_delta", "%", "%"});
 
+    // Cross-catalog tests: null catalog (match all catalogs)
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getTables", 4),
+        new String[] {null, "tpcds_sf100_delta", "%", null});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getTablePrivileges", 3),
+        new String[] {null, "tpcds_sf100_delta", "%"});
+    putInMapForKey(functionToArgsMap, Map.entry("getSchemas", 2), new String[] {null, "tpcds_%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getColumns", 4),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getPseudoColumns", 4),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getColumnPrivileges", 4),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getVersionColumns", 3),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getFunctions", 3),
+        new String[] {null, "tpcds_sf100_delta", "aggregate"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getFunctionColumns", 4),
+        new String[] {null, "tpcds_sf100_delta", "aggregate", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getProcedures", 3),
+        new String[] {null, "tpcds_sf100_delta", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getProcedureColumns", 4),
+        new String[] {null, "tpcds_sf100_delta", "%", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getPrimaryKeys", 3),
+        new String[] {null, "oss_jdbc_tests", "test_result_set_types"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getImportedKeys", 3),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getExportedKeys", 3),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getCrossReference", 6),
+        new String[] {
+          null, "tpcds_sf100_delta", "catalog_sales", null, "tpcds_sf100_delta", "catalog_sales"
+        });
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getIndexInfo", 5),
+        new Object[] {null, "tpcds_sf100_delta", "catalog_sales", true, false});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getUDTs", 4),
+        new String[] {null, "tpcds_sf100_delta", "%", null});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getSuperTypes", 3),
+        new String[] {null, "tpcds_sf100_delta", "%"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getSuperTables", 3),
+        new String[] {null, "tpcds_sf100_delta", "catalog_sales"});
+    putInMapForKey(
+        functionToArgsMap,
+        Map.entry("getAttributes", 4),
+        new String[] {null, "tpcds_sf100_delta", "%", "%"});
+
     // Methods for ResultSet concurrency and visibility
     for (Integer type : getResultSetTypes()) {
       putInMapForKey(
@@ -129,6 +210,11 @@ public class DatabaseMetaDataTestParams implements TestParams {
           functionToArgsMap,
           Map.entry("getBestRowIdentifier", 5),
           new Object[] {"main", "tpcds_sf100_delta", "catalog_sales", i, true});
+      // Cross-catalog: null catalog
+      putInMapForKey(
+          functionToArgsMap,
+          Map.entry("getBestRowIdentifier", 5),
+          new Object[] {null, "tpcds_sf100_delta", "catalog_sales", i, true});
     }
     for (Integer i : getResultSetHoldability()) {
       putInMapForKey(


### PR DESCRIPTION
## Description
Added cross-catalog metadata tests to the JDBC comparator and fixed bug where all old(2.7.6) driver comparisons were failing due to JUnit 5's `autoCloseArguments` default.

**Changes:**
- Added null-catalog test args for all `DatabaseMetaData` methods that accept a catalog parameter (e.g., `getTables(null, ...)`, `getSchemas(null, ...)`, `getColumns(null, ...)`), adding 42 new parameterized test invocations to validate cross-catalog metadata behavior.
- Fixed `autoCloseArguments` issue: JUnit 5.8+ defaults to calling `.close()` on any `AutoCloseable` argument (`Connection`, `ResultSet`) after each parameterized test invocation. Since the comparator reuses the same connection objects across 4220+ test invocations, JUnit was silently closing them after the first invocation — causing 1917 test failures. Set `autoCloseArguments = false` on all 5 `@ParameterizedTest` annotations.
- Wrapped `ResultSet` comparison in `ResultSetComparator` with try-catch to handle lazy `ResultSet` errors (e.g., old driver's `getPrimaryKeys(null, ...)` returns a `ResultSet` that throws server errors during iteration).

## Testing
- Ran the full comparator test suite: **4220 tests, 0 failures, 0 errors** (previously 1917 failures).
- Verified the comparison report has **zero "closed" errors** (previously 1716).

NO_CHANGELOG=true