### PR TITLE
[PECOBLR-2318] Unify EnableDirectResults and EnableSQLExecDirectResults params

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -286,7 +286,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   @Override
   public Boolean getDirectResultMode() {
-    return Objects.equals(getParameter(DatabricksJdbcUrlParams.DIRECT_RESULT), "1");
+    return Objects.equals(
+        getParameter(
+            DatabricksJdbcUrlParams.DIRECT_RESULT,
+            getParameter(DatabricksJdbcUrlParams.ENABLE_SQL_EXEC_DIRECT_RESULTS)),
+        "1");
   }
 
   public Cloud getCloud() throws DatabricksParsingException {
@@ -912,11 +916,6 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public boolean isSqlExecHybridResultsEnabled() {
     return getParameter(DatabricksJdbcUrlParams.ENABLE_SQL_EXEC_HYBRID_RESULTS).equals("1");
-  }
-
-  @Override
-  public boolean isSqlExecDirectResultsEnabled() {
-    return getParameter(DatabricksJdbcUrlParams.ENABLE_SQL_EXEC_DIRECT_RESULTS).equals("1");
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksConnectionContext.java
@@ -296,9 +296,6 @@ public interface IDatabricksConnectionContext {
   /** Returns true if driver should use hybrid results in SQL_EXEC API. */
   boolean isSqlExecHybridResultsEnabled();
 
-  /** Returns true if driver should use direct results in SQL_EXEC API. */
-  boolean isSqlExecDirectResultsEnabled();
-
   /** Returns the Azure tenant ID for the Azure Databricks workspace. */
   String getAzureTenantId();
 

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -121,7 +121,9 @@ public enum DatabricksJdbcUrlParams {
   ENABLE_SQL_EXEC_HYBRID_RESULTS(
       "EnableSQLExecHybridResults", "flag to enable hybrid results", "1"),
   ENABLE_SQL_EXEC_DIRECT_RESULTS(
-      "EnableSQLExecDirectResults", "flag to enable direct results", "1"),
+      "EnableSQLExecDirectResults",
+      "Alias for EnableDirectResults. Enables direct results in SQL execution",
+      "1"),
   ENABLE_COMPLEX_DATATYPE_SUPPORT(
       "EnableComplexDatatypeSupport",
       "flag to enable native support of complex data types as java objects",

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -676,7 +676,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
       request.setWaitTimeout(ASYNC_TIMEOUT_VALUE);
     } else {
       // Only set timeout if direct results mode is not enabled
-      if (!connectionContext.isSqlExecDirectResultsEnabled()) {
+      if (!connectionContext.getDirectResultMode()) {
         request.setWaitTimeout(SYNC_TIMEOUT_VALUE);
       }
       request.setOnWaitTimeout(ExecuteStatementRequestOnWaitTimeout.CONTINUE);

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -813,7 +813,7 @@ class DatabricksConnectionContextTest {
     DatabricksConnectionContext connectionContext =
         (DatabricksConnectionContext)
             DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
-    assertTrue(connectionContext.isSqlExecDirectResultsEnabled());
+    assertTrue(connectionContext.getDirectResultMode());
 
     // Test when EnableSQLExecDirectResults=1
     String urlWithDirectResults =
@@ -822,7 +822,7 @@ class DatabricksConnectionContextTest {
     connectionContext =
         (DatabricksConnectionContext)
             DatabricksConnectionContext.parse(urlWithDirectResults, properties);
-    assertTrue(connectionContext.isSqlExecDirectResultsEnabled());
+    assertTrue(connectionContext.getDirectResultMode());
 
     // Test when EnableSQLExecDirectResults=0
     String urlWithoutDirectResults =
@@ -831,7 +831,7 @@ class DatabricksConnectionContextTest {
     connectionContext =
         (DatabricksConnectionContext)
             DatabricksConnectionContext.parse(urlWithoutDirectResults, properties);
-    assertFalse(connectionContext.isSqlExecDirectResultsEnabled());
+    assertFalse(connectionContext.getDirectResultMode());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Merges `EnableDirectResults` (Thrift) and `EnableSQLExecDirectResults` (SEA) into a single unified resolution using the existing alias/fallback pattern
- `EnableDirectResults` is the canonical param; `EnableSQLExecDirectResults` is a backward-compatible alias
- Users can now set either param to control direct results for both Thrift and SEA modes
- Removes the now-redundant `isSqlExecDirectResultsEnabled()` method from the interface and implementation

## Test plan
- [x] Existing unit tests pass (162 tests: ConnectionContextTest, ThriftAccessorTest, SdkClientTest)
- [x] Verified with live integration tests against both Thrift and SEA modes with direct results ON/OFF
- [x] Verified inline results (small queries) and CloudFetch results (large queries) work correctly in both modes

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.