### PR TITLE
Enable release freeze for 3.3.2

### DIFF
--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,3 +1,3 @@
 {
-  "freeze": false
+  "freeze": true
 }


### PR DESCRIPTION
## Summary
Set `freeze: true` in `development/.release-freeze.json` to block non-critical merges to `main` while the 3.3.2 release is being cut (#1419).

## Behavior
While the freeze is active, the `check-release-freeze` CI check fails on PRs targeting `main`. PRs that must merge during the window can opt out by adding `OVERRIDE_FREEZE=true` to the PR description.

## Follow-up
This freeze should be lifted (set back to `false`) once the 3.3.2 release is cut.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.