### PR TITLE
[SEA] Fix CloudFetch path to wrap ARRAY and MAP columns as JSON strings (PECO-3016)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
 - Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
 - Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase. The client-side filter used case-sensitive comparison against server-returned lowercase names.
+- Fixed CloudFetch path not wrapping ARRAY and MAP columns as JSON strings. When the SEA manifest reports ARRAY/MAP/STRUCT columns with a STRING wire type, the driver now consults the Arrow schema metadata embedded in the IPC file to detect and correctly handle complex types.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResult.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResult.java
@@ -9,6 +9,7 @@ import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
 import com.databricks.jdbc.common.CompressionCodec;
+import com.databricks.jdbc.common.util.DatabricksTypeUtil;
 import com.databricks.jdbc.dbclient.IDatabricksHttpClient;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.dbclient.impl.http.DatabricksHttpClientFactory;
@@ -377,8 +378,30 @@ public class ArrowStreamResult implements IExecutionResult {
       return result;
     }
 
-    if (!isComplexDatatypeSupportEnabled && isComplexType(requiredType)) {
-      LOGGER.debug("Complex datatype support is disabled, converting complex type to STRING");
+    // On the CloudFetch path the Arrow schema embedded in the IPC file is the authoritative source
+    // of type information. When the manifest's column type (requiredType) does not reflect the
+    // true complex type (e.g. the SEA manifest uses STRING as the wire type for ARRAY/MAP/STRUCT),
+    // fall back to the Arrow metadata string to detect complex types and derive the correct type.
+    ColumnInfoTypeName effectiveType = requiredType;
+    if (effectiveType != ColumnInfoTypeName.ARRAY
+        && effectiveType != ColumnInfoTypeName.MAP
+        && effectiveType != ColumnInfoTypeName.STRUCT
+        && arrowMetadata != null
+        && DatabricksTypeUtil.isComplexType(arrowMetadata)) {
+      if (arrowMetadata.startsWith("ARRAY")) {
+        effectiveType = ColumnInfoTypeName.ARRAY;
+      } else if (arrowMetadata.startsWith("MAP")) {
+        effectiveType = ColumnInfoTypeName.MAP;
+      } else if (arrowMetadata.startsWith("STRUCT")) {
+        effectiveType = ColumnInfoTypeName.STRUCT;
+      }
+      // GEOMETRY and GEOGRAPHY are already handled by the geospatial branch above
+    }
+
+    if (!isComplexDatatypeSupportEnabled && isComplexType(effectiveType)) {
+      LOGGER.debug(
+          "Complex datatype support is disabled, converting complex type {} to STRING",
+          effectiveType);
       Object result =
           chunkIterator.getColumnObjectAtCurrentRow(
               columnIndex, ColumnInfoTypeName.STRING, "STRING", columnInfo);
@@ -387,11 +410,12 @@ public class ArrowStreamResult implements IExecutionResult {
       }
       ComplexDataTypeParser parser = new ComplexDataTypeParser();
 
-      return parser.formatComplexTypeString(result.toString(), requiredType.name(), arrowMetadata);
+      return parser.formatComplexTypeString(
+          result.toString(), effectiveType.name(), arrowMetadata);
     }
 
     return chunkIterator.getColumnObjectAtCurrentRow(
-        columnIndex, requiredType, arrowMetadata, columnInfo);
+        columnIndex, effectiveType, arrowMetadata, columnInfo);
   }
 
   /**

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResultTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/ArrowStreamResultTest.java
@@ -4,9 +4,12 @@ import static com.databricks.jdbc.TestConstants.*;
 import static java.lang.Math.min;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.databricks.jdbc.api.impl.DatabricksArray;
 import com.databricks.jdbc.api.impl.DatabricksConnectionContextFactory;
+import com.databricks.jdbc.api.impl.DatabricksMap;
 import com.databricks.jdbc.api.impl.DatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
@@ -658,5 +661,153 @@ public class ArrowStreamResultTest {
     assertNotNull(result);
     assertFalse(result.hasNext(), "Empty result should have no data");
     assertDoesNotThrow(result::close);
+  }
+
+  // ==================== CloudFetch Complex Type Wrapping Tests (PECO-3016) ====================
+
+  /**
+   * PECO-3016: When the SEA manifest reports a column as STRING (the wire type used for
+   * ARRAY/MAP/STRUCT in CloudFetch) but the Arrow schema metadata identifies it as ARRAY, and
+   * complex datatype support is disabled, getObjectWithComplexTypeHandling must still wrap the value
+   * as a JSON string rather than trying to parse it into a DatabricksArray.
+   */
+  @Test
+  public void testGetObjectWithComplexTypeHandling_arrowMetadataArray_complexTypeSupportDisabled()
+      throws Exception {
+    // Complex datatype support disabled (default)
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContextFactory.create(JDBC_URL, new Properties());
+    IDatabricksSession localSession = mock(IDatabricksSession.class);
+    when(localSession.getConnectionContext()).thenReturn(connectionContext);
+
+    // Column type from SEA manifest is STRING (wire type), but Arrow metadata says ARRAY<INT>
+    ColumnInfo columnInfo =
+        new ColumnInfo()
+            .setName("array_col")
+            .setTypeName(ColumnInfoTypeName.STRING)
+            .setTypeText("ARRAY<INT>");
+    String arrowMetadata = "ARRAY<INT>";
+
+    ArrowResultChunkIterator mockIterator = mock(ArrowResultChunkIterator.class);
+    // Arrow file stores the value as a JSON string
+    when(mockIterator.getColumnObjectAtCurrentRow(
+            eq(0), eq(ColumnInfoTypeName.STRING), eq("STRING"), eq(columnInfo)))
+        .thenReturn("[1,2,3]");
+
+    Object result =
+        ArrowStreamResult.getObjectWithComplexTypeHandling(
+            localSession, mockIterator, 0, ColumnInfoTypeName.STRING, arrowMetadata, columnInfo);
+
+    // Should return a JSON string, not a DatabricksArray
+    assertInstanceOf(String.class, result);
+    assertEquals("[1,2,3]", result);
+  }
+
+  /**
+   * PECO-3016: When the SEA manifest reports a column as STRING (the wire type used for ARRAY in
+   * CloudFetch) but the Arrow schema metadata identifies it as ARRAY, and complex datatype support
+   * is enabled, getObjectWithComplexTypeHandling must parse the JSON string into a DatabricksArray.
+   */
+  @Test
+  public void testGetObjectWithComplexTypeHandling_arrowMetadataArray_complexTypeSupportEnabled()
+      throws Exception {
+    Properties props = new Properties();
+    props.setProperty("EnableComplexDatatypeSupport", "1");
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContextFactory.create(JDBC_URL, props);
+    IDatabricksSession localSession = mock(IDatabricksSession.class);
+    when(localSession.getConnectionContext()).thenReturn(connectionContext);
+
+    // Column type from SEA manifest is STRING (wire type), but Arrow metadata says ARRAY<STRING>
+    ColumnInfo columnInfo =
+        new ColumnInfo()
+            .setName("array_col")
+            .setTypeName(ColumnInfoTypeName.STRING)
+            .setTypeText("ARRAY<STRING>");
+    String arrowMetadata = "ARRAY<STRING>";
+
+    ArrowResultChunkIterator mockIterator = mock(ArrowResultChunkIterator.class);
+    // When complex type support is enabled, the converter should get the raw value as ARRAY
+    when(mockIterator.getColumnObjectAtCurrentRow(
+            eq(0), eq(ColumnInfoTypeName.ARRAY), eq(arrowMetadata), eq(columnInfo)))
+        .thenReturn(new DatabricksArray(java.util.Arrays.asList("a", "b")));
+
+    Object result =
+        ArrowStreamResult.getObjectWithComplexTypeHandling(
+            localSession, mockIterator, 0, ColumnInfoTypeName.STRING, arrowMetadata, columnInfo);
+
+    // Should return a DatabricksArray when complex type support is enabled
+    assertInstanceOf(DatabricksArray.class, result);
+  }
+
+  /**
+   * PECO-3016: When the SEA manifest reports a column as STRING (the wire type used for MAP in
+   * CloudFetch) but the Arrow schema metadata identifies it as MAP, and complex datatype support is
+   * disabled, getObjectWithComplexTypeHandling must wrap the value as a JSON string.
+   */
+  @Test
+  public void testGetObjectWithComplexTypeHandling_arrowMetadataMap_complexTypeSupportDisabled()
+      throws Exception {
+    // Complex datatype support disabled (default)
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContextFactory.create(JDBC_URL, new Properties());
+    IDatabricksSession localSession = mock(IDatabricksSession.class);
+    when(localSession.getConnectionContext()).thenReturn(connectionContext);
+
+    // Column type from SEA manifest is STRING (wire type), but Arrow metadata says MAP<STRING,INT>
+    ColumnInfo columnInfo =
+        new ColumnInfo()
+            .setName("map_col")
+            .setTypeName(ColumnInfoTypeName.STRING)
+            .setTypeText("MAP<STRING,INT>");
+    String arrowMetadata = "MAP<STRING,INT>";
+    // Arrow MAP format: list of {key, value} entries
+    String mapJson = "[{\"key\":\"a\",\"value\":1}]";
+
+    ArrowResultChunkIterator mockIterator = mock(ArrowResultChunkIterator.class);
+    when(mockIterator.getColumnObjectAtCurrentRow(
+            eq(0), eq(ColumnInfoTypeName.STRING), eq("STRING"), eq(columnInfo)))
+        .thenReturn(mapJson);
+
+    Object result =
+        ArrowStreamResult.getObjectWithComplexTypeHandling(
+            localSession, mockIterator, 0, ColumnInfoTypeName.STRING, arrowMetadata, columnInfo);
+
+    // Should return a formatted string representation, not a DatabricksMap
+    assertInstanceOf(String.class, result);
+  }
+
+  /**
+   * PECO-3016: Verifies that when requiredType is already ARRAY (column correctly identified from
+   * SEA manifest), the existing code path is unchanged and still works correctly.
+   */
+  @Test
+  public void testGetObjectWithComplexTypeHandling_requiredTypeArray_complexTypeSupportDisabled()
+      throws Exception {
+    // Complex datatype support disabled (default)
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContextFactory.create(JDBC_URL, new Properties());
+    IDatabricksSession localSession = mock(IDatabricksSession.class);
+    when(localSession.getConnectionContext()).thenReturn(connectionContext);
+
+    ColumnInfo columnInfo =
+        new ColumnInfo()
+            .setName("array_col")
+            .setTypeName(ColumnInfoTypeName.ARRAY)
+            .setTypeText("ARRAY<INT>");
+    String arrowMetadata = "ARRAY<INT>";
+
+    ArrowResultChunkIterator mockIterator = mock(ArrowResultChunkIterator.class);
+    when(mockIterator.getColumnObjectAtCurrentRow(
+            eq(0), eq(ColumnInfoTypeName.STRING), eq("STRING"), eq(columnInfo)))
+        .thenReturn("[10,20,30]");
+
+    Object result =
+        ArrowStreamResult.getObjectWithComplexTypeHandling(
+            localSession, mockIterator, 0, ColumnInfoTypeName.ARRAY, arrowMetadata, columnInfo);
+
+    // Should return JSON string when complex type support is disabled
+    assertInstanceOf(String.class, result);
+    assertEquals("[10,20,30]", result);
   }
 }


