### PR TITLE
Catch Throwable in comparator test to log AssertionError in CSV

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
+++ b/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
@@ -191,7 +191,7 @@ public class JDBCDriverComparisonTest {
                   "[" + comparisonName + "] Differences found for: " + testCase.getDescription());
               System.err.println(result);
             }
-          } catch (Exception e) {
+          } catch (Throwable e) {
             System.err.printf(
                 "[%s] [%s] ERROR in %s: %s%n",
                 Instant.now(), comparisonName, testCase.getDescription(), e.getMessage());


### PR DESCRIPTION
## Summary
- `AssertionError` (e.g., CloudFetch threshold failure) extends `Error`, not `Exception`
- The catch block was missing it, so these failures showed as PASS in CSV instead of ERROR
- Changed `catch (Exception e)` to `catch (Throwable e)`

## Test plan
- [x] Verified locally: geospatial CloudFetch failure now shows as ERROR in CSV
- [x] Before: `GEOSPATIAL,Geospatial enabled,Geo columns — CloudFetch,PASS,`
- [x] After: `GEOSPATIAL,Geospatial enabled,Geo columns — CloudFetch,ERROR,CloudFetch expectation failed...`

NO_CHANGELOG=true