### PR TITLE
Fix broken auto-merge artifacts from merging main into jdbc-comparator-updated

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
@@ -162,7 +162,8 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
 
     DatabricksThreadContextHolder.setStatementType(statementType);
 
-    TExecuteStatementReq request = getRequest(sql, parameters, session, parentStatement, false);
+    TExecuteStatementReq request =
+        getRequest(sql, parameters, session, parentStatement, false, statementType);
 
     return thriftAccessor.execute(request, parentStatement, session, statementType);
   }
@@ -181,7 +182,8 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
             "public DatabricksResultSet executeStatementAsync(String sql = {%s}, Compute cluster = {%s}, Map<Integer, ImmutableSqlParameter> parameters = {%s})",
             sql, computeResource.toString(), parameters.toString()));
 
-    TExecuteStatementReq request = getRequest(sql, parameters, session, parentStatement, true);
+    TExecuteStatementReq request =
+        getRequest(sql, parameters, session, parentStatement, true, StatementType.SQL);
 
     return thriftAccessor.executeAsync(request, parentStatement, session, StatementType.SQL);
   }
@@ -204,7 +206,8 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
       Map<Integer, ImmutableSqlParameter> parameters,
       IDatabricksSession session,
       IDatabricksStatementInternal parentStatement,
-      boolean runAsync)
+      boolean runAsync,
+      StatementType statementType)
       throws SQLException {
     DatabricksThreadContextHolder.setSessionId(session.getSessionId());
     TSparkArrowTypes arrowNativeTypes = new TSparkArrowTypes().setTimestampAsArrow(true);
@@ -254,7 +257,9 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
       request.setResultRowLimit(maxRows);
     }
 
-    if (runAsync || !DriverUtil.isRunningAgainstFake()) {
+    if (statementType == StatementType.METADATA) {
+      request.setRunAsync(false);
+    } else if (runAsync || !DriverUtil.isRunningAgainstFake()) {
       request.setRunAsync(true);
     }
 

--- a/src/main/java/com/databricks/jdbc/log/JulLogger.java
+++ b/src/main/java/com/databricks/jdbc/log/JulLogger.java
@@ -230,19 +230,6 @@ public class JulLogger implements JdbcLogger {
         return actualPackageName.substring(0, defaultPrefixIndex + DEFAULT_PACKAGE_PREFIX.length());
       }
     }
-    // Auto-detect the actual package prefix by using the current class
-    // This handles shaded JARs where the package might be relocated
-    String actualPackageName = JulLogger.class.getPackage().getName();
-    // Extract the root prefix (e.g., "jdbc.shaded.v1.0.12.OSS.com.databricks.jdbc"
-    // or "com.databricks.jdbc")
-    if (actualPackageName.contains(DEFAULT_PACKAGE_PREFIX)) {
-      // Find the actual prefix including any shading prefix
-      int defaultPrefixIndex = actualPackageName.indexOf(DEFAULT_PACKAGE_PREFIX);
-      if (defaultPrefixIndex > 0) {
-        // Include everything up to and including the default prefix
-        return actualPackageName.substring(0, defaultPrefixIndex + DEFAULT_PACKAGE_PREFIX.length());
-      }
-    }
     return DEFAULT_PACKAGE_PREFIX;
   }
 

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -340,48 +340,6 @@ public class DatabricksThriftServiceClientTest {
   }
 
   @Test
