### PR TITLE
Make weekly security scan actionable: suppress documented false positives + fix broken email notification

### DIFF
--- a/.github/workflows/vulnerabilityCatcher.yml
+++ b/.github/workflows/vulnerabilityCatcher.yml
@@ -81,6 +81,14 @@ jobs:
           echo "Maven configured to use JFrog registry"
 
       - name: Run OWASP Dependency Check
+        # The maven plugin exits non-zero when CVSS >= 7 findings exist
+        # (`<failBuildOnCVSS>7</failBuildOnCVSS>` in jdbc-core/pom.xml). Without
+        # continue-on-error, that non-zero exit short-circuits the rest of the
+        # job and the Send Email step never runs — which means the weekly
+        # notification only fires when the scan is clean. Let this step "pass"
+        # so the explicit `Check for vulnerabilities` step below decides whether
+        # to alert and fail the job.
+        continue-on-error: true
         run: mvn -pl jdbc-core org.owasp:dependency-check-maven:check -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
 
       - name: Check for vulnerabilities
@@ -116,6 +124,9 @@ jobs:
           content_type: text/html
 
       - name: Upload Report as Artifact
+        # Always upload, even when findings cause the job to fail. The HTML/JSON
+        # reports are the primary artifact recipients use to triage findings.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-scan-reports

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -16,4 +16,119 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.arrow/.*$</packageUrl>
         <cve>CVE-2026-25087</cve>
     </suppress>
