### PR TITLE
Fix getCrossReference case-insensitive parent matching

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed escaped pattern characters in catalogName for `getSchemas`, as returned catalogName should be unescaped.
 - Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
 - Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
+- Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase. The client-side filter used case-sensitive comparison against server-returned lowercase names.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/CrossReferenceKeysDatabricksResultSetAdapter.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/CrossReferenceKeysDatabricksResultSetAdapter.java
@@ -43,15 +43,15 @@ public class CrossReferenceKeysDatabricksResultSetAdapter
     boolean isParentCatalogMatching =
         resultSet
             .getString(parentCatalogNameColumn.getResultSetColumnName())
-            .equals(targetParentCatalogName);
+            .equalsIgnoreCase(targetParentCatalogName);
     boolean isParentNamespaceMatching =
         resultSet
             .getString(parentNamespaceColumn.getResultSetColumnName())
-            .equals(targetParentNamespaceName);
+            .equalsIgnoreCase(targetParentNamespaceName);
     boolean isParentTableMatching =
         resultSet
             .getString(parentTableNameColumn.getResultSetColumnName())
-            .equals(targetParentTableName);
+            .equalsIgnoreCase(targetParentTableName);
 
     if (!isParentTableMatching || !isParentCatalogMatching || !isParentNamespaceMatching) {
       return false;

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/CrossReferenceKeysDatabricksResultSetAdapterTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/CrossReferenceKeysDatabricksResultSetAdapterTest.java
@@ -126,6 +126,45 @@ public class CrossReferenceKeysDatabricksResultSetAdapterTest {
   }
 
   @Test
+  public void testIncludeRowMatchesCaseInsensitively() throws SQLException {
+    List<ResultColumn> columns = new ArrayList<>();
+
+    // Mock the ResultSet to return lowercase values while adapter was constructed with mixed case
+    when(mockResultSet.getString(PARENT_CATALOG_NAME.getResultSetColumnName()))
+        .thenReturn("targetcatalog");
+    when(mockResultSet.getString(PARENT_NAMESPACE_NAME.getResultSetColumnName()))
+        .thenReturn("targetschema");
+    when(mockResultSet.getString(PARENT_TABLE_NAME.getResultSetColumnName()))
+        .thenReturn("targettable");
+
+    boolean result = crossRefAdapter.includeRow(mockResultSet, columns);
+
+    assertTrue(result, "includeRow should match case-insensitively");
+  }
+
+  @Test
+  public void testIncludeRowMatchesUppercaseInput() throws SQLException {
+    List<ResultColumn> columns = new ArrayList<>();
+
+    // Adapter constructed with mixed case, server returns lowercase
+    CrossReferenceKeysDatabricksResultSetAdapter uppercaseAdapter =
+        new CrossReferenceKeysDatabricksResultSetAdapter(
+            "TARGETCATALOG", "TARGETSCHEMA", "TARGETTABLE");
+
+    when(mockResultSet.getString(PARENT_CATALOG_NAME.getResultSetColumnName()))
+        .thenReturn("targetcatalog");
+    when(mockResultSet.getString(PARENT_NAMESPACE_NAME.getResultSetColumnName()))
+        .thenReturn("targetschema");
+    when(mockResultSet.getString(PARENT_TABLE_NAME.getResultSetColumnName()))
+        .thenReturn("targettable");
+
+    boolean result = uppercaseAdapter.includeRow(mockResultSet, columns);
+
+    assertTrue(
+        result, "includeRow should match when user passes uppercase and server returns lowercase");
+  }
+
+  @Test
   public void testInheritanceFromImportedKeysAdapter() {
     assertInstanceOf(ImportedKeysDatabricksResultSetAdapter.class, crossRefAdapter);
   }


### PR DESCRIPTION
## Summary
- `getCrossReference()` returned 0 rows when parent catalog/schema/table args were passed in uppercase
- Root cause: `CrossReferenceKeysDatabricksResultSetAdapter.includeRow()` used `.equals()` for comparing user-provided parent args against server-returned lowercase values
- Fixed by changing to `.equalsIgnoreCase()` — Databricks identifiers are case-insensitive

## Test plan
- [x] Unit tests: 2 new tests for case-insensitive matching (12 total pass)
- [x] End-to-end: verified with `getCrossReference(COMPARATOR_TESTS, OSS_JDBC_TESTS, FK_PARENT, ...)` — SEA now returns 1 row matching Thrift
- [x] Tested on both Peco testing and Peco comparator workspaces