### PR TITLE
Cut new release 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Version Changelog
 
+## [v3.3.2] - 2026-04-27
+
+### Added
+- Added `CallableStatement` support with IN parameters. `Connection.prepareCall()` now returns a working `DatabricksCallableStatement` that supports positional parameter binding and execution via `{call proc(?)}` JDBC escape syntax. OUT/INOUT parameters and named parameters throw `SQLFeatureNotSupportedException`.
+- Added AI coding agent detection to the User-Agent header. When the driver is invoked by a known AI coding agent (e.g. Claude Code, Cursor, Gemini CLI), `agent/<product>` is appended to the User-Agent string.
+
+### Updated
+- Added support for using SQL SHOW commands for Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`). Enable by setting `UseQueryForMetadata=1`. This aligns Thrift metadata behavior with Statement Execution API (SEA) mode.
+
+### Fixed
+- Improved error messages for cancelled statements: operations cancelled via `Statement.cancel()` or closed connections now return SQL state `HY008` (operation cancelled) instead of generic error codes, making it easier for applications to detect and handle cancellations.
+- Fixed race condition between chunk download error handling and result set close that could cause invalid state transition warnings (`CHUNK_RELEASED -> DOWNLOAD_FAILED`) during Arrow Cloud Fetch operations in resource-constrained environments.
+- Fixed `EnableBatchedInserts` silently falling back to individual execution when table or schema names contain special characters (e.g., hyphens) inside backtick-quoted identifiers. Added a warn log when the fallback occurs.
+- Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch. Arrow metadata from CloudFetch uses underscored format (`INTERVAL_YEAR_MONTH`, `INTERVAL_DAY_TIME`) which the driver's regex did not accept.
+- Fixed `Statement` being prematurely closed after queries that return inline results, which prevented re-execution, `getResultSet()`, and `getExecutionResult()` from working. Statements now remain open and reusable until explicitly closed by the caller.
+- Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
+- Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled, by re-quoting column names with backticks in reconstructed multi-row INSERT statements.
+- Fixed Volume ingestion for SEA mode, which was broken due to statement being closed prematurely.
+- Fixed unclear `error: [null]` messages during transient HTTP failures (e.g. 502 Bad Gateway) in Thrift polling. Error messages now include server error details and use SQL state `08S01` (communication link failure) so callers can identify retryable errors. Also fixed `DatabricksError` (RuntimeException) from SDK client being unhandled in CloudFetch download paths.
+- Fixed escaped pattern characters in catalogName for `getSchemas`, as returned catalogName should be unescaped.
+- Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
+- Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
+- Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase. The client-side filter used case-sensitive comparison against server-returned lowercase names.
+
 ## [v3.3.1] - 2026-03-17
 
 ### Added

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,26 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- Added `CallableStatement` support with IN parameters. `Connection.prepareCall()` now returns a working `DatabricksCallableStatement` that supports positional parameter binding and execution via `{call proc(?)}` JDBC escape syntax. OUT/INOUT parameters and named parameters throw `SQLFeatureNotSupportedException`.
-- Added AI coding agent detection to the User-Agent header. When the driver is invoked by a known AI coding agent (e.g. Claude Code, Cursor, Gemini CLI), `agent/<product>` is appended to the User-Agent string.
 
 ### Updated
-- Added support for using SQL SHOW commands for Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`). Enable by setting `UseQueryForMetadata=1`. This aligns Thrift metadata behavior with Statement Execution API (SEA) mode.
 
 ### Fixed
