### PR TITLE
Add CSV output and skip reasons to comparator framework

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/ComparisonResult.java
+++ b/src/test/java/com/databricks/jdbc/comparator/ComparisonResult.java
@@ -24,6 +24,37 @@ public class ComparisonResult {
     return !metadataDifferences.isEmpty() || !dataDifferences.isEmpty();
   }
 
+  /** Returns a concise one-line summary of diffs for CSV output. */
+  public String csvSummary() {
+    List<String> parts = new ArrayList<>();
+
+    // Exception vs ResultSet — already concise, keep as is
+    for (String d : metadataDifferences) {
+      if (d.contains(" vs class ")) {
+        parts.add(d);
+      }
+    }
+
+    // Count metadata mismatches (e.g., "Column name X mismatch: ...")
+    long metaMismatches = metadataDifferences.stream().filter(d -> d.contains("mismatch")).count();
+    if (metaMismatches > 0) parts.add(metaMismatches + " metadata mismatches");
+
+    // Extra rows (e.g., "First ResultSet has N extra rows")
+    for (String d : dataDifferences) {
+      if (d.contains("extra rows")) parts.add(d);
+    }
+
+    // Count row data mismatches (e.g., "Row 1, Column X mismatch: ...")
+    long rowMismatches =
+        dataDifferences.stream()
+            .filter(d -> d.startsWith("Row ") || d.startsWith("["))
+            .filter(d -> d.contains("mismatch"))
+            .count();
+    if (rowMismatches > 0) parts.add(rowMismatches + " data mismatches");
+
+    return parts.isEmpty() ? "" : String.join(", ", parts);
+  }
+
   /** Returns a new ComparisonResult with diffs matching any skip pattern removed. */
   public ComparisonResult filterDiffs(List<String> skipPatterns) {
     if (skipPatterns.isEmpty()) return this;

--- a/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
+++ b/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
@@ -6,6 +6,8 @@ import com.databricks.jdbc.comparator.config.ConnectionConfig;
 import com.databricks.jdbc.comparator.config.ConnectionManager;
 import com.databricks.jdbc.comparator.config.TestSuite;
 import com.databricks.jdbc.comparator.setup.WorkspaceSetup;
+import com.databricks.jdbc.comparator.suite.CombinationResult;
+import com.databricks.jdbc.comparator.suite.DatabaseMetaDataProvider;
 import com.databricks.jdbc.comparator.suite.SuiteProvider;
 import com.databricks.jdbc.comparator.suite.TestCase;
 import java.io.IOException;
@@ -81,7 +83,10 @@ public class JDBCDriverComparisonTest {
   @AfterAll
   static void teardown() throws Exception {
     if (connectionManager != null) connectionManager.close();
-    if (reporter != null) reporter.finish();
+    if (reporter != null) {
+      reporter.finish();
+      System.out.println("CSV results: " + reporter.getCsvPath());
+    }
   }
 
   /**
@@ -143,9 +148,43 @@ public class JDBCDriverComparisonTest {
               "[%s] [%s] Running: %s%n", Instant.now(), comparisonName, testCase.getDescription());
 
           String label = suite.name() + " [" + comparisonName + "]";
+          // comparisonName is "Config | Suite", extract config part
+          String configName =
+              comparisonName.contains(" | ")
+                  ? comparisonName.substring(0, comparisonName.indexOf(" | "))
+                  : comparisonName;
           try {
             ComparisonResult result = suite.getProvider().execute(conn1, conn2, testCase, label);
             reporter.addResult(result);
+
+            // CSV: per-combo rows for metadata, single row for other suites
+            SuiteProvider provider = suite.getProvider();
+            if (provider instanceof DatabaseMetaDataProvider) {
+              String methodName = testCase.getIdentifier();
+              for (CombinationResult cr :
+                  ((DatabaseMetaDataProvider) provider).getLastComboResults()) {
+                String comboTestCase = methodName + "(" + cr.argsLabel + ")";
+                if (cr.skipped) {
+                  reporter.addCsvRow(
+                      suite.name(),
+                      configName,
+                      comboTestCase,
+                      "SKIPPED",
+                      cr.skipReason != null ? cr.skipReason : "");
+                } else if (cr.metadataDiffs.isEmpty() && cr.dataDiffs.isEmpty()) {
+                  reporter.addCsvRow(suite.name(), configName, comboTestCase, "PASS", "");
+                } else {
+                  ComparisonResult temp = new ComparisonResult("", "", new Object[0]);
+                  temp.metadataDifferences = cr.metadataDiffs;
+                  temp.dataDifferences = cr.dataDiffs;
+                  reporter.addCsvRow(
+                      suite.name(), configName, comboTestCase, "DIFF", temp.csvSummary());
+                }
+              }
+            } else {
+              reporter.addCsvFromResult(
+                  suite.name(), configName, testCase.getDescription(), result);
+            }
 
             if (result.hasDifferences()) {
               System.err.println(
@@ -156,6 +195,8 @@ public class JDBCDriverComparisonTest {
             System.err.printf(
                 "[%s] [%s] ERROR in %s: %s%n",
                 Instant.now(), comparisonName, testCase.getDescription(), e.getMessage());
+            reporter.addCsvRow(
+                suite.name(), configName, testCase.getDescription(), "ERROR", e.getMessage());
             throw e;
           }
         });

--- a/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
+++ b/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
@@ -11,6 +11,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Note: If diff string formats are changed here, update {@link ComparisonResult#csvSummary()} which
+ * parses these strings to generate concise CSV summaries.
+ */
 public class ResultSetComparator {
   public static ComparisonResult compare(
       String queryType, String queryOrMethod, Object[] methodArgs, Object result1, Object result2)

--- a/src/test/java/com/databricks/jdbc/comparator/TestReporter.java
+++ b/src/test/java/com/databricks/jdbc/comparator/TestReporter.java
@@ -10,17 +10,25 @@ import java.util.List;
 
 public class TestReporter {
   private final Path outputPath;
+  private final Path csvPath;
   private final List<String> skipDiffPatterns;
 
   public TestReporter(Path outputPath, List<String> headerLines) throws IOException {
     this.skipDiffPatterns = parseSkipDiffPatterns();
     this.outputPath = outputPath;
+    this.csvPath =
+        Path.of(
+            outputPath.toString().replaceFirst("-report-", "-results-").replace(".txt", ".csv"));
     try (FileWriter writer = new FileWriter(outputPath.toFile())) {
       writer.write("Report generated at: " + Instant.now() + "\n");
       for (String line : headerLines) {
         writer.write(line + "\n");
       }
       writer.write("============================\n\n");
+    }
+    // Write CSV header
+    try (FileWriter csv = new FileWriter(csvPath.toFile())) {
+      csv.write("Suite,Config,Test Case,Result,Diff Summary\n");
     }
   }
 
@@ -36,10 +44,60 @@ public class TestReporter {
     }
   }
 
+  /** Writes a single CSV row for a test case result. */
+  public void addCsvRow(
+      String suite, String config, String testCase, String result, String diffSummary) {
+    try (FileWriter csv = new FileWriter(csvPath.toFile(), true)) {
+      csv.write(
+          escapeCsv(suite)
+              + ","
+              + escapeCsv(config)
+              + ","
+              + escapeCsv(testCase)
+              + ","
+              + escapeCsv(result)
+              + ","
+              + escapeCsv(diffSummary)
+              + "\n");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Convenience method to add CSV rows from a ComparisonResult. Writes one row per diff, or a
+   * single PASS/DIFF_FILTERED row.
+   */
+  public void addCsvFromResult(
+      String suite, String config, String testCase, ComparisonResult result) {
+    ComparisonResult filtered = result.filterDiffs(skipDiffPatterns);
+
+    if (!result.hasDifferences()) {
+      addCsvRow(suite, config, testCase, "PASS", "");
+    } else if (!filtered.hasDifferences()) {
+      // Had diffs but all were filtered
+      addCsvRow(suite, config, testCase, "DIFF_FILTERED", "");
+    } else {
+      addCsvRow(suite, config, testCase, "DIFF", filtered.csvSummary());
+    }
+  }
+
+  private static String escapeCsv(String value) {
+    if (value == null || value.isEmpty()) return "";
+    if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
   private static List<String> parseSkipDiffPatterns() {
     String prop = System.getProperty("SKIP_DIFF_PATTERNS");
     if (prop == null || prop.isEmpty()) return Collections.emptyList();
     return Arrays.asList(prop.split("\\|"));
+  }
+
+  public Path getCsvPath() {
+    return csvPath;
   }
 
   public void finish() {

--- a/src/test/java/com/databricks/jdbc/comparator/suite/CombinationExecutor.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/CombinationExecutor.java
@@ -79,11 +79,12 @@ public class CombinationExecutor {
     for (int idx = 0; idx < total; idx++) {
       Object[] args = argCombos.get(idx);
       String argsLabel = formatArgs(args);
-      if (FILTER_CONFIG.shouldSkip(methodName, args)) {
+      String skipReason = FILTER_CONFIG.getSkipReason(methodName, args);
+      if (skipReason != null) {
         System.out.printf(
-            "[%s]   Skipped %s(%s) [%d/%d] — filtered%n",
-            Instant.now(), methodName, argsLabel, idx + 1, total);
-        results.add(CombinationResult.skipped(argsLabel));
+            "[%s]   Skipped %s(%s) [%d/%d] — %s%n",
+            Instant.now(), methodName, argsLabel, idx + 1, total, skipReason);
+        results.add(CombinationResult.skipped(argsLabel, skipReason));
         continue;
       }
       System.out.printf(
@@ -107,10 +108,12 @@ public class CombinationExecutor {
 
     for (Object[] args : argCombos) {
       final String argsLabel = formatArgs(args);
-      if (FILTER_CONFIG.shouldSkip(methodName, args)) {
+      String skipReason = FILTER_CONFIG.getSkipReason(methodName, args);
+      if (skipReason != null) {
         System.out.printf(
-            "[%s]   Skipped %s(%s) — filtered%n", Instant.now(), methodName, argsLabel);
-        futures.add(CompletableFuture.completedFuture(CombinationResult.skipped(argsLabel)));
+            "[%s]   Skipped %s(%s) — %s%n", Instant.now(), methodName, argsLabel, skipReason);
+        futures.add(
+            CompletableFuture.completedFuture(CombinationResult.skipped(argsLabel, skipReason)));
         continue;
       }
       futures.add(

--- a/src/test/java/com/databricks/jdbc/comparator/suite/CombinationResult.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/CombinationResult.java
@@ -5,26 +5,33 @@ import java.util.List;
 
 /** Result of comparing one argument combination for a DatabaseMetaData method. */
 public class CombinationResult {
-  final String argsLabel;
-  final List<String> metadataDiffs;
-  final List<String> dataDiffs;
-  final boolean skipped;
+  public final String argsLabel;
+  public final List<String> metadataDiffs;
+  public final List<String> dataDiffs;
+  public final boolean skipped;
+  public final String skipReason;
 
   CombinationResult(String argsLabel, List<String> metadataDiffs, List<String> dataDiffs) {
     this.argsLabel = argsLabel;
     this.metadataDiffs = metadataDiffs;
     this.dataDiffs = dataDiffs;
     this.skipped = false;
+    this.skipReason = null;
   }
 
-  private CombinationResult(String argsLabel, boolean skipped) {
+  private CombinationResult(String argsLabel, String skipReason) {
     this.argsLabel = argsLabel;
     this.metadataDiffs = Collections.emptyList();
     this.dataDiffs = Collections.emptyList();
-    this.skipped = skipped;
+    this.skipped = true;
+    this.skipReason = skipReason;
   }
 
   static CombinationResult skipped(String argsLabel) {
-    return new CombinationResult(argsLabel, true);
+    return new CombinationResult(argsLabel, (String) null);
+  }
+
+  static CombinationResult skipped(String argsLabel, String reason) {
+    return new CombinationResult(argsLabel, reason);
   }
 }

--- a/src/test/java/com/databricks/jdbc/comparator/suite/DatabaseMetaDataProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/DatabaseMetaDataProvider.java
@@ -21,6 +21,9 @@ public class DatabaseMetaDataProvider implements SuiteProvider {
   private static final Map<String, List<Object[]>> METHOD_REGISTRY =
       DatabaseMetaDataParams.buildRegistry();
 
+  /** Last execution's per-combo results, available after {@link #execute}. */
+  private List<CombinationResult> lastComboResults;
+
   @Override
   public List<TestCase> getTestCases() {
     List<TestCase> cases = new ArrayList<>();
@@ -43,6 +46,7 @@ public class DatabaseMetaDataProvider implements SuiteProvider {
 
     List<CombinationResult> results =
         CombinationExecutor.executeAll(methodName, argCombinations, md1, md2, label);
+    this.lastComboResults = results;
 
     // Merge results with [argsLabel] prefix for traceability
     List<String> metadataDiffs = new ArrayList<>();
@@ -61,5 +65,10 @@ public class DatabaseMetaDataProvider implements SuiteProvider {
     result.metadataDifferences = metadataDiffs;
     result.dataDifferences = dataDiffs;
     return result;
+  }
+
+  /** Returns per-combo results from the last {@link #execute} call. */
+  public List<CombinationResult> getLastComboResults() {
+    return lastComboResults;
   }
 }

--- a/src/test/java/com/databricks/jdbc/comparator/suite/MetadataFilterConfig.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/MetadataFilterConfig.java
@@ -160,6 +160,35 @@ public class MetadataFilterConfig {
     return false;
   }
 
+  /**
+   * Returns the skip reason for this argument combination, or null if not skipped. Checks both
+   * runOnly (not in whitelist) and skip (in blacklist) filters.
+   */
+  public String getSkipReason(String methodName, Object[] args) {
+    List<String> argNames = ARG_NAMES.get(methodName);
+    if (argNames == null || argNames.isEmpty()) return null;
+
+    Map<String, String> namedArgs = toNamedArgs(args, argNames);
+
+    List<Map<String, String>> runOnlyPatterns = metadataRunOnlyFilters.get(methodName);
+    if (runOnlyPatterns != null && !runOnlyPatterns.isEmpty()) {
+      if (!matchesAnyPattern(namedArgs, runOnlyPatterns)) {
+        return "not in runOnly filter";
+      }
+    }
+
+    List<Map<String, String>> skipPatterns = metadataSkipFilters.get(methodName);
+    if (skipPatterns != null && !skipPatterns.isEmpty()) {
+      for (Map<String, String> pattern : skipPatterns) {
+        if (matchesPattern(namedArgs, pattern)) {
+          return pattern.getOrDefault(REASON_KEY, "matched skip filter");
+        }
+      }
+    }
+
+    return null;
+  }
+
   /** Whether this config has any filters defined. */
   public boolean isEmpty() {
     return metadataRunOnlyFilters.isEmpty() && metadataSkipFilters.isEmpty();
@@ -187,10 +216,13 @@ public class MetadataFilterConfig {
     return named;
   }
 
+  private static final String REASON_KEY = "reason";
+
   private static boolean matchesPattern(
       Map<String, String> namedArgs, Map<String, String> pattern) {
     for (Map.Entry<String, String> condition : pattern.entrySet()) {
       String argName = condition.getKey();
+      if (REASON_KEY.equals(argName)) continue; // reason is metadata, not a filter condition
       String skipValue = condition.getValue();
       String actual = namedArgs.get(argName);
       if (skipValue.startsWith("!")) {


### PR DESCRIPTION
## Summary
- Generates a CSV file alongside the text report with one row per test case
- Columns: Suite, Config, Test Case, Result (PASS/DIFF/DIFF_FILTERED/SKIPPED/ERROR), Diff Summary
- Concise diff summaries via `csvSummary()` (e.g., "First ResultSet has N extra rows", "N data mismatches")
- Optional `reason` field in filter config JSON for documenting why combinations are skipped
- Per-combo CSV rows for DatabaseMetaData methods, single row for other suites

## Test plan
- [x] Verified CSV output with getColumns `compar%` runOnly filter — correct PASS/DIFF/SKIPPED counts
- [x] Skip reason shows custom message from filter config, default "matched skip filter" otherwise
- [x] One row per test case with concise summary — no verbose row dumps
- [x] Compilation verified

NO_CHANGELOG=true