### PR TITLE
Fix SEA backend prematurely closing Statement/PreparedStatement after execute()

### DIFF
--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -318,29 +318,14 @@ public class DatabricksSdkClient implements IDatabricksClient {
       handleFailedExecution(response, statementId, sql);
     }
 
-    // Defer markAsClosed until AFTER ResultSet construction. VolumeOperationResult
-    // (created during ResultSet construction) accesses statement properties via
-    // isAllowedInputStreamForVolumeOperation() which calls checkIfClosed().
-    // Marking the statement closed before ResultSet construction causes volume
-    // operations to fail with "Statement is closed".
-    boolean shouldMarkClosed = responseState == StatementState.CLOSED && parentStatement != null;
-
-    DatabricksResultSet resultSet =
-        new DatabricksResultSet(
-            response.getStatus(),
-            typedStatementId,
-            response.getResult(),
-            response.getManifest(),
-            statementType,
-            session,
-            parentStatement);
-
-    if (shouldMarkClosed) {
-      LOGGER.debug("Statement {} returned CLOSED status, marking statement as closed", statementId);
-      ((DatabricksStatement) parentStatement.getStatement()).markAsClosed();
-    }
-
-    return resultSet;
+    return new DatabricksResultSet(
+        response.getStatus(),
+        typedStatementId,
+        response.getResult(),
+        response.getManifest(),
+        statementType,
+        session,
+        parentStatement);
   }
 
   @Override

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
@@ -945,8 +945,10 @@ public class DatabricksSdkClientTest {
   }
 
   @Test
-  public void testExecuteStatementWithClosedStatus() throws Exception {
-    // Set up connection and statement
+  public void testExecuteStatementWithClosedStatusDoesNotCloseStatement() throws Exception {
+    // Verify that when the SEA server returns CLOSED status, the JDBC Statement
+    // object is NOT marked as closed. Per JDBC spec, Statement should remain open
+    // until explicitly closed by the user, enabling PreparedStatement reuse.
     IDatabricksConnectionContext connectionContext =
         DatabricksConnectionContext.parse(JDBC_URL, new Properties());
     DatabricksSdkClient databricksSdkClient =
@@ -998,8 +1000,9 @@ public class DatabricksSdkClientTest {
         statement,
         null);
 
-    // Verify that markAsClosed was called on the statement
-    verify(statement, times(1)).markAsClosed();
+    // Verify that markAsClosed was NOT called — statement should remain open
+    verify(statement, never()).markAsClosed();
+    assertFalse(statement.isClosed());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Remove auto-close logic in `DatabricksSdkClient.executeStatement()` that called `markAsClosed()` when the SEA server returned `StatementState.CLOSED`
- This was violating JDBC spec §13.1.1: Statement objects must remain open until explicitly closed by the user
- Fixes PreparedStatement reuse across transaction boundaries and `getMetaData()` after execution on the SEA backend

## Test plan
- [x] Updated `testExecuteStatementWithClosedStatusDoesNotCloseStatement` to verify statement remains open after CLOSED response
- [x] Existing `testExecuteStatementWithClosedStatusAndNoParentStatement` still passes
- [x] All `DatabricksStatementTest` markAsClosed tests still pass (method retained for potential future use)

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.