### PR TITLE
Fix unresolvable 3.3.2 Maven Central POM for uber jar

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Fixed
 
+- Fix unresolvable Maven Central POM for the uber JAR. The published POM no longer
+  declares a transitive dependency on the internal `databricks-jdbc-core` coordinate
+  (which is not published to Maven Central), restoring resolution for downstream
+  consumers (#1431).
+
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/assembly-uber/pom.xml
+++ b/assembly-uber/pom.xml
@@ -61,6 +61,13 @@
 
     <build>
         <plugins>
+            <!-- flatten-maven-plugin produces .flattened-pom.xml: a self-contained
+                 POM with the parent reference inlined and all <dependencies> stripped.
+                 The shaded uber jar bundles every runtime dep, so the published POM
+                 must declare zero compile deps; otherwise consumers transitively pull
+                 the internal databricks-jdbc-core coordinate (which is not published
+                 to Maven Central) and resolution fails. The release workflow uploads
+                 .flattened-pom.xml as the published POM. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
@@ -69,7 +76,7 @@
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>oss</flattenMode>
                     <pomElements>
-                        <dependencies>expand</dependencies>
+                        <dependencies>remove</dependencies>
                         <build>remove</build>
                     </pomElements>
                 </configuration>


### PR DESCRIPTION
## Summary

- Fixes #1431. The uber jar's published 3.3.2 POM on Maven Central declares a compile dependency on `com.databricks:databricks-jdbc-core:3.3.2`, which is never published. Consumers bumping to 3.3.2 fail to resolve.
- Switch `flatten-maven-plugin` for `assembly-uber` from `<dependencies>expand</dependencies>` to `<dependencies>remove</dependencies>`. The shaded uber jar bundles every runtime class, so the published POM should declare zero compile deps.
- Adds a code comment explaining what `.flattened-pom.xml` is and why the dependencies must be stripped.

## Why `expand` was wrong

`flatten-maven-plugin`'s `expand` rewrites direct + transitive deps into a flat list, but it doesn't strip a direct dependency that points at an unpublished sibling module. `databricks-jdbc-core` is built locally during the release workflow's `mvn install -pl jdbc-core -am` step but is intentionally not deployed to Maven Central. The 3.3.1 release happened to publish a POM with no `<dependencies>` section (via the prior release pipeline); 3.3.2 was the first release through the new `peco-databricks-jdbc.yml` workflow, and that workflow uploads `assembly-uber/.flattened-pom.xml` as the published POM — which still names `databricks-jdbc-core` as a compile dep.

## Test plan

- [x] Reproduced the bug locally by running the release workflow's exact `mvn` invocations on `main` (v3.3.2 source) and confirming `assembly-uber/.flattened-pom.xml` had the broken `databricks-jdbc-core` dep.
- [x] Reproduced the consumer-side failure: `mvn dependency:resolve` of `com.databricks:databricks-jdbc:3.3.2` against a local repo with `jdbc-core` removed fails with the same error reported in #1431.
- [x] Verified the fix: with this patch applied, the rebuilt `.flattened-pom.xml` has no `<dependencies>` and no `<parent>`, byte-equivalent in shape to the published 3.3.1 POM. `mvn dependency:resolve` of `com.databricks:databricks-jdbc:3.3.2` against a local repo missing both `databricks-jdbc-core` and `databricks-jdbc-parent` succeeds.
- [ ] Recovery: a follow-up release (3.3.3) is needed since 3.3.2 cannot be yanked from Maven Central. This patch is the source-side change required for that release.

## Companion change

A workflow-side change is also needed in `databricks-eng/secure-public-registry-releases-eng` so the thin JAR's published POM is sourced from `dependency-reduced-pom.xml` instead of `.flattened-pom.xml`. The thin POM happened to publish correctly for 3.3.1 due to flatten-plugin behaviour but is structurally fragile in the same way — that PR is filed separately.

NO_CHANGELOG=false

OVERRIDE_FREEZE=true

This pull request and its description were written by Isaac.