### PR TITLE
Strip META-INF/maven/** from uber and thin JARs

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Updated
 
 ### Fixed
+- Stripped `META-INF/maven/**` (`pom.properties`, `pom.xml`) from the uber JAR.
 - Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch. Arrow metadata from CloudFetch uses underscored format (`INTERVAL_YEAR_MONTH`, `INTERVAL_DAY_TIME`) which the driver's regex did not accept.
 - Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
 - Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled, by re-quoting column names with backticks in reconstructed multi-row INSERT statements.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Updated
 
 ### Fixed
-- Stripped `META-INF/maven/**` (`pom.properties`, `pom.xml`) from the uber JAR.
+- Stripped `META-INF/maven/**` (`pom.properties`, `pom.xml`) from the uber and thin JARs.
 - Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch. Arrow metadata from CloudFetch uses underscored format (`INTERVAL_YEAR_MONTH`, `INTERVAL_DAY_TIME`) which the driver's regex did not accept.
 - Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
 - Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled, by re-quoting column names with backticks in reconstructed multi-row INSERT statements.

--- a/assembly-thin/pom.xml
+++ b/assembly-thin/pom.xml
@@ -142,6 +142,7 @@
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                         <exclude>META-INF/versions/**</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/assembly-uber/pom.xml
+++ b/assembly-uber/pom.xml
@@ -204,6 +204,7 @@
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                         <exclude>META-INF/versions/**</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>


### PR DESCRIPTION
## Summary
- Strip `META-INF/maven/**` (`pom.properties`, `pom.xml`) from the shade plugin filter in both `assembly-uber` and `assembly-thin`.
- Dependency information remains available in the published POM on Maven Central.

## Test plan
- [x] Built uber JAR and verified `META-INF/maven/` has 0 entries
- [x] Verified all other META-INF files intact (MANIFEST.MF, services/, io.netty.versions.properties)
- [x] `TestUberPackaging` shaded dependency tests pass
- [x] CI checks

This pull request was AI-assisted by Isaac.