### PR TITLE
Enable release freeze for v3.3.1

### DIFF
--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,3 +1,3 @@
 {
-  "freeze": false
+  "freeze": true
 }


### PR DESCRIPTION
## Summary
- Activates release freeze by setting `"freeze": true` in `development/.release-freeze.json`
- All PRs targeting `main` will be blocked unless they include `OVERRIDE_FREEZE=true` in their description

## Test plan
- [ ] Verify the `Enforce Release Freeze` CI check blocks PRs without `OVERRIDE_FREEZE=true`
- [ ] Verify PRs with `OVERRIDE_FREEZE=true` can still merge

NO_CHANGELOG=true

OVERRIDE_FREEZE=true

This pull request was AI-assisted by Isaac.