### PR TITLE
Generalize comparator endpoints — support arbitrary (httpPath, transport) per side

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/COMPARATOR_README.md
+++ b/src/test/java/com/databricks/jdbc/comparator/COMPARATOR_README.md
@@ -1,6 +1,11 @@
 # JDBC Driver Comparator
 
-Compares Thrift vs SEA modes of the Databricks JDBC driver by running identical JDBC API calls through both code paths and reporting differences.
+Compares two SQL endpoints by running identical JDBC API calls through both and reporting differences. The two endpoints (LEFT and RIGHT) can differ along any combination of:
+
+- **Transport**: Thrift (`useThriftClient=1`) vs SEA (`useThriftClient=0`).
+- **Resource**: a SQL warehouse, an interactive cluster, or any explicit JDBC `httpPath`.
+
+The original use case — Thrift vs SEA against a single warehouse — is preserved as the legacy default. See [Comparison axis](#comparison-axis) for the configuration matrix.
 
 ## Quickstart
 
@@ -37,6 +42,30 @@ Sample `metadata-filters.json`:
   }
 }
 ```
+
+## Comparison axis
+
+Each comparator run defines two **endpoints**, LEFT and RIGHT, each specified by:
+
+- `httpPath` — `/sql/1.0/warehouses/<id>` or `/sql/protocolv1/o/<orgId>/<clusterId>` or any value you supply.
+- `transport` — `sea` (default) or `thrift`.
+- `label` — free text used in headers; defaults to `<SIDE>-<TRANSPORT>` uppercased.
+
+Per side, the path resolves via this precedence (first match wins): `<SIDE>_HTTP_PATH` → `<SIDE>_CLUSTER` → `<SIDE>_WAREHOUSE`.
+
+If neither LEFT nor RIGHT is set, the comparator falls back to the legacy mode: same warehouse on both sides, Thrift on the left and SEA on the right (driven by `COMPARATOR_WAREHOUSE`).
+
+Setup DDL (when `WORKSPACE_SETUP=recreate|validate`) always runs against the LEFT side. Make LEFT the side that supports the suite's DDL.
+
+| Use case | Properties |
+|---|---|
+| Legacy (Thrift vs SEA, one warehouse) | `COMPARATOR_WAREHOUSE=<id>` |
+| SEA vs SEA across two warehouses | `LEFT_WAREHOUSE=<dbr> RIGHT_WAREHOUSE=<reyden>` |
+| Thrift vs Thrift across two warehouses | `LEFT_WAREHOUSE=<a> LEFT_TRANSPORT=thrift RIGHT_WAREHOUSE=<b> RIGHT_TRANSPORT=thrift` |
+| Warehouse (SEA) vs cluster (Thrift) | `LEFT_WAREHOUSE=<a> RIGHT_CLUSTER=<orgId>:<clusterId> RIGHT_TRANSPORT=thrift` |
+| Hand-rolled paths | `LEFT_HTTP_PATH=… RIGHT_HTTP_PATH=…` |
+
+Both endpoints share `COMPARATOR_HOST` and the single `DATABRICKS_COMPARATOR_TOKEN`.
 
 ## Running
 
@@ -159,9 +188,14 @@ If both are present for a method, **runOnly takes precedence**: argument combina
 
 | Property | Default | Description |
 |---|---|---|
-| `COMPARATOR_HOST` | `adb-7405613695221181.1.azuredatabricks.net` | Workspace host |
-| `COMPARATOR_WAREHOUSE` | `6feab30b476abfa4` | Warehouse ID |
-| `PRO_WAREHOUSE_ID` | _(disabled)_ | Pro warehouse ID |
+| `COMPARATOR_HOST` | `adb-7405613695221181.1.azuredatabricks.net` | Workspace host (shared by LEFT and RIGHT) |
+| `COMPARATOR_WAREHOUSE` | `6feab30b476abfa4` | Legacy single-warehouse ID; ignored when any `LEFT_*` / `RIGHT_*` is set |
+| `LEFT_WAREHOUSE` / `RIGHT_WAREHOUSE` | _(none)_ | Warehouse ID for that side |
+| `LEFT_CLUSTER` / `RIGHT_CLUSTER` | _(none)_ | Interactive cluster `orgId:clusterId` for that side |
+| `LEFT_HTTP_PATH` / `RIGHT_HTTP_PATH` | _(none)_ | Full JDBC `httpPath` for that side (escape hatch) |
+| `LEFT_TRANSPORT` / `RIGHT_TRANSPORT` | `sea` | `sea` or `thrift` |
+| `LEFT_LABEL` / `RIGHT_LABEL` | `<SIDE>-<TRANSPORT>` | Free-text label used in report header and AssertionError messages |
+| `PRO_WAREHOUSE_ID` | _(disabled)_ | Pro warehouse ID — used by the `PRO_WAREHOUSE` config |
 | `CONNECTION_CONFIG` | _(all)_ | Comma-separated configs to run |
 | `SUITES_RUN_ONLY` | _(all)_ | Comma-separated suites to run |
 | `METADATA_RUN_ONLY_METHODS` | _(all)_ | Comma-separated methods to run |

--- a/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
+++ b/src/test/java/com/databricks/jdbc/comparator/JDBCDriverComparisonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.databricks.jdbc.comparator.config.ConnectionConfig;
 import com.databricks.jdbc.comparator.config.ConnectionManager;
+import com.databricks.jdbc.comparator.config.Endpoint;
 import com.databricks.jdbc.comparator.config.TestSuite;
 import com.databricks.jdbc.comparator.setup.WorkspaceSetup;
 import com.databricks.jdbc.comparator.suite.CombinationResult;
@@ -33,13 +34,43 @@ public class JDBCDriverComparisonTest {
   private static final String DEFAULT_HOST = "adb-7405613695221181.1.azuredatabricks.net";
   private static final String DEFAULT_WAREHOUSE = "6feab30b476abfa4";
 
-  private static final String BASE_JDBC_URL =
+  private static final String BASE_HOST_URL =
       "jdbc:databricks://"
           + System.getProperty("COMPARATOR_HOST", DEFAULT_HOST)
-          + ":443/default;ssl=1;authMech=3;httpPath=/sql/1.0/warehouses/"
-          + System.getProperty("COMPARATOR_WAREHOUSE", DEFAULT_WAREHOUSE);
-  private static final String BASE_THRIFT_URL = BASE_JDBC_URL + ";useThriftClient=1";
-  private static final String BASE_SEA_URL = BASE_JDBC_URL + ";useThriftClient=0";
+          + ":443/default;ssl=1;authMech=3";
+
+  private static final Endpoint LEFT;
+  private static final Endpoint RIGHT;
+
+  static {
+    Endpoint left = Endpoint.fromSystemProperties("LEFT");
+    Endpoint right = Endpoint.fromSystemProperties("RIGHT");
+    if (left == null && right == null) {
+      // Legacy mode: single warehouse, dual transport.
+      String warehouse = System.getProperty("COMPARATOR_WAREHOUSE", DEFAULT_WAREHOUSE);
+      Endpoint[] pair = Endpoint.legacyPair(warehouse);
+      LEFT = pair[0];
+      RIGHT = pair[1];
+    } else if (left == null || right == null) {
+      throw new IllegalStateException(
+          "Both LEFT_* and RIGHT_* must be configured. Set one of "
+              + "LEFT_WAREHOUSE / LEFT_CLUSTER / LEFT_HTTP_PATH and the same for RIGHT, "
+              + "or omit all of them to fall back to legacy single-warehouse Thrift-vs-SEA mode.");
+    } else {
+      LEFT = left;
+      RIGHT = right;
+    }
+  }
+
+  private static final String BASE_LEFT_URL = LEFT.toUrl(BASE_HOST_URL);
+  private static final String BASE_RIGHT_URL = RIGHT.toUrl(BASE_HOST_URL);
+
+  /** Returns the configured endpoint for the named side. Used by suite providers for labeling. */
+  public static Endpoint endpointFor(String side) {
+    if ("LEFT".equalsIgnoreCase(side)) return LEFT;
+    if ("RIGHT".equalsIgnoreCase(side)) return RIGHT;
+    throw new IllegalArgumentException("side must be LEFT or RIGHT, got: " + side);
+  }
 
   private static ConnectionManager connectionManager;
   private static TestReporter reporter;
@@ -49,14 +80,15 @@ public class JDBCDriverComparisonTest {
     String token = System.getenv("DATABRICKS_COMPARATOR_TOKEN");
     connectionManager = new ConnectionManager(token);
 
-    // Workspace validation/setup — only runs when -DWORKSPACE_SETUP=validate|create
-    WorkspaceSetup.run(connectionManager.getConnection(BASE_THRIFT_URL));
+    // Workspace validation/setup — only runs when -DWORKSPACE_SETUP=validate|create.
+    // Setup runs against LEFT by convention; LEFT must be the side that supports the suite DDL.
+    WorkspaceSetup.run(connectionManager.getConnection(BASE_LEFT_URL));
 
     String timestamp = Instant.now().toString().replaceAll("[:.]+", "-");
     List<String> headerLines =
         List.of(
-            "Base Thrift URL: " + BASE_THRIFT_URL,
-            "Base SEA URL: " + BASE_SEA_URL,
+            "LEFT  (" + LEFT.getLabel() + "): " + BASE_LEFT_URL,
+            "RIGHT (" + RIGHT.getLabel() + "): " + BASE_RIGHT_URL,
             "CONNECTION_CONFIG: " + System.getProperty("CONNECTION_CONFIG", "(all)"),
             "SUITES_RUN_ONLY: " + System.getProperty("SUITES_RUN_ONLY", "(all)"),
             "METADATA_RUN_ONLY_METHODS: "
@@ -104,11 +136,11 @@ public class JDBCDriverComparisonTest {
             : new HashSet<>(Arrays.asList(suiteFilter.split(",")));
 
     for (ConnectionConfig config : ConnectionConfig.activeConfigs()) {
-      Connection thriftConn;
-      Connection seaConn;
+      Connection leftConn;
+      Connection rightConn;
       try {
-        thriftConn = connectionManager.getConnection(config.buildUrl(BASE_THRIFT_URL));
-        seaConn = connectionManager.getConnection(config.buildUrl(BASE_SEA_URL));
+        leftConn = connectionManager.getConnection(config.buildUrl(BASE_LEFT_URL));
+        rightConn = connectionManager.getConnection(config.buildUrl(BASE_RIGHT_URL));
       } catch (SQLException e) {
         throw new RuntimeException(
             "Failed to create connections for config: " + config.getDisplayName(), e);
@@ -126,7 +158,7 @@ public class JDBCDriverComparisonTest {
         String label = config.getDisplayName() + " | " + suite.name();
 
         for (TestCase tc : testCases) {
-          allTests.add(Arguments.of(label, thriftConn, seaConn, suite, tc));
+          allTests.add(Arguments.of(label, leftConn, rightConn, suite, tc));
         }
       }
     }

--- a/src/test/java/com/databricks/jdbc/comparator/config/Endpoint.java
+++ b/src/test/java/com/databricks/jdbc/comparator/config/Endpoint.java
@@ -1,0 +1,122 @@
+package com.databricks.jdbc.comparator.config;
+
+/**
+ * One side of a comparator run — an SQL endpoint identified by an httpPath, a transport, and a
+ * human-readable label. Two {@code Endpoint}s (LEFT and RIGHT) define the comparison axis.
+ *
+ * <p>Properties are resolved by {@link #fromSystemProperties} with the prefix {@code LEFT_} or
+ * {@code RIGHT_}. Resolution precedence for the path:
+ *
+ * <ol>
+ *   <li>{@code <SIDE>_HTTP_PATH} — full path, escape hatch.
+ *   <li>{@code <SIDE>_CLUSTER} — {@code orgId:clusterId} → {@code /sql/protocolv1/o/<orgId>/<clusterId>}.
+ *   <li>{@code <SIDE>_WAREHOUSE} — {@code <warehouseId>} → {@code /sql/1.0/warehouses/<warehouseId>}.
+ * </ol>
+ *
+ * <p>If none of the above is set on either side, callers should fall back to the legacy
+ * single-warehouse / dual-transport mode via {@link #legacyPair(String)}.
+ *
+ * <p>Transport ({@code sea} or {@code thrift}) comes from {@code <SIDE>_TRANSPORT} (default {@code
+ * sea}). Label comes from {@code <SIDE>_LABEL} (default {@code <SIDE>-<TRANSPORT>}).
+ */
+public final class Endpoint {
+
+  public static final String SEA = "sea";
+  public static final String THRIFT = "thrift";
+
+  private final String httpPath;
+  private final String transport;
+  private final String label;
+
+  public Endpoint(String httpPath, String transport, String label) {
+    this.httpPath = httpPath;
+    this.transport = normalizeTransport(transport);
+    this.label = label;
+  }
+
+  public String getHttpPath() {
+    return httpPath;
+  }
+
+  public String getTransport() {
+    return transport;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Builds the full JDBC URL by appending {@code httpPath} and {@code useThriftClient} to the base
+   * host URL (which must NOT already contain either of those parameters).
+   */
+  public String toUrl(String baseHostUrl) {
+    return baseHostUrl
+        + ";httpPath="
+        + httpPath
+        + ";useThriftClient="
+        + (THRIFT.equals(transport) ? "1" : "0");
+  }
+
+  /**
+   * Resolves an endpoint from system properties prefixed with {@code <side>_}. Returns {@code null}
+   * if no path-bearing property is set for that side.
+   */
+  public static Endpoint fromSystemProperties(String side) {
+    String prefix = side.toUpperCase() + "_";
+    String httpPath = resolvePath(prefix);
+    if (httpPath == null) return null;
+    String transport = systemPropertyOrDefault(prefix + "TRANSPORT", SEA);
+    String label =
+        systemPropertyOrDefault(
+            prefix + "LABEL", side.toUpperCase() + "-" + transport.toUpperCase());
+    return new Endpoint(httpPath, transport, label);
+  }
+
+  /**
+   * Legacy single-warehouse pair: {@code (warehouse, thrift)} on the left, {@code (warehouse, sea)}
+   * on the right. Used when neither {@code LEFT_*} nor {@code RIGHT_*} is set.
+   */
+  public static Endpoint[] legacyPair(String warehouseId) {
+    String path = "/sql/1.0/warehouses/" + warehouseId;
+    return new Endpoint[] {
+      new Endpoint(path, THRIFT, "Thrift"), new Endpoint(path, SEA, "SEA"),
+    };
+  }
+
+  private static String resolvePath(String prefix) {
+    String httpPath = System.getProperty(prefix + "HTTP_PATH");
+    if (httpPath != null && !httpPath.isEmpty()) return httpPath;
+
+    String cluster = System.getProperty(prefix + "CLUSTER");
+    if (cluster != null && !cluster.isEmpty()) {
+      int colon = cluster.indexOf(':');
+      if (colon <= 0 || colon == cluster.length() - 1) {
+        throw new IllegalArgumentException(
+            prefix + "CLUSTER must be of the form orgId:clusterId, got: " + cluster);
+      }
+      return "/sql/protocolv1/o/" + cluster.substring(0, colon) + "/" + cluster.substring(colon + 1);
+    }
+
+    String warehouse = System.getProperty(prefix + "WAREHOUSE");
+    if (warehouse != null && !warehouse.isEmpty()) {
+      return "/sql/1.0/warehouses/" + warehouse;
+    }
+    return null;
+  }
+
+  private static String systemPropertyOrDefault(String key, String defaultValue) {
+    String v = System.getProperty(key);
+    return (v == null || v.isEmpty()) ? defaultValue : v;
+  }
+
+  private static String normalizeTransport(String transport) {
+    if (transport == null) return SEA;
+    String lower = transport.toLowerCase();
+    if (!SEA.equals(lower) && !THRIFT.equals(lower)) {
+      throw new IllegalArgumentException(
+          "transport must be 'sea' or 'thrift', got: " + transport);
+    }
+    return lower;
+  }
+}

--- a/src/test/java/com/databricks/jdbc/comparator/run-comparator.sh
+++ b/src/test/java/com/databricks/jdbc/comparator/run-comparator.sh
@@ -21,10 +21,44 @@
 
 # Workspace
 COMPARATOR_HOST="adb-7405613695221181.1.azuredatabricks.net"
-COMPARATOR_WAREHOUSE="6feab30b476abfa4"
 DATABRICKS_COMPARATOR_TOKEN="dapi..."  # Replace with your token
 
-# Pro warehouse (leave empty to skip)
+# Comparison axis — choose ONE of:
+#
+# (A) Legacy single-warehouse Thrift-vs-SEA mode
+#     Set COMPARATOR_WAREHOUSE; leave LEFT_*/RIGHT_* empty.
+#
+# (B) Generic two-endpoint mode
+#     Set both LEFT_* and RIGHT_*; COMPARATOR_WAREHOUSE is ignored.
+#     Each side resolves its httpPath via this precedence (first match wins):
+#       <SIDE>_HTTP_PATH > <SIDE>_CLUSTER (orgId:clusterId) > <SIDE>_WAREHOUSE
+#     <SIDE>_TRANSPORT defaults to "sea" (alternative: "thrift").
+#     <SIDE>_LABEL defaults to <SIDE>-<TRANSPORT> uppercased.
+#
+# Example: SEA-vs-SEA across two warehouses
+#   LEFT_WAREHOUSE="33f48d57a0dc69f9"; LEFT_LABEL="DBR-SEA"
+#   RIGHT_WAREHOUSE="000000000000000d"; RIGHT_LABEL="Reyden-SEA"
+#
+# Example: warehouse vs interactive cluster
+#   LEFT_WAREHOUSE="abc123"
+#   RIGHT_CLUSTER="1234567890:0413-104341-eajdv7uv"
+#   RIGHT_TRANSPORT="thrift"
+#
+COMPARATOR_WAREHOUSE="6feab30b476abfa4"  # legacy mode default
+
+LEFT_WAREHOUSE=""
+LEFT_CLUSTER=""
+LEFT_HTTP_PATH=""
+LEFT_TRANSPORT=""
+LEFT_LABEL=""
+
+RIGHT_WAREHOUSE=""
+RIGHT_CLUSTER=""
+RIGHT_HTTP_PATH=""
+RIGHT_TRANSPORT=""
+RIGHT_LABEL=""
+
+# Pro warehouse (leave empty to skip; runs the PRO_WAREHOUSE config against this third warehouse)
 PRO_WAREHOUSE_ID=""
 
 # Connection configs to run (comma-separated, empty = all)
@@ -101,10 +135,17 @@ else
 fi
 FILTER_FILE="${WORK_DIR}/metadata-filters.json"
 
+# Detect generic vs legacy axis and emit a one-line summary of each side.
+ANY_LEFT_RIGHT="${LEFT_WAREHOUSE}${LEFT_CLUSTER}${LEFT_HTTP_PATH}${RIGHT_WAREHOUSE}${RIGHT_CLUSTER}${RIGHT_HTTP_PATH}"
 echo "=== JDBC Driver Comparator ==="
 echo "Timestamp: ${TIMESTAMP}"
 echo "Workspace: ${COMPARATOR_HOST}"
-echo "Warehouse: ${COMPARATOR_WAREHOUSE}"
+if [ -n "${ANY_LEFT_RIGHT}" ]; then
+  echo "LEFT  : ${LEFT_LABEL:-<auto>} | warehouse=${LEFT_WAREHOUSE:--} cluster=${LEFT_CLUSTER:--} httpPath=${LEFT_HTTP_PATH:--} transport=${LEFT_TRANSPORT:-sea}"
+  echo "RIGHT : ${RIGHT_LABEL:-<auto>} | warehouse=${RIGHT_WAREHOUSE:--} cluster=${RIGHT_CLUSTER:--} httpPath=${RIGHT_HTTP_PATH:--} transport=${RIGHT_TRANSPORT:-sea}"
+else
+  echo "Warehouse: ${COMPARATOR_WAREHOUSE} (legacy Thrift-vs-SEA mode)"
+fi
 echo "Config: ${CONNECTION_CONFIG:-all}"
 echo "Output: ${LOG_FILE}, ${REPORT_FILE}"
 echo ""
@@ -139,6 +180,16 @@ fi
 if [ -n "${COMPARATOR_WAREHOUSE}" ]; then
   MVN_ARGS="${MVN_ARGS} -DCOMPARATOR_WAREHOUSE=${COMPARATOR_WAREHOUSE}"
 fi
+
+# Pass through LEFT_*/RIGHT_* generic-axis properties when set.
+for var in LEFT_WAREHOUSE LEFT_CLUSTER LEFT_HTTP_PATH LEFT_TRANSPORT LEFT_LABEL \
+           RIGHT_WAREHOUSE RIGHT_CLUSTER RIGHT_HTTP_PATH RIGHT_TRANSPORT RIGHT_LABEL; do
+  val="${!var}"
+  if [ -n "${val}" ]; then
+    MVN_ARGS="${MVN_ARGS} -D${var}=${val}"
+  fi
+done
+
 if [ -n "${CONNECTION_CONFIG}" ]; then
   MVN_ARGS="${MVN_ARGS} -DCONNECTION_CONFIG=${CONNECTION_CONFIG}"
 fi

--- a/src/test/java/com/databricks/jdbc/comparator/suite/SuiteProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/SuiteProvider.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.comparator.suite;
 
 import com.databricks.jdbc.api.impl.DatabricksResultSetMetaData;
 import com.databricks.jdbc.comparator.ComparisonResult;
+import com.databricks.jdbc.comparator.JDBCDriverComparisonTest;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -38,8 +39,10 @@ public interface SuiteProvider {
     if (expected == null) {
       return;
     }
-    assertCloudFetchOnResultSet(expected, rs1, testCase, "Thrift");
-    assertCloudFetchOnResultSet(expected, rs2, testCase, "SEA");
+    assertCloudFetchOnResultSet(
+        expected, rs1, testCase, JDBCDriverComparisonTest.endpointFor("LEFT").getLabel());
+    assertCloudFetchOnResultSet(
+        expected, rs2, testCase, JDBCDriverComparisonTest.endpointFor("RIGHT").getLabel());
   }
 
   private static void assertCloudFetchOnResultSet(


### PR DESCRIPTION
Replaces the hardcoded "single warehouse, Thrift vs SEA" comparison axis with two independent endpoints (LEFT and RIGHT), each specified by an httpPath, transport, and label. The diff engine and reporter already operate on opaque (conn1, conn2), so the change is surgical.

- New Endpoint class: resolves httpPath via <SIDE>_HTTP_PATH >
  <SIDE>_CLUSTER (orgId:clusterId) > <SIDE>_WAREHOUSE; transport
  defaults to sea; label defaults to <SIDE>-<TRANSPORT>.
- JDBCDriverComparisonTest: BASE_HOST_URL + LEFT.toUrl/RIGHT.toUrl replace BASE_THRIFT_URL/BASE_SEA_URL. Falls back to legacy single-warehouse Thrift-vs-SEA when neither LEFT_* nor RIGHT_* is set. WorkspaceSetup runs against LEFT (was BASE_THRIFT_URL).
- SuiteProvider.assertCloudFetchExpectation: pulls labels from the configured endpoints instead of hardcoded "Thrift"/"SEA".
- run-comparator.sh: new LEFT_*/RIGHT_* config block; banner reflects the configured axis. Legacy COMPARATOR_WAREHOUSE keeps working.
- COMPARATOR_README.md: new "Comparison axis" section with the configuration matrix.

Use cases unlocked:
- SEA-vs-SEA across two warehouses (e.g. baseline vs Reyden).
- Thrift-vs-Thrift across two warehouses.
- Warehouse vs interactive cluster, mixed transports.
- Hand-rolled JDBC httpPaths.

Backwards compatible: existing invocations relying on COMPARATOR_WAREHOUSE produce an identical Thrift-vs-SEA report.

## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->

## Testing
<!-- Describe how the changes have been tested-->

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->

