### PR TITLE
Enable native geospatial type support by default

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Added
 
 ### Updated
+- Enabled native geospatial type support (`GEOMETRY` and `GEOGRAPHY`) by default. `getObject()` now returns `IGeometry`/`IGeography` instances instead of EWKT strings. Set `EnableGeoSpatialSupport=0` to restore the previous behavior.
 - `EnableGeoSpatialSupport` no longer requires `EnableComplexDatatypeSupport=1`. Geospatial types (GEOMETRY, GEOGRAPHY) can now be enabled independently of complex type support (ARRAY, MAP, STRUCT).
 - Arrow schema deserialization failures (Thrift metadata path) now surface a dedicated driver error code `ARROW_SCHEMA_PARSING_ERROR` (vendor code `22000`) and a proper SQLSTATE `22000` (Data Exception) on the thrown `SQLException`, instead of the generic `RESULT_SET_ERROR` (1004) and the enum name as SQLSTATE. The exception message is unchanged.
 

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -131,7 +131,7 @@ public enum DatabricksJdbcUrlParams {
   ENABLE_GEOSPATIAL_SUPPORT(
       "EnableGeoSpatialSupport",
       "flag to enable native support of GEOMETRY and GEOGRAPHY data types",
-      "0"),
+      "1"),
   ROWS_FETCHED_PER_BLOCK(
       "RowsFetchedPerBlock",
       "The maximum number of rows that a query returns at a time.",


### PR DESCRIPTION
## Summary
- Changes `EnableGeoSpatialSupport` default from `0` to `1` so `getObject()` returns `IGeometry`/`IGeography` instances instead of raw EWKT strings out of the box.
- Users can set `EnableGeoSpatialSupport=0` to restore the previous behavior.

## Test plan
- [ ] Run `GeospatialTests` E2E suite (all 48 configurations) — verified locally, all pass
- [ ] Verified default behavior across all 6 protocol/serialization/CloudFetch combinations: geospatial objects returned in all modes except Thrift+Inline (expected)
- [ ] Existing tests unaffected since they explicitly set the flag

This pull request and its description were written by Isaac.