### PR TITLE
Revert UseQueryForMetadata default to 0, make SHOW commands opt-in

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,12 +7,7 @@
 - Added AI coding agent detection to the User-Agent header. When the driver is invoked by a known AI coding agent (e.g. Claude Code, Cursor, Gemini CLI), `agent/<product>` is appended to the User-Agent string.
 
 ### Updated
-- **[Breaking Change]** Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`) on **SQL Warehouses** now use SQL SHOW commands by default instead of native Thrift RPCs, aligning behavior with Statement Execution API (SEA) mode. All-Purpose Clusters are unaffected and continue using native Thrift RPCs. The `UseQueryForMetadata` connection property default changed from `0` to `1`. To revert to native Thrift RPCs, set `UseQueryForMetadata=0`. Key behavioral changes:
-  - Catalog parameter is now treated as a literal identifier (not a wildcard pattern) per JDBC spec. Use `null` to search across all catalogs.
-  - Methods that previously threw exceptions for null/empty edge-case inputs now return empty result sets.
-  - `getFunctions` now works correctly (was broken via native Thrift RPC).
-  - Result columns (TABLE_CATALOG, etc.) return stored values (lowercase) instead of preserving input case.
-- Connection properties `EnableShowCommandForGetFunctions` and `TreatMetadataCatalogNameAsPattern` are now redundant when `UseQueryForMetadata=1` (the new default).
+- Added support for using SQL SHOW commands for Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`). Enable by setting `UseQueryForMetadata=1`. This aligns Thrift metadata behavior with Statement Execution API (SEA) mode.
 
 ### Fixed
 - Fixed `EnableBatchedInserts` silently falling back to individual execution when table or schema names contain special characters (e.g., hyphens) inside backtick-quoted identifiers. Added a warn log when the fallback occurs.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -1133,14 +1133,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   @Override
   public boolean useQueryForMetadata() {
-    // If user explicitly set the property, honour their choice for any compute type
-    String userValue = getParameterIgnoreDefault(DatabricksJdbcUrlParams.USE_QUERY_FOR_METADATA);
-    if (userValue != null) {
-      return userValue.equals("1");
-    }
-    // Default: SHOW commands for SQL Warehouses only.
-    // All-Purpose Clusters default to native Thrift RPCs.
-    return !(computeResource instanceof AllPurposeCluster);
+    return getParameter(DatabricksJdbcUrlParams.USE_QUERY_FOR_METADATA).equals("1");
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -173,7 +173,7 @@ public enum DatabricksJdbcUrlParams {
   USE_QUERY_FOR_METADATA(
       "UseQueryForMetadata",
       "Use SQL SHOW commands instead of Thrift RPCs for metadata operations. When enabled, EnableShowCommandForGetFunctions is redundant",
-      "1"),
+      "0"),
   TREAT_METADATA_CATALOG_NAME_AS_PATTERN(
       "TreatMetadataCatalogNameAsPattern",
       "Treat catalog names as patterns in Thrift metadata RPCs. When disabled (default), wildcard characters in catalog names are escaped",

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -1455,16 +1455,16 @@ class DatabricksConnectionContextTest {
   }
 
   @Test
-  public void testUseQueryForMetadataDefaultTrueForWarehouse() throws DatabricksSQLException {
-    // Warehouse URL without explicit UseQueryForMetadata — should default to true
+  public void testUseQueryForMetadataDefaultFalseForWarehouse() throws DatabricksSQLException {
+    // Warehouse URL without explicit UseQueryForMetadata — default is false (native RPCs)
     IDatabricksConnectionContext ctx =
         DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
-    assertTrue(ctx.useQueryForMetadata());
+    assertFalse(ctx.useQueryForMetadata());
   }
 
   @Test
   public void testUseQueryForMetadataDefaultFalseForCluster() throws DatabricksSQLException {
-    // Cluster URL without explicit UseQueryForMetadata — should default to false
+    // Cluster URL without explicit UseQueryForMetadata — default is false
     IDatabricksConnectionContext ctx =
         DatabricksConnectionContext.parse(TestConstants.VALID_CLUSTER_URL, properties);
     assertFalse(ctx.useQueryForMetadata());

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksSessionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksSessionTest.java
@@ -75,8 +75,8 @@ public class DatabricksSessionTest {
     session.open();
     assertTrue(session.isOpen());
     assertEquals(SESSION_ID, session.getSessionId());
-    // Warehouses use DatabricksMetadataQueryClient (SHOW commands) by default
-    assertInstanceOf(DatabricksMetadataQueryClient.class, session.getDatabricksMetadataClient());
+    // Default UseQueryForMetadata=0: Thrift client used for metadata
+    assertInstanceOf(DatabricksThriftServiceClient.class, session.getDatabricksMetadataClient());
     assertEquals(WAREHOUSE_COMPUTE, session.getComputeResource());
     session.close();
     assertFalse(session.isOpen());
@@ -111,10 +111,8 @@ public class DatabricksSessionTest {
       assertEquals(SESSION_ID, session.getSessionId());
       assertEquals(DatabricksClientType.THRIFT, connectionContext.getClientType());
       assertInstanceOf(DatabricksThriftServiceClient.class, session.getDatabricksClient());
-      // After redirect, the createProxy mock returns thriftClient for all proxy calls.
-      // In production, useQueryForMetadata=1 (warehouse default) would create a
-      // DatabricksMetadataQueryClient. Here the mock collapses it.
-      assertNotNull(session.getDatabricksMetadataClient());
+      // After redirect to Thrift, default UseQueryForMetadata=0 → native Thrift for metadata
+      assertInstanceOf(DatabricksThriftServiceClient.class, session.getDatabricksMetadataClient());
       assertEquals(WAREHOUSE_COMPUTE, session.getComputeResource());
 
       session.close();
@@ -140,8 +138,8 @@ public class DatabricksSessionTest {
     assertTrue(session.isOpen());
     assertEquals(SESSION_ID, session.getSessionId());
     assertEquals(tSessionHandle, session.getSessionInfo().sessionHandle());
-    // Warehouses use DatabricksMetadataQueryClient (SHOW commands) by default
-    assertInstanceOf(DatabricksMetadataQueryClient.class, session.getDatabricksMetadataClient());
+    // Default UseQueryForMetadata=0: Thrift client used for metadata
+    assertEquals(thriftClient, session.getDatabricksMetadataClient());
     assertEquals(WAREHOUSE_COMPUTE, session.getComputeResource());
     session.close();
     assertFalse(session.isOpen());
@@ -320,14 +318,14 @@ public class DatabricksSessionTest {
   }
 
   @Test
-  public void testUseQueryForMetadataEnabledByDefaultForWarehouse() throws SQLException {
+  public void testUseQueryForMetadataDisabledByDefaultForWarehouse() throws SQLException {
     setupWarehouse(true /* useThrift */);
     DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
-    assertTrue(connectionContext.useQueryForMetadata());
+    assertFalse(connectionContext.useQueryForMetadata());
     assertInstanceOf(
-        DatabricksMetadataQueryClient.class,
+        DatabricksThriftServiceClient.class,
         session.getDatabricksMetadataClient(),
-        "Warehouses should use SHOW commands (DatabricksMetadataQueryClient) by default");
+        "Default UseQueryForMetadata=0: warehouse uses native Thrift RPCs for metadata");
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/EnableMultipleCatalogSupportIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/EnableMultipleCatalogSupportIntegrationTests.java
@@ -32,11 +32,7 @@ public class EnableMultipleCatalogSupportIntegrationTests
         DatabricksJdbcUrlParams.USE_THRIFT_CLIENT.getParamName(),
         FakeServiceConfigLoader.shouldUseThriftClient());
 
-    // UseQueryForMetadata=0: Thrift fake service uses binary protocol stubs with
-    // exact session handle matching. SHOW command stubs can't be recorded reliably
-    // because session handles change between recording and replay.
-    String jdbcUrl =
-        getFakeServiceBenchfoodJDBCUrl() + ";enableMultipleCatalogSupport=1;UseQueryForMetadata=0";
+    String jdbcUrl = getFakeServiceBenchfoodJDBCUrl() + ";enableMultipleCatalogSupport=1";
 
     try (Connection connectionWithMultiCatalog = DriverManager.getConnection(jdbcUrl, props)) {
       DatabaseMetaData metaData = connectionWithMultiCatalog.getMetaData();
@@ -78,9 +74,7 @@ public class EnableMultipleCatalogSupportIntegrationTests
         DatabricksJdbcUrlParams.USE_THRIFT_CLIENT.getParamName(),
         FakeServiceConfigLoader.shouldUseThriftClient());
 
-    // UseQueryForMetadata=0: same rationale as the enabled test above
-    String jdbcUrl =
-        getFakeServiceBenchfoodJDBCUrl() + ";enableMultipleCatalogSupport=0;UseQueryForMetadata=0";
+    String jdbcUrl = getFakeServiceBenchfoodJDBCUrl() + ";enableMultipleCatalogSupport=0";
 
     try (Connection connectionWithSingleCatalog = DriverManager.getConnection(jdbcUrl, props)) {
       DatabaseMetaData metaData = connectionWithSingleCatalog.getMetaData();


### PR DESCRIPTION
## Summary
Revert `UseQueryForMetadata` default from `1` back to `0`. SHOW commands for Thrift metadata operations are now opt-in (`UseQueryForMetadata=1`), not the default. This removes the breaking change from the release.

## Changes
- `DatabricksJdbcUrlParams`: default `"1"` → `"0"`
- `DatabricksConnectionContext.useQueryForMetadata()`: simplified to simple param check (removed warehouse/cluster default logic)
- `NEXT_CHANGELOG.md`: replaced breaking change entry with opt-in feature description
- Tests updated for default=0 behavior
- `EnableMultipleCatalogSupportIntegrationTests`: removed `UseQueryForMetadata=0` override (no longer needed)

## Test plan
- [x] DatabricksConnectionContextTest: 110 tests pass
- [x] DatabricksSessionTest: 18 tests pass

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.