### PR TITLE
Show row count in exception-vs-ResultSet comparator diffs

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
+++ b/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
@@ -75,10 +75,26 @@ public class ResultSetComparator {
     } else {
       // when we see different classes of results, it would generally mean that one result is an
       // exception and the other is an actual result set.
-      result.metadataDifferences.add(result1.getClass() + " vs " + result2.getClass());
+      String r1Label = describeResult(result1);
+      String r2Label = describeResult(result2);
+      result.metadataDifferences.add(r1Label + " vs " + r2Label);
     }
 
     return result;
+  }
+
+  private static String describeResult(Object result) {
+    if (result instanceof ResultSet) {
+      try {
+        ResultSet rs = (ResultSet) result;
+        int rowCount = 0;
+        while (rs.next()) rowCount++;
+        return result.getClass() + (rowCount == 0 ? " (empty)" : " (" + rowCount + " rows)");
+      } catch (SQLException e) {
+        return result.getClass().toString();
+      }
+    }
+    return result.getClass().toString();
   }
 
   private static boolean resultIsSame(Object result1, Object result2) {


### PR DESCRIPTION
## Summary
- When one side throws an exception and the other returns a ResultSet, the comparator diff now shows whether the ResultSet is empty or has data
- Before: `class DatabricksSQLException vs class DatabricksResultSet`
- After: `class DatabricksSQLException vs class DatabricksResultSet (empty)` or `(5 rows)`

## Test plan
- [x] Verified with getTables `catalog=""` cases — all show `(empty)` as expected
- [x] No impact on existing comparator behavior for ResultSet-vs-ResultSet or exception-vs-exception cases

NO_CHANGELOG=true