-  void testExecuteWithCloudFetchDisabled() throws SQLException {
-    when(connectionContext.shouldEnableArrow()).thenReturn(true);
-    when(connectionContext.isCloudFetchEnabled()).thenReturn(false);
-    DatabricksThriftServiceClient client =
-        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
-    when(session.getSessionInfo()).thenReturn(SESSION_INFO);
-    when(parentStatement.getStatement()).thenReturn(statement);
-    when(parentStatement.getMaxRows()).thenReturn(10);
-    when(statement.getQueryTimeout()).thenReturn(10);
-    TSparkArrowTypes arrowNativeTypes =
-        new TSparkArrowTypes()
-            .setComplexTypesAsArrow(true)
-            .setIntervalTypesAsArrow(true)
-            .setNullTypeAsArrow(true)
-            .setDecimalAsArrow(true)
-            .setTimestampAsArrow(true);
-    TExecuteStatementReq executeStatementReq =
-        new TExecuteStatementReq()
-            .setStatement(TEST_STRING)
-            .setSessionHandle(SESSION_HANDLE)
-            .setCanReadArrowResult(true)
-            .setQueryTimeout(10)
-            .setResultRowLimit(10)
-            .setCanDecompressLZ4Result(true)
-            .setCanDownloadResult(false)
-            .setParameters(Collections.emptyList())
-            .setRunAsync(true)
-            .setUseArrowNativeTypes(arrowNativeTypes);
-    when(thriftAccessor.execute(executeStatementReq, parentStatement, session, StatementType.SQL))
-        .thenReturn(resultSet);
-    DatabricksResultSet actualResultSet =
-        client.executeStatement(
-            TEST_STRING,
-            CLUSTER_COMPUTE,
-            Collections.emptyMap(),
-            StatementType.SQL,
-            session,
-            parentStatement);
-    assertEquals(resultSet, actualResultSet);
-  }
-
-  @Test
   void testExecuteAsync() throws SQLException {
     when(connectionContext.shouldEnableArrow()).thenReturn(true);
     when(connectionContext.isCloudFetchEnabled()).thenReturn(true);
@@ -749,8 +707,8 @@ public class DatabricksThriftServiceClientTest {
             .setCanDecompressLZ4Result(true)
             .setCanDownloadResult(true)
             .setQueryTimeout(0)
+            .setRunAsync(false)
             .setParameters(Collections.emptyList())
-            .setRunAsync(true)
             .setUseArrowNativeTypes(arrowNativeTypes);
     when(thriftAccessor.execute(executeStatementReq, null, session, StatementType.METADATA))
         .thenReturn(resultSet);
@@ -1095,6 +1053,66 @@ public class DatabricksThriftServiceClientTest {
     assertEquals("STRING", result.getType());
     assertEquals(TEST_STRING, result.getValue().getStringValue());
     assertEquals(2, result.getOrdinal());
+  }
+
+  @Test
+  void testExecuteStatementWithMetadataTypeDoesNotSetRunAsync() throws SQLException {
+    when(connectionContext.shouldEnableArrow()).thenReturn(true);
+    lenient().when(connectionContext.isCloudFetchEnabled()).thenReturn(true);
+    DatabricksThriftServiceClient client =
+        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
+    when(session.getSessionInfo()).thenReturn(SESSION_INFO);
+
+    when(thriftAccessor.execute(
+            any(TExecuteStatementReq.class), eq(null), eq(session), eq(StatementType.METADATA)))
+        .thenReturn(resultSet);
+
+    client.executeStatement(
+        "SHOW TABLES",
+        CLUSTER_COMPUTE,
+        Collections.emptyMap(),
+        StatementType.METADATA,
+        session,
+        null,
+        null);
+
+    ArgumentCaptor<TExecuteStatementReq> requestCaptor =
+        ArgumentCaptor.forClass(TExecuteStatementReq.class);
+    verify(thriftAccessor)
+        .execute(requestCaptor.capture(), eq(null), eq(session), eq(StatementType.METADATA));
+    TExecuteStatementReq request = requestCaptor.getValue();
+
+    assertFalse(request.isRunAsync(), "Expected runAsync to be false for METADATA statement type");
+  }
+
+  @Test
+  void testExecuteStatementWithSqlTypeStillSetsRunAsync() throws SQLException {
+    when(connectionContext.shouldEnableArrow()).thenReturn(true);
+    lenient().when(connectionContext.isCloudFetchEnabled()).thenReturn(true);
+    DatabricksThriftServiceClient client =
+        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
+    when(session.getSessionInfo()).thenReturn(SESSION_INFO);
+
+    when(thriftAccessor.execute(
+            any(TExecuteStatementReq.class), eq(null), eq(session), eq(StatementType.SQL)))
+        .thenReturn(resultSet);
+
+    client.executeStatement(
+        "SELECT 1",
+        CLUSTER_COMPUTE,
+        Collections.emptyMap(),
+        StatementType.SQL,
+        session,
+        null,
+        null);
+
+    ArgumentCaptor<TExecuteStatementReq> requestCaptor =
+        ArgumentCaptor.forClass(TExecuteStatementReq.class);
+    verify(thriftAccessor)
+        .execute(requestCaptor.capture(), eq(null), eq(session), eq(StatementType.SQL));
+    TExecuteStatementReq request = requestCaptor.getValue();
+
+    assertTrue(request.isRunAsync(), "Expected runAsync to be true for SQL statement type");
   }
 
   @Test


### PR DESCRIPTION
## Summary

During the merge of `upstream/main` into `jdbc-comparator-updated` (#1260), git auto-merged three files without flagging them as conflicts, but produced incorrect results. This PR fixes those broken merge artifacts by restoring all three files to exactly match `upstream/main`.

### Files Fixed

- **`JulLogger.java`** — Auto-merge duplicated the entire `getPackagePrefix()` method body, causing a compilation error (`variable actualPackageName is already defined`).

- **`DatabricksThriftServiceClient.java`** — Auto-merge silently reverted to the older version from `jdbc-comparator-updated`, dropping the `statementType` parameter that was added in `main`. This caused a method signature mismatch.

- **`DatabricksThriftServiceClientTest.java`** — Auto-merge duplicated the `testExecuteWithCloudFetchDisabled()` method, causing a compilation error and a test call with mismatched argument count.

### Verification

- All three files now match `upstream/main` exactly (`git diff upstream/main` shows no diff for these files)
- `mvn clean install -DskipTests` passes successfully
- `mvn test` passes — only `JDBCDriverComparisonTest` fails as expected (requires live Databricks credentials)

NO_CHANGELOG=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)