### PR TITLE
Add COMPARATOR_MODE flag to selectively run comparator pairs

### DIFF
--- a/.github/workflows/runJdbcComparator.yml
+++ b/.github/workflows/runJdbcComparator.yml
@@ -4,6 +4,16 @@ on:
   schedule:
     - cron: '0 0 * * 1' # Run at 00:00 UTC on Monday (1)
   workflow_dispatch:    # Allow manual trigger
+    inputs:
+      comparison_mode:
+        description: 'Which comparison pair to run'
+        required: false
+        default: 'thrift-vs-sea'
+        type: choice
+        options:
+          - thrift-vs-sea
+          - simba-vs-sea
+          - all
 
 jobs:
   comparator:
@@ -47,7 +57,7 @@ jobs:
           echo "DATABRICKS_COMPARATOR_TOKEN=${DATABRICKS_COMPARATOR_TOKEN}" >> $GITHUB_ENV
 
       - name: Run Tests
-        run: mvn -pl jdbc-core test -Dtest=JDBCDriverComparisonTest
+        run: mvn -pl jdbc-core test -Dtest=JDBCDriverComparisonTest -DCOMPARATOR_MODE=${{ inputs.comparison_mode || 'thrift-vs-sea' }}
 
       - name: Format Email Content
         run: |

