### PR TITLE
Fix getTables(types=[]) returning rows in Thrift mode

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -20,6 +20,7 @@
 - When a Statement is re-executed, the previous server-side operation is now explicitly closed before starting the new execution, preventing orphaned server-side operations when Statements are reused.
 
 ### Fixed
+- Fixed `DatabaseMetaData.getTables()` in Thrift mode returning rows when called with an empty `types` array. Per JDBC spec, empty types means "no types selected" and now correctly returns zero rows (matching SEA mode).
 - Fixed `?` characters inside SQL comments, string literals, and quoted identifiers being incorrectly counted as parameter placeholders when `supportManyParameters=1`. `SQLInterpolator` now uses `SqlCommentParser` to locate only real placeholders. Fixes #1331.
 - Fixed `MetadataOperationTimeout` not being applied when metadata operations use SHOW commands. Operations like `getTables`, `getSchemas`, and `getColumns` now respect the `MetadataOperationTimeout` connection property instead of hanging indefinitely with no timeout.
 - Reclassify transient server errors to standard SQL states (08S01, 40001) across all Thrift error sites. This ensures UC unavailability and concurrent modification errors surface consistently for better retry handling. Note: Dashboards and branching logic keyed on legacy XXUCC or 42000 must be updated.

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
@@ -476,6 +476,11 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
             session.toString(), catalog, schemaNamePattern, tableNamePattern);
     LOGGER.debug(context);
 
+    // Per JDBC spec: null types = return all types; empty array = return nothing
+    if (tableTypes != null && tableTypes.length == 0) {
+      return metadataResultSetBuilder.getTablesResult(catalog, tableTypes, new ArrayList<>());
+    }
+
     if (!metadataResultSetBuilder.shouldAllowCatalogAccess(catalog, null, session)) {
       return metadataResultSetBuilder.getTablesResult(catalog, tableTypes, new ArrayList<>());
     }

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -588,6 +589,21 @@ public class DatabricksThriftServiceClientTest {
     DatabricksResultSet resultSet =
         client.listTables(session, TEST_CATALOG, TEST_SCHEMA, TEST_TABLE, tableTypes);
     assertEquals(resultSet.getStatementStatus().getState(), StatementState.SUCCEEDED);
+  }
+
+  @Test
+  void testListTablesWithEmptyTypesReturnsEmptyWithoutServerCall() throws SQLException {
+    // Per JDBC spec: empty types array means "no types selected" → return no rows.
+    // The driver must short-circuit and NOT send the Thrift request to the server.
+    DatabricksThriftServiceClient client =
+        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
+
+    DatabricksResultSet resultSet =
+        client.listTables(session, TEST_CATALOG, TEST_SCHEMA, TEST_TABLE, new String[0]);
+
+    assertEquals(StatementState.SUCCEEDED, resultSet.getStatementStatus().getState());
+    assertFalse(resultSet.next(), "Empty types array must yield zero rows");
+    verify(thriftAccessor, never()).getThriftResponse(any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Per JDBC spec, `DatabaseMetaData.getTables(_, _, _, new String[0])` (empty `types` array) means "no types selected" and should return zero rows. The Thrift path was leaking rows because the post-server filter at `MetadataResultSetBuilder.getTablesResult` is guarded by `tableTypes.length > 0`, which short-circuits the filter for empty arrays.
- Symptom: legacy `hive_metastore` objects have `TABLE_TYPE=""` from the Thrift server. The client normalizes `""` → `"TABLE"`, and with the broken filter guard those rows survived even for `types=[]`.
- Fix: mirror SEA's existing guard (`DatabricksMetadataQueryClient.java:128-131`) in the Thrift `listTables` — short-circuit to an empty result set at the top of the method when `tableTypes` is non-null and length 0. The server is never queried.

## Test plan

- [x] Added `testListTablesWithEmptyTypesReturnsEmptyWithoutServerCall` — asserts zero rows AND that `thriftAccessor.getThriftResponse` is never invoked
- [x] Existing `testListTables` (non-empty types) still passes — 46/46 in `DatabricksThriftServiceClientTest`
- [x] Verified end-to-end against a real workspace: before fix, `getTables(null, null, null, [])` on Thrift returned 2 `hive_metastore.default.trim_repro*` rows while SEA returned 0; after fix, both return 0

This pull request and its description were written by Isaac.