-- Improved error messages for cancelled statements: operations cancelled via `Statement.cancel()` or closed connections now return SQL state `HY008` (operation cancelled) instead of generic error codes, making it easier for applications to detect and handle cancellations.
-- Fixed race condition between chunk download error handling and result set close that could cause invalid state transition warnings (`CHUNK_RELEASED -> DOWNLOAD_FAILED`) during Arrow Cloud Fetch operations in resource-constrained environments.
-- Fixed `EnableBatchedInserts` silently falling back to individual execution when table or schema names contain special characters (e.g., hyphens) inside backtick-quoted identifiers. Added a warn log when the fallback occurs.
-- Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch. Arrow metadata from CloudFetch uses underscored format (`INTERVAL_YEAR_MONTH`, `INTERVAL_DAY_TIME`) which the driver's regex did not accept.
-- Fixed `Statement` being prematurely closed after queries that return inline results, which prevented re-execution, `getResultSet()`, and `getExecutionResult()` from working. Statements now remain open and reusable until explicitly closed by the caller.
-- Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
-- Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled, by re-quoting column names with backticks in reconstructed multi-row INSERT statements.
-- Fixed Volume ingestion for SEA mode, which was broken due to statement being closed prematurely.
-- Fixed unclear `error: [null]` messages during transient HTTP failures (e.g. 502 Bad Gateway) in Thrift polling. Error messages now include server error details and use SQL state `08S01` (communication link failure) so callers can identify retryable errors. Also fixed `DatabricksError` (RuntimeException) from SDK client being unhandled in CloudFetch download paths.
-- Fixed escaped pattern characters in catalogName for `getSchemas`, as returned catalogName should be unescaped.
-- Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
-- Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
-- Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase. The client-side filter used case-sensitive comparison against server-returned lowercase names.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-jdbc</artifactId>
-  <version>3.3.2-SNAPSHOT</version>
+  <version>3.3.2</version>
 </dependency>
 ```
 

--- a/assembly-thin/pom.xml
+++ b/assembly-thin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>3.3.2</version>
     </parent>
 
     <artifactId>databricks-jdbc-thin</artifactId>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-core</artifactId>
-            <version>3.3.2-SNAPSHOT</version>
+            <version>3.3.2</version>
         </dependency>
     </dependencies>
 

--- a/assembly-uber/pom.xml
+++ b/assembly-uber/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>3.3.2</version>
     </parent>
 
     <artifactId>databricks-jdbc</artifactId>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-core</artifactId>
-            <version>3.3.2-SNAPSHOT</version>
+            <version>3.3.2</version>
         </dependency>
     </dependencies>
 

--- a/jdbc-core/pom.xml
+++ b/jdbc-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-jdbc-parent</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.2</version>
   </parent>
 
   <artifactId>databricks-jdbc-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.databricks</groupId>
   <artifactId>databricks-jdbc-parent</artifactId>
   <!-- This value may be modified by a release script to reflect the current version of the driver. -->
-  <version>3.3.2-SNAPSHOT</version>
+  <version>3.3.2</version>
   <packaging>pom</packaging>
   <name>Databricks JDBC Parent</name>
   <description>Parent POM for Databricks JDBC Driver.</description>
@@ -63,7 +63,7 @@
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 
     <!-- Dependency Versions -->
-    <databricks-jdbc-version>3.3.2-SNAPSHOT</databricks-jdbc-version>
+    <databricks-jdbc-version>3.3.2</databricks-jdbc-version>
     <arrow.version>18.3.0</arrow.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration.version>2.10.1</commons-configuration.version>

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,6 +6,31 @@ The release notes summarize enhancements, new features, known issues, workflow c
 
 Version History ==============================================================
 
+3.3.2 ========================================================================
+Released 2026-04-27
+
+Enhancements & New Features
+
+ * Added `CallableStatement` support with IN parameters. `Connection.prepareCall()` now returns a working `DatabricksCallableStatement` that supports positional parameter binding and execution via `{call proc(?)}` JDBC escape syntax. OUT/INOUT parameters and named parameters throw `SQLFeatureNotSupportedException`.
+ * Added AI coding agent detection to the User-Agent header. When the driver is invoked by a known AI coding agent (e.g. Claude Code, Cursor, Gemini CLI), `agent/<product>` is appended to the User-Agent string.
+ * Added support for using SQL SHOW commands for Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`). Enable by setting `UseQueryForMetadata=1`. This aligns Thrift metadata behavior with Statement Execution API (SEA) mode.
+
+Resolved Issues
+
+ * Improved error messages for cancelled statements: operations cancelled via `Statement.cancel()` or closed connections now return SQL state `HY008` (operation cancelled) instead of generic error codes.
+ * Fixed race condition between chunk download error handling and result set close that could cause invalid state transition warnings (`CHUNK_RELEASED -> DOWNLOAD_FAILED`) during Arrow Cloud Fetch operations in resource-constrained environments.
+ * Fixed `EnableBatchedInserts` silently falling back to individual execution when table or schema names contain special characters (e.g., hyphens) inside backtick-quoted identifiers. Added a warn log when the fallback occurs.
+ * Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch.
+ * Fixed `Statement` being prematurely closed after queries that return inline results, which prevented re-execution, `getResultSet()`, and `getExecutionResult()` from working.
+ * Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
+ * Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled.
+ * Fixed Volume ingestion for SEA mode, which was broken due to statement being closed prematurely.
+ * Fixed unclear `error: [null]` messages during transient HTTP failures (e.g. 502 Bad Gateway) in Thrift polling. Error messages now include server error details and use SQL state `08S01` (communication link failure) so callers can identify retryable errors. Also fixed `DatabricksError` (RuntimeException) from SDK client being unhandled in CloudFetch download paths.
+ * Fixed escaped pattern characters in catalogName for `getSchemas`, as returned catalogName should be unescaped.
+ * Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
+ * Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
+ * Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase.
+
 3.3.1 ========================================================================
 Released 2026-03-17
 