--- a/src/test/java/com/jayant/JDBCDriverComparisonTest.java
+++ b/src/test/java/com/jayant/JDBCDriverComparisonTest.java
@@ -25,6 +25,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class JDBCDriverComparisonTest {
+  private static final String COMPARATOR_MODE =
+      System.getProperty("COMPARATOR_MODE", "thrift-vs-sea");
+
   private static final String OLD_DRIVER_JDBC_URL =
       "jdbc:databricks://benchmarking-prod-aws-us-west-2.cloud.databricks.com:443/default;ssl=1;authMech=3;httpPath=/sql/1.0/warehouses/e3c43f3911e50d7c;UID=token;";
   private static final String OSS_DRIVER_JDBC_URL =
@@ -48,29 +51,25 @@ public class JDBCDriverComparisonTest {
     // Create temporary directory for extracted JARs
     tempDir = Files.createTempDirectory("jdbc-drivers");
 
-    // Extract and load drivers
-    URL oldDriverJarUrl = extractJarToTemp("databricks-jdbc-2.7.6.jar", tempDir);
-
-    if (oldDriverJarUrl == null) {
-      throw new RuntimeException("Unable to find JDBC driver JARs in the classpath");
-    }
-
-    // Initialize class loaders and drivers
-    URLClassLoader oldDriverClassLoader =
-        new CustomClassLoader(
-            new URL[] {oldDriverJarUrl}, JDBCDriverComparisonTest.class.getClassLoader());
-
-    Class<?> oldDriverClass =
-        Class.forName("com.databricks.client.jdbc.Driver", true, oldDriverClassLoader);
-
-    Driver oldDriver = (Driver) oldDriverClass.getDeclaredConstructor().newInstance();
-
     // Initialize connections
     String pwd = System.getenv("DATABRICKS_COMPARATOR_TOKEN");
 
     Properties props = new Properties();
-    // Use the old driver (2.7.6)
-    oldDriverConnection = oldDriver.connect(OLD_DRIVER_JDBC_URL + "PWD=" + pwd, props);
+
+    if (COMPARATOR_MODE.equals("simba-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      // Extract and load old driver (2.7.6)
+      URL oldDriverJarUrl = extractJarToTemp("databricks-jdbc-2.7.6.jar", tempDir);
+      if (oldDriverJarUrl == null) {
+        throw new RuntimeException("Unable to find JDBC driver JARs in the classpath");
+      }
+      URLClassLoader oldDriverClassLoader =
+          new CustomClassLoader(
+              new URL[] {oldDriverJarUrl}, JDBCDriverComparisonTest.class.getClassLoader());
+      Class<?> oldDriverClass =
+          Class.forName("com.databricks.client.jdbc.Driver", true, oldDriverClassLoader);
+      Driver oldDriver = (Driver) oldDriverClass.getDeclaredConstructor().newInstance();
+      oldDriverConnection = oldDriver.connect(OLD_DRIVER_JDBC_URL + "PWD=" + pwd, props);
+    }
 
     // OSS driver with Thrift
     ossThriftConnection = DriverManager.getConnection(OSS_DRIVER_JDBC_URL, "token", pwd);
@@ -82,9 +81,11 @@ public class JDBCDriverComparisonTest {
 
     String queryResultSetTypesTable = "select * from main.tpch_sf100_delta.customer limit 100";
     // Create separate ResultSets for each comparison pair to avoid reuse issues
-    oldDriverResultSet =
-        oldDriverConnection.createStatement().executeQuery(queryResultSetTypesTable);
-    ossSeaResultSet1 = ossSeaConnection.createStatement().executeQuery(queryResultSetTypesTable);
+    if (COMPARATOR_MODE.equals("simba-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      oldDriverResultSet =
+          oldDriverConnection.createStatement().executeQuery(queryResultSetTypesTable);
+      ossSeaResultSet1 = ossSeaConnection.createStatement().executeQuery(queryResultSetTypesTable);
+    }
 
     ossThriftResultSet =
         ossThriftConnection.createStatement().executeQuery(queryResultSetTypesTable);
@@ -120,11 +121,15 @@ public class JDBCDriverComparisonTest {
     List<Arguments> base = baseProvider.collect(Collectors.toList());
     List<Arguments> combined = new ArrayList<>();
 
-    // Define connection pairs
-    Object[][] connectionPairs = {
-      {"Old(2.7.6) vs OSS-SEA", oldDriverConnection, ossSeaConnection},
-      {"OSS-Thrift vs OSS-SEA", ossThriftConnection, ossSeaConnection}
-    };
+    // Define connection pairs based on COMPARATOR_MODE
+    List<Object[]> pairList = new ArrayList<>();
+    if (COMPARATOR_MODE.equals("simba-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      pairList.add(new Object[] {"Old(2.7.6) vs OSS-SEA", oldDriverConnection, ossSeaConnection});
+    }
+    if (COMPARATOR_MODE.equals("thrift-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      pairList.add(new Object[] {"OSS-Thrift vs OSS-SEA", ossThriftConnection, ossSeaConnection});
+    }
+    Object[][] connectionPairs = pairList.toArray(new Object[0][]);
 
     // Combine each pair with each base argument
     for (Object[] pair : connectionPairs) {
@@ -151,11 +156,15 @@ public class JDBCDriverComparisonTest {
     List<Arguments> base = baseProvider.collect(Collectors.toList());
     List<Arguments> combined = new ArrayList<>();
 
-    // Define ResultSet pairs - each with separate instances to avoid reuse
-    Object[][] resultSetPairs = {
-      {"Old(2.7.6) vs OSS-SEA", oldDriverResultSet, ossSeaResultSet1},
-      {"OSS-Thrift vs OSS-SEA", ossThriftResultSet, ossSeaResultSet2}
-    };
+    // Define ResultSet pairs based on COMPARATOR_MODE - each with separate instances to avoid reuse
+    List<Object[]> pairList = new ArrayList<>();
+    if (COMPARATOR_MODE.equals("simba-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      pairList.add(new Object[] {"Old(2.7.6) vs OSS-SEA", oldDriverResultSet, ossSeaResultSet1});
+    }
+    if (COMPARATOR_MODE.equals("thrift-vs-sea") || COMPARATOR_MODE.equals("all")) {
+      pairList.add(new Object[] {"OSS-Thrift vs OSS-SEA", ossThriftResultSet, ossSeaResultSet2});
+    }
+    Object[][] resultSetPairs = pairList.toArray(new Object[0][]);
 
     // Combine each pair with each base argument
     for (Object[] pair : resultSetPairs) {
@@ -174,7 +183,7 @@ public class JDBCDriverComparisonTest {
     return combined.stream();
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideSQLQueries")
   @DisplayName("Compare SQL Query Results")
   void compareSQLQueryResults(
@@ -197,7 +206,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideMetadataMethods")
   @DisplayName("Compare Metadata API Results")
   void compareMetadataResults(
@@ -227,7 +236,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideResultSetMethods")
   @DisplayName("Compare ResultSet API Results")
   void compareResultSetResults(
@@ -254,7 +263,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideResultSetMetaDataMethods")
   @DisplayName("Compare ResultSetMetaData API Results")
   void compareResultSetMetaDataResults(
@@ -283,7 +292,7 @@ public class JDBCDriverComparisonTest {
         });
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("provideConnectionMethods")
   @DisplayName("Compare Connection API Results")
   void compareConnectionResults(


### PR DESCRIPTION
## Summary
- Adds `COMPARATOR_MODE` system property (default: `thrift-vs-sea`) to `JDBCDriverComparisonTest` to control which comparison pair runs (`thrift-vs-sea`, `simba-vs-sea`, or `all`)
- Skips old driver JAR loading and connection setup entirely when not needed (faster runs)
- Adds `workflow_dispatch` inputs to `runJdbcComparator.yml` with a dropdown for easy manual selection; scheduled runs default to `thrift-vs-sea`
- Applies `autoCloseArguments = false` to all 5 `@ParameterizedTest` methods to prevent premature closure of JDBC resources between test invocations (fixes `simba-vs-sea` failures)

## Test plan
- [x] `thrift-vs-sea`: 2087 tests, 0 failures
- [x] `simba-vs-sea`: 2087 tests, 0 failures
- [x] `all`: 4174 tests, 0 failures

NO_CHANGELOG=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)