### PR TITLE
Cut new release 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - Fixed unresolvable Maven Central POM for the uber JAR. The published POM no longer declares a transitive dependency on the internal `databricks-jdbc-core` coordinate (which is not published to Maven Central), restoring resolution for downstream consumers (#1431).
 
-## [v3.3.2] - 2026-04-27
+## [v3.3.2] - 2026-04-27: DEPRECATED, Use v3.3.3 instead
 
 ### Added
 - Added `CallableStatement` support with IN parameters. `Connection.prepareCall()` now returns a working `DatabricksCallableStatement` that supports positional parameter binding and execution via `{call proc(?)}` JDBC escape syntax. OUT/INOUT parameters and named parameters throw `SQLFeatureNotSupportedException`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version Changelog
 
+## [v3.3.3] - 2026-04-29
+
+### Fixed
+- Fixed unresolvable Maven Central POM for the uber JAR. The published POM no longer declares a transitive dependency on the internal `databricks-jdbc-core` coordinate (which is not published to Maven Central), restoring resolution for downstream consumers (#1431).
+
 ## [v3.3.2] - 2026-04-27
 
 ### Added

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,11 +8,6 @@
 
 ### Fixed
 
-- Fix unresolvable Maven Central POM for the uber JAR. The published POM no longer
-  declares a transitive dependency on the internal `databricks-jdbc-core` coordinate
-  (which is not published to Maven Central), restoring resolution for downstream
-  consumers (#1431).
-
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
   <groupId>com.databricks</groupId>
   <artifactId>databricks-jdbc</artifactId>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
 </dependency>
 ```
 

--- a/assembly-thin/pom.xml
+++ b/assembly-thin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
     </parent>
 
     <artifactId>databricks-jdbc-thin</artifactId>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-core</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.3</version>
         </dependency>
     </dependencies>
 

--- a/assembly-uber/pom.xml
+++ b/assembly-uber/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
     </parent>
 
     <artifactId>databricks-jdbc</artifactId>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-core</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.3</version>
         </dependency>
     </dependencies>
 

--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,3 +1,3 @@
 {
-  "freeze": true
+  "freeze": false
 }

--- a/jdbc-core/pom.xml
+++ b/jdbc-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-jdbc-parent</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
   </parent>
 
   <artifactId>databricks-jdbc-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.databricks</groupId>
   <artifactId>databricks-jdbc-parent</artifactId>
   <!-- This value may be modified by a release script to reflect the current version of the driver. -->
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <packaging>pom</packaging>
   <name>Databricks JDBC Parent</name>
   <description>Parent POM for Databricks JDBC Driver.</description>
@@ -63,7 +63,7 @@
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 
     <!-- Dependency Versions -->
-    <databricks-jdbc-version>3.3.2</databricks-jdbc-version>
+    <databricks-jdbc-version>3.3.3</databricks-jdbc-version>
     <arrow.version>18.3.0</arrow.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration.version>2.10.1</commons-configuration.version>

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
@@ -28,7 +28,7 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public static final String PRODUCT_NAME = "SparkSQL";
   public static final int DATABASE_MAJOR_VERSION = 3;
   public static final int DATABASE_MINOR_VERSION = 3;
-  public static final int DATABASE_PATCH_VERSION = 2;
+  public static final int DATABASE_PATCH_VERSION = 3;
   public static final Integer MAX_NAME_LENGTH = 128;
   public static final String NUMERIC_FUNCTIONS =
       "ABS,ACOS,ASIN,ATAN,ATAN2,CEILING,COS,COT,DEGREES,EXP,FLOOR,LOG,LOG10,MOD,PI,POWER,RADIANS,RAND,ROUND,SIGN,SIN,SQRT,TAN,TRUNCATE";

--- a/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DriverUtil.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 public class DriverUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(DriverUtil.class);
-  private static final String DRIVER_VERSION = "3.3.2";
+  private static final String DRIVER_VERSION = "3.3.3";
   private static final String DRIVER_NAME = "oss-jdbc";
   private static final String JDBC_VERSION = "4.3";
 

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
@@ -828,7 +828,7 @@ public class DatabricksDatabaseMetaDataTest {
   @Test
   public void testGetDatabaseProductVersion() throws SQLException {
     String result = metaData.getDatabaseProductVersion();
-    assertEquals("3.3.2", result);
+    assertEquals("3.3.3", result);
   }
 
   @Test
@@ -840,7 +840,7 @@ public class DatabricksDatabaseMetaDataTest {
   @Test
   public void testGetDriverVersion() throws SQLException {
     String result = metaData.getDriverVersion();
-    assertEquals("3.3.2", result);
+    assertEquals("3.3.3", result);
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/common/safe/DatabricksDriverFeatureFlagsContextTest.java
+++ b/src/test/java/com/databricks/jdbc/common/safe/DatabricksDriverFeatureFlagsContextTest.java
@@ -37,7 +37,7 @@ class DatabricksDriverFeatureFlagsContextTest {
   @Mock private ObjectMapper objectMapperMock;
   private static final String FEATURE_FLAG_NAME = "featureFlagName";
   private static final String FEATURE_FLAGS_ENDPOINT =
-      "https://test-host/api/2.0/connector-service/feature-flags/OSS_JDBC/3.3.2";
+      "https://test-host/api/2.0/connector-service/feature-flags/OSS_JDBC/3.3.3";
 
   private DatabricksDriverFeatureFlagsContext context;
 

--- a/src/test/java/com/databricks/jdbc/common/util/DriverUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DriverUtilTest.java
@@ -14,14 +14,14 @@ public class DriverUtilTest {
   public void testGetDriverVersion() {
     String version = DriverUtil.getDriverVersion();
     assertNotNull(version);
-    assertEquals("3.3.2", version);
+    assertEquals("3.3.3", version);
   }
 
   @Test
   public void testGetDriverVersionWithoutOSSSuffix() {
     String version = DriverUtil.getDriverVersionWithoutOSSSuffix();
     assertNotNull(version);
-    assertEquals("3.3.2", version);
+    assertEquals("3.3.3", version);
   }
 
   @Test

--- a/test-assembly-thin/pom.xml
+++ b/test-assembly-thin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.databricks</groupId>
         <artifactId>databricks-jdbc-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
     </parent>
 
     <artifactId>test-databricks-jdbc-thin</artifactId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>databricks-jdbc-thin</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/test-assembly-uber/pom.xml
+++ b/test-assembly-uber/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.databricks</groupId>
     <artifactId>databricks-jdbc-parent</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
   </parent>
 
   <artifactId>test-databricks-jdbc-uber</artifactId>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>databricks-jdbc</artifactId>
-      <version>3.3.2</version>
+      <version>3.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

Recovers from the broken 3.3.2 Maven Central release (#1431) by cutting 3.3.3 with the source-side fix from #1432.

3.3.2 published a POM that declared an unresolvable transitive dependency on `com.databricks:databricks-jdbc-core:3.3.2` (an internal coordinate that is not published to Maven Central). Downstream consumers bumping to 3.3.2 saw `Could not find artifact com.databricks:databricks-jdbc-core:jar:3.3.2`. Yanking from Maven Central is not possible, so 3.3.3 is the recovery release.

## Changes

- Version bump 3.3.2 → 3.3.3 across all POMs, the `DRIVER_VERSION` constant in `DriverUtil`, and assertion strings in `DriverUtilTest`, `DatabricksDatabaseMetaDataTest`, `DatabricksDriverFeatureFlagsContextTest`.
- Move `NEXT_CHANGELOG.md` entries into `CHANGELOG.md` under `[v3.3.3]`. Reset `NEXT_CHANGELOG.md` to empty template.
- Flip `development/.release-freeze.json` from `freeze: true` → `freeze: false`.
- Update install snippet in `README.md`.

## Validation

The post-#1432 release artifacts have been pre-validated end-to-end via a staging dry-run:

1. **Tagged `v3.3.3-rc1`** off the same commit pool as this release.
2. **Ran the `peco-databricks-jdbc` workflow with `staging-only=true`** (USER_MANAGED upload to Sonatype Central Portal).
3. **Sonatype validated the bundle on attempt 2** — full validators (signatures, checksums, POM completeness, namespace ownership, file naming) all green.
4. **Inspected the staged POMs:**
   - Uber POM: 0 dependencies, no `<parent>`, all required Maven Central metadata present. Byte-shape-equivalent to the working 3.3.1 POM.
   - Thin POM: 57 runtime deps, no `databricks-jdbc-core`, no `databricks-jdbc-parent` references. Same shape as published 3.3.1 thin.
5. **Staged the bundle into a local file repo** and verified `mvn dependency:resolve` of `com.databricks:databricks-jdbc:3.3.3-rc1` succeeds — exactly the resolution that fails for 3.3.2.
6. **Built a probe project that imports the staged uber jar**, loaded the driver via JDK ServiceLoader, opened a real connection to the dogfood workspace, and round-tripped a `SELECT` query. Output:
   ```
   Driver class: com.databricks.client.jdbc.Driver
   Driver version: 3.3
   DriverVersion: 3.3.3-rc1
   Row: one=1 msg=hello
   PROBE_OK
   ```
7. **Dropped the rc1 deployment** in the Central Portal (deployment ID `a83f922f-9750-4a14-b697-a6005a6fc858`) — never reached `repo1.maven.org`.

## After merge

1. Tag `v3.3.3` on this commit.
2. Run `peco-databricks-jdbc` workflow off `main` of `databricks/secure-public-registry-releases-eng` with `ref=v3.3.3`, `dry-run=false`, `staging-only=false`.
3. Confirm 3.3.3 lands on Maven Central and resolves cleanly.

## Test plan

- [x] All version strings bumped in lockstep (verified by `git grep "3\.3\.2"` returning only CHANGELOG hits).
- [x] Local build of jdbc-core + assembly-uber succeeds with the bumped version.
- [x] `assembly-uber/.flattened-pom.xml` confirmed to have 0 `<dependencies>` after build.
- [x] End-to-end rc1 validation as described above.
- [ ] Post-merge: live publish run on Maven Central.

This pull request and its description were written by Isaac.