### PR DESCRIPTION
## Problem

On the CloudFetch path (SEA mode), ARRAY and MAP columns were not being wrapped as JSON strings and not being returned as `DatabricksArray`/`DatabricksMap` objects.

## Root Cause

The `getObjectWithComplexTypeHandling()` method in `ArrowStreamResult` determines how to handle a column by inspecting `requiredType` (sourced from the column metadata in the SEA manifest). On the CloudFetch path, the SEA manifest reports ARRAY/MAP/STRUCT columns with a `STRING` wire type — because CloudFetch transmits these as Arrow UTF-8 strings in the IPC file. As a result, `isComplexType(requiredType)` returns `false` and the complex-type handling branch is never entered.

However, the Arrow IPC file embedded in each CloudFetch chunk carries richer metadata: the `"Spark:DataType:SqlName"` field metadata key (`ARROW_METADATA_KEY`) is set to the true SQL type, e.g. `"ARRAY<INT>"` or `"MAP<STRING,INT>"`. This `arrowMetadata` string was already being extracted and passed into the method, but was only used *after* the complex-type check — too late.

## Fix

Before the complex-type branch, derive an `effectiveType` from `arrowMetadata` using `DatabricksTypeUtil.isComplexType(String)`. When `requiredType` is not already a complex type but `arrowMetadata` identifies the column as `ARRAY`/`MAP`/`STRUCT`, override `effectiveType` accordingly. All subsequent branching uses `effectiveType` instead of `requiredType`, so both:
- the JSON-string path (`EnableComplexDatatypeSupport=false`) and
- the `DatabricksArray`/`DatabricksMap` path (`EnableComplexDatatypeSupport=true`)

