### PR TITLE
Update release-notes.txt for 3.3.3 and mark 3.3.2 as DEPRECATED

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,7 +6,35 @@ The release notes summarize enhancements, new features, known issues, workflow c
 
 Version History ==============================================================
 
+3.3.3 ========================================================================
+Released 2026-04-29
+
+Enhancements & New Features
+
+ * Added `CallableStatement` support with IN parameters. `Connection.prepareCall()` now returns a working `DatabricksCallableStatement` that supports positional parameter binding and execution via `{call proc(?)}` JDBC escape syntax. OUT/INOUT parameters and named parameters throw `SQLFeatureNotSupportedException`.
+ * Added AI coding agent detection to the User-Agent header. When the driver is invoked by a known AI coding agent (e.g. Claude Code, Cursor, Gemini CLI), `agent/<product>` is appended to the User-Agent string.
+ * Added support for using SQL SHOW commands for Thrift-mode metadata operations (`getTables`, `getColumns`, `getSchemas`, `getFunctions`, `getPrimaryKeys`, `getImportedKeys`, `getCrossReference`). Enable by setting `UseQueryForMetadata=1`. This aligns Thrift metadata behavior with Statement Execution API (SEA) mode.
+
+Resolved Issues
+
+ * Fixed unresolvable Maven Central POM for the uber JAR. The published POM no longer declares a transitive dependency on the internal `databricks-jdbc-core` coordinate (which is not published to Maven Central), restoring resolution for downstream consumers.
+ * Improved error messages for cancelled statements: operations cancelled via `Statement.cancel()` or closed connections now return SQL state `HY008` (operation cancelled) instead of generic error codes.
+ * Fixed race condition between chunk download error handling and result set close that could cause invalid state transition warnings (`CHUNK_RELEASED -> DOWNLOAD_FAILED`) during Arrow Cloud Fetch operations in resource-constrained environments.
+ * Fixed `EnableBatchedInserts` silently falling back to individual execution when table or schema names contain special characters (e.g., hyphens) inside backtick-quoted identifiers. Added a warn log when the fallback occurs.
+ * Fixed `IntervalConverter` crash (`IllegalArgumentException: Invalid interval metadata`) when INTERVAL columns are returned via CloudFetch.
+ * Fixed `Statement` being prematurely closed after queries that return inline results, which prevented re-execution, `getResultSet()`, and `getExecutionResult()` from working.
+ * Fixed primitive types within complex types (ARRAY, MAP, STRUCT) not being correctly parsed when Arrow serialization uses alternate formats: TIMESTAMP/TIMESTAMP_NTZ as epoch microseconds or component arrays, and BINARY as base64-encoded strings.
+ * Fixed `PARSE_SYNTAX_ERROR` for column names containing special characters (e.g., dots) when `EnableBatchedInserts` is enabled.
+ * Fixed Volume ingestion for SEA mode, which was broken due to statement being closed prematurely.
+ * Fixed unclear `error: [null]` messages during transient HTTP failures (e.g. 502 Bad Gateway) in Thrift polling. Error messages now include server error details and use SQL state `08S01` (communication link failure) so callers can identify retryable errors. Also fixed `DatabricksError` (RuntimeException) from SDK client being unhandled in CloudFetch download paths.
+ * Fixed escaped pattern characters in catalogName for `getSchemas`, as returned catalogName should be unescaped.
+ * Fixed `getColumnClassName()` returning null for VARIANT columns in SEA mode by adding VARIANT to the type system.
+ * Fixed `getColumns()` returning `DATA_TYPE=0` (NULL) for GEOMETRY/GEOGRAPHY columns in Thrift mode. Now returns `Types.VARCHAR` (12) when geospatial is disabled and `Types.OTHER` (1111) when enabled, consistent with SEA mode.
+ * Fixed `getCrossReference()` returning 0 rows when parent args are passed in uppercase.
+
 3.3.2 ========================================================================
+DEPRECATED, Use v3.3.3 instead
+
 Released 2026-04-27
 
 Enhancements & New Features


### PR DESCRIPTION
## Summary

`release-notes.txt` was not updated when 3.3.3 was cut. This PR backfills the entry.

- Adds a `3.3.3` section (Released 2026-04-29) describing the POM fix plus the changes carried over from 3.3.2.
- Marks `3.3.2` as `DEPRECATED, Use v3.3.3 instead`, mirroring the format already used for `3.0.1` in the same file.

### Why

3.3.3 was cut to fix an unresolvable Maven Central POM for the uber JAR (#1431) — 3.3.2's published POM declared a transitive dependency on the internal `databricks-jdbc-core` coordinate, which is not published to Maven Central, breaking resolution for downstream consumers. Without this update, customers reading `release-notes.txt` see 3.3.2 as the latest entry with no indication that they should use 3.3.3 instead.

NO_CHANGELOG=true

## Test plan

- [x] `release-notes.txt` rendering reviewed — section follows the existing 3.0.1 deprecation format.
- [x] No source/build changes; docs-only.

This pull request and its description were written by Isaac.