--- a/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 public class DriverUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(DriverUtil.class);
-  private static final String DRIVER_VERSION = "3.3.2-SNAPSHOT";
+  private static final String DRIVER_VERSION = "3.3.2";
   private static final String DRIVER_NAME = "oss-jdbc";
   private static final String JDBC_VERSION = "4.3";
 

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
@@ -840,7 +840,7 @@ public class DatabricksDatabaseMetaDataTest {
   @Test
   public void testGetDriverVersion() throws SQLException {
     String result = metaData.getDriverVersion();
-    assertEquals("3.3.2-SNAPSHOT", result);
+    assertEquals("3.3.2", result);
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/common/safe/DatabricksDriverFeatureFlagsContextTest.java
+++ b/src/test/java/com/databricks/jdbc/common/safe/DatabricksDriverFeatureFlagsContextTest.java
@@ -37,7 +37,7 @@ class DatabricksDriverFeatureFlagsContextTest {
   @Mock private ObjectMapper objectMapperMock;
   private static final String FEATURE_FLAG_NAME = "featureFlagName";
   private static final String FEATURE_FLAGS_ENDPOINT =
-      "https://test-host/api/2.0/connector-service/feature-flags/OSS_JDBC/3.3.2-SNAPSHOT";
+      "https://test-host/api/2.0/connector-service/feature-flags/OSS_JDBC/3.3.2";
 
   private DatabricksDriverFeatureFlagsContext context;
 

--- a/src/test/java/com/databricks/jdbc/common/util/DriverUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DriverUtilTest.java
@@ -14,14 +14,14 @@ public class DriverUtilTest {
   public void testGetDriverVersion() {
     String version = DriverUtil.getDriverVersion();
     assertNotNull(version);
-    assertEquals("3.3.2-SNAPSHOT", version);
+    assertEquals("3.3.2", version);
   }
 
   @Test
   public void testGetDriverVersionWithoutOSSSuffix() {
     String version = DriverUtil.getDriverVersionWithoutOSSSuffix();
     assertNotNull(version);
-    assertEquals("3.3.2-SNAPSHOT", version);
+    assertEquals("3.3.2", version);
   }
 
   @Test

--- a/test-assembly-thin/pom.xml
+++ b/test-assembly-thin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>3.3.2</version>
     </parent>
 
     <artifactId>test-databricks-jdbc-thin</artifactId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-thin</artifactId>
-            <version>3.3.2-SNAPSHOT</version>
+            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/test-assembly-uber/pom.xml
+++ b/test-assembly-uber/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-jdbc-parent</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.2</version>
   </parent>
 
   <artifactId>test-databricks-jdbc-uber</artifactId>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-jdbc</artifactId>
-      <version>3.3.2-SNAPSHOT</version>
+      <version>3.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Description
- New version cut: 3.3.2
- Version bumped across all pom.xml files, Java source, tests, README, and release notes
- NEXT_CHANGELOG entries moved to CHANGELOG.md and release-notes.txt

## Testing
- Version string tests updated for 3.3.2 (`DriverUtilTest`, `DatabricksDatabaseMetaDataTest`, `DatabricksDriverFeatureFlagsContextTest` all pass locally — 268 tests)
- CI will validate build and tests

## Additional Notes to the Reviewer
Modeled after PR #1281 (release 3.3.1). Companion freeze PR: #1427.

OVERRIDE_FREEZE=true

This pull request and its description were written by Isaac.