### PR TITLE
Route to Thrift when TreatMetadataCatalogNameAsPattern=1

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -478,6 +478,10 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
     if (!isCloudFetchEnabled()) {
       return DatabricksClientType.THRIFT;
     }
+    // TreatMetadataCatalogNameAsPattern is a Thrift-only metadata behavior
+    if (treatMetadataCatalogNameAsPattern()) {
+      return DatabricksClientType.THRIFT;
+    }
     // Check feature flag to determine if SEA client should be enabled
     if (DatabricksDriverFeatureFlagsContextFactory.getInstance(this)
         .isFeatureEnabled(SQL_EXEC_FLAG_NAME)) {

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -978,6 +978,25 @@ class DatabricksConnectionContextTest {
     assertEquals(DatabricksClientType.THRIFT, connectionContext.getClientType());
   }
 
+  @Test
+  public void testClientTypeWhenTreatMetadataCatalogNameAsPatternEnabled()
+      throws DatabricksSQLException {
+    String url =
+        "jdbc:databricks://sample-host.cloud.databricks.com:9999/default;AuthMech=3;"
+            + "httpPath=/sql/1.0/warehouses/9999999999999999;EnableArrow=1;"
+            + "EnableQueryResultDownload=1;TreatMetadataCatalogNameAsPattern=1";
+    DatabricksConnectionContext connectionContext =
+        (DatabricksConnectionContext) DatabricksConnectionContext.parse(url, properties);
+
+    // Even with SEA feature flag enabled, Thrift should win because
+    // TreatMetadataCatalogNameAsPattern is a Thrift-only metadata behavior.
+    Map<String, String> flags = new HashMap<>();
+    flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(connectionContext, flags);
+
+    assertEquals(DatabricksClientType.THRIFT, connectionContext.getClientType());
+  }
+
   // ===== setClientType Override Tests =====
 
   @Test


### PR DESCRIPTION
## Summary

- `TreatMetadataCatalogNameAsPattern` controls a Thrift-only metadata behavior (escaping wildcards in Thrift metadata RPCs). When a user explicitly sets it to `1`, the driver now routes to the THRIFT client so the flag actually takes effect, instead of silently no-oping under SEA.
- Placed in `DatabricksConnectionContext.getClientTypeFromContext()` after the explicit `UseThriftClient` override — user explicit client-type choice still wins, matching the existing precedence for `EnableArrow` and `EnableQueryResultDownload`.
- Note: with the new `UseQueryForMetadata=1` default, `TreatMetadataCatalogNameAsPattern` is already redundant for default configs. This new rule is meaningful for users who explicitly set both `TreatMetadataCatalogNameAsPattern=1` and `UseQueryForMetadata=0`.

NO_CHANGELOG=true

## Test plan

- [x] Added `testClientTypeWhenTreatMetadataCatalogNameAsPatternEnabled` — verifies `TreatMetadataCatalogNameAsPattern=1` forces THRIFT even when the SEA feature flag is ON
- [x] Existing client-type routing tests still pass (`UseThriftClient` override, Arrow/CloudFetch disabled, feature flag variants)

This pull request and its description were written by Isaac.