+
+    <!--
+      CVE-2024-52338 is a deserialization vulnerability in the Apache Arrow R
+      package on CRAN (R 4.0.0 - 16.1.0, fixed in R 17.0.0). The Apache advisory
+      explicitly states it does NOT affect other Arrow implementations or
+      bindings. The Java Arrow libraries (arrow-memory-core, arrow-vector, etc.)
+      are unaffected by both ecosystem (Java != R) and version range
+      (driver ships 18.3.0, which is outside the affected range).
+      See: https://nvd.nist.gov/vuln/detail/CVE-2024-52338
+           https://www.openwall.com/lists/oss-security/2024/11/28/3
+    -->
+    <suppress>
+        <notes><![CDATA[
+            CVE-2024-52338 affects the Apache Arrow R package only, not Java.
+            False positive due to CPE matching on the shared "apache:arrow" namespace.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.arrow/.*$</packageUrl>
+        <cve>CVE-2024-52338</cve>
+    </suppress>
+
+    <!--
+      CVE-2026-33186 is an authorization bypass in gRPC-Go server routing
+      (google.golang.org/grpc, fixed in 1.79.3). The Java gRPC libraries
+      (io.grpc:grpc-api, grpc-context, grpc-stub) are a completely separate
+      codebase (grpc-java) with independent release lines. The advisory record
+      lists only the Go module as affected. Additionally, the JDBC driver is a
+      gRPC client only — it does not run a gRPC server and has no attack
+      surface for a server-side routing bug.
+      See: https://nvd.nist.gov/vuln/detail/CVE-2026-33186
+           https://github.com/advisories/GHSA-p77j-4mvh-x3m3
+    -->
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-33186 affects gRPC-Go (google.golang.org/grpc) only,
+            not gRPC-Java. False positive due to CPE matching on the shared
+            "grpc:grpc" namespace. Driver is a gRPC client; no server attack
+            surface.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/.*$</packageUrl>
+        <cve>CVE-2026-33186</cve>
+    </suppress>
+
+    <!--
+      CVE-2026-0994 is a vulnerability in the protobuf Python library
+      (`pip install protobuf`, fixed in 5.29.6 / 6.33.5). The advisory record
+      lists only the pip module as affected; no Maven artifact is listed.
+      The Java protobuf library (com.google.protobuf:protobuf-java) shares a
+      CPE namespace with the Python library, causing the OWASP scanner to
+      match it incorrectly.
+      See: https://nvd.nist.gov/vuln/detail/CVE-2026-0994
+           https://github.com/advisories/GHSA-7gcm-g887-7qv7
+    -->
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-0994 affects pip protobuf (Python) only, not protobuf-java.
+            False positive due to CPE matching on the shared "google:protobuf"
+            / "protobuf:protobuf" namespace.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/.*$</packageUrl>
+        <cve>CVE-2026-0994</cve>
+    </suppress>
+
+    <!--
+      Several CVEs in the May 2026 Apache Thrift advisory batch are scoped to
+      non-Java bindings (Go, Node.js, C_glib, Rust). They get matched against
+      the Java libthrift jar via the shared "apache:thrift" CPE namespace.
+      The driver uses libthrift as a Java client only (TBinaryProtocol over
+      HTTP) — none of these vulnerabilities are reachable from Java usage.
+      The remaining libthrift CVEs whose binding is unspecified or known to
+      affect Java are NOT suppressed and will be cleared by a follow-up bump
+      to libthrift 0.23.0 (requires regenerating TCLIService.java).
+      See per-CVE notes below for the affected binding.
+    -->
+    <suppress>
+        <notes><![CDATA[
+            CVE-2025-48431 affects libthrift C_glib (invalid free), not the
+            Java binding. False positive due to shared "apache:thrift" CPE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2025-48431</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-41602 affects libthrift Go (TFramedTransport), not the
+            Java binding. False positive due to shared "apache:thrift" CPE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2026-41602</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-41636 affects libthrift Node.js (skip() recursion), not
+            the Java binding. False positive due to shared "apache:thrift" CPE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2026-41636</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-43868 affects libthrift Rust (memory allocation excess
+            size), not the Java binding. False positive due to shared
+            "apache:thrift" CPE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2026-43868</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-43870 affects libthrift Node.js (web_server.js multi-vuln),
+            not the Java binding. False positive due to shared "apache:thrift"
+            CPE.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2026-43870</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Two related changes to the weekly OWASP security scan, both aimed at getting the scanner back to a state where its output is useful instead of noise.

### 1. Add suppressions for documented false positives

After PR #1456 landed the real CVE fixes, the remaining findings in the weekly scan are dominated by CPE-mismatch false positives: scanner matching a Java artifact against an advisory that's actually scoped to a different language binding (R, Go, Python, C_glib, Node.js, Rust). Each entry below has been independently verified against the upstream advisory:

| CVE | Why it's a false positive against our artifacts |
|---|---|
| CVE-2024-52338 | Apache Arrow R package on CRAN only (R 4.0.0 – 16.1.0). Driver ships Java Arrow 18.3.0 — wrong ecosystem AND outside the version range. |
| CVE-2026-33186 | gRPC-Go server authz bypass (fixed in 1.79.3). grpc-java is a separate codebase. Driver runs no gRPC server. |
| CVE-2026-0994 | pip protobuf (Python) `json_format.ParseDict()`. No Java fix exists because Java isn't affected. |
| CVE-2025-48431 | libthrift C_glib (invalid free). Not Java. |
| CVE-2026-41602 | libthrift Go (TFramedTransport). Not Java. |
| CVE-2026-41636 | libthrift Node.js (skip() recursion). Not Java. |
| CVE-2026-43868 | libthrift Rust (memory allocation excess size). Not Java. |
| CVE-2026-43870 | libthrift Node.js (web_server.js multi-vuln). Not Java. |

Each suppression has a comment block above it explaining the rationale, affected binding, and advisory link — same pattern as the existing CVE-2026-25087 suppression for Arrow C++ vs Java.

The remaining libthrift CVEs whose binding is unspecified or known to affect Java (CVE-2026-41603, 41604, 41605, 43869) are **NOT** suppressed. They will be cleared by a follow-up PR bumping libthrift 0.19 → 0.23.0, which requires regenerating `TCLIService.java` with the matching compiler (separate, larger work item).

### 2. Fix `vulnerabilityCatcher.yml` so the email notification actually runs

The weekly workflow has been failing every Sunday for 7+ consecutive weeks (since early April 2026) without sending a notification email. Root cause: the OWASP maven plugin step exits non-zero when CVEs are found (because `<failBuildOnCVSS>7</failBuildOnCVSS>` is set in `jdbc-core/pom.xml:357`). That non-zero exit short-circuits the rest of the job, so the subsequent `Check for vulnerabilities` and `Send Email` steps never run. Result: emails fire only when the scan is **clean** — exactly backwards from intent.

Fixes:
- Add `continue-on-error: true` to the OWASP maven step. The explicit `Check for vulnerabilities` gate downstream is now what decides whether to alert and fail the job (it already does `exit 1` on findings, after writing the email HTML).
- Add `if: always()` to the artifact upload so the dependency-check HTML/JSON report is uploaded even when findings cause the job to fail. Recipients need the report to triage.

### Verification

```
$ mvn org.owasp:dependency-check-maven:check -pl jdbc-core
[before this PR] ~20+ findings across 4 dependencies
[after this PR]   4 findings on 1 dependency (libthrift, unspecified-binding CVEs)
```

No real findings are hidden by the suppressions. The 4 libthrift entries that remain are exactly the ones we want the next person to see when the weekly scan fires.

## Out of scope — follow-up work

- **libthrift 0.19 → 0.23.0** (requires regenerating `TCLIService.java` with the 0.23 compiler from `src/main/java/com/databricks/jdbc/dbclient/impl/thrift/TCLIService.thrift`; no codegen tooling currently in repo). Tracked separately.
- **PR-blocking security gate** with diff-mode (osv-scanner) for net-new findings on every PR, severity-tiered, with `OVERRIDE_SECURITY=true` escape hatch. Out of scope here; needs separate proposal.
- **Auto-file GH issues per finding** (instead of email-to-distlist) so weekly findings get assigned owners and SLAs. Also separate.

## Test plan

- [x] Local `mvn org.owasp:dependency-check-maven:check -pl jdbc-core` shows the expected reduced finding set.
- [ ] Manually trigger the workflow (`workflow_dispatch`) post-merge to verify the email notification fires correctly when findings exist.
- [ ] Confirm artifact upload still works on a failed run.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.