### PR TITLE
Fix main CI: JFrog mirror bypass and Windows pwsh parse error

### DIFF
--- a/.github/workflows/loggingTesting.yml
+++ b/.github/workflows/loggingTesting.yml
@@ -44,6 +44,7 @@ jobs:
           java-version: '21'
 
       - name: Get JFrog OIDC token
+        shell: bash
         run: |
           set -euo pipefail
 
@@ -70,6 +71,7 @@ jobs:
           echo "JFrog OIDC token obtained successfully"
 
       - name: Configure maven
+        shell: bash
         run: |
           set -euo pipefail
 

--- a/.github/workflows/runIntegrationTests.yml
+++ b/.github/workflows/runIntegrationTests.yml
@@ -85,7 +85,11 @@ jobs:
           echo "Maven configured to use JFrog registry"
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: ~/.m2
+          # Cache only the local repository — caching ~/.m2 itself would
+          # restore a stale settings.xml on top of the JFrog-configured one
+          # written above, causing Maven to bypass the mirror and hit Maven
+          # Central directly.
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Create .pem file from secret


### PR DESCRIPTION
## Summary

Two CI workflows on `main` have been failing. This PR fixes the root causes.

### 1. `Integration Tests Workflow - Main Branch` (failing 30+ runs in a row since Apr 8)

- The cache step uses `path: ~/.m2` with a long-lived restore-key `${{ runner.os }}-m2`. It restores a stale cache from before the JFrog OIDC migration, whose `~/.m2/settings.xml` (the github-server one written by `actions/setup-java`) **overwrites** the JFrog mirror config that the preceding "Configure maven" step just wrote.
- Maven then tries to resolve from `repo.maven.apache.org` directly, which the protected runner cannot reach: `Could not transfer artifact ... from/to central (https://repo.maven.apache.org/maven2): Remote host terminated the handshake`.
- **Fix**: narrow `path` to `~/.m2/repository` so `settings.xml` is left alone (matches the pattern used by `warmMavenCache.yml`).

### 2. `Test JDBC Logging` (Windows jobs failing since Apr 27)

- The "Get JFrog OIDC token" step uses bash syntax (`if [ -z "$X" ]`, `set -euo pipefail`) but has no `shell:` directive. On Windows runners the default shell is `pwsh`, which fails parsing the bash `if` with `Missing '(' after 'if'`. The "Configure maven" step has the same problem (bash heredoc).
- **Fix**: pin both steps to `shell: bash`. Linux jobs were unaffected because their default shell is already bash.

## Test plan

- [ ] After merge, confirm `Integration Tests Workflow - Main Branch` passes on the next push to `main`
- [ ] After merge, confirm `Test JDBC Logging` Windows jobs pass on the next push to `main`

NO_CHANGELOG=true
OVERRIDE_FREEZE=true

This pull request and its description were written by Isaac.