work correctly for CloudFetch ARRAY/MAP/STRUCT columns.

## Changes

- **`ArrowStreamResult.java`**: Added `effectiveType` derivation logic in `getObjectWithComplexTypeHandling()`; replaced all uses of `requiredType` with `effectiveType` in the complex-type handling branches. Added import for `DatabricksTypeUtil`.
- **`ArrowStreamResultTest.java`**: Added 4 unit tests covering:
  - ARRAY column (`arrowMetadata="ARRAY<INT>"`), complex support **disabled** → returns JSON String
  - ARRAY column (`arrowMetadata="ARRAY<STRING>"`), complex support **enabled** → returns `DatabricksArray`
  - MAP column (`arrowMetadata="MAP<STRING,INT>"`), complex support **disabled** → returns JSON String
  - ARRAY column via `requiredType=ARRAY` (existing path), complex support **disabled** → returns JSON String
- **`NEXT_CHANGELOG.md`**: Added entry under `### Fixed`.

## Test Plan

- [ ] New unit tests in `ArrowStreamResultTest` pass
- [ ] Existing `ArrowStreamResultTest` tests pass
- [ ] Manual verification: connect to a Databricks workspace via SEA with CloudFetch enabled, query a table with ARRAY/MAP columns, and verify they are returned as JSON strings (complex support disabled) or `DatabricksArray`/`DatabricksMap` (complex support enabled)

Fixes: PECO-3016