### PR TITLE
Add per-PR security scan: OWASP + OSV-Scanner with cyclonedx SBOM

### DIFF
--- a/.github/workflows/prSecurityScan.yml
+++ b/.github/workflows/prSecurityScan.yml
@@ -1,0 +1,197 @@
+name: PR Security Scan
+
+# Phase 1 of the security gate. Runs on every PR (and on workflow_dispatch
+# for manual reruns). Fails the job if either OWASP dependency-check or
+# OSV-Scanner reports an unsuppressed CVSS >= 7 finding against the PR
+# branch.
+#
+# Two scanners, complementary coverage:
+#
+#   - OWASP dependency-check: NVD CPE-based. Existing setup; reuses
+#     owasp-suppressions.xml and the failBuildOnCVSS=7 threshold from
+#     jdbc-core/pom.xml.
+#
+#   - OSV-Scanner: purl-based via the OSV database (federates GHSA/NVD/
+#     PyPA/RustSec). Catches advisories that OWASP misses because they
+#     have no NVD CPE entry (e.g., CVE-2025-66566 in at.yawk.lz4:lz4-java,
+#     or CVE-2026-5598 in bouncycastle). Reads the cyclonedx aggregate
+#     SBOM produced by `mvn package` so it sees the actually-resolved
+#     local dependency tree, not deps.dev's stale published-artifact
+#     metadata.
+#
+# Suppression workflow: known false positives are listed in
+# owasp-suppressions.xml (for OWASP) and osv-scanner.toml (for OSV). Keep
+# the two files in sync when adding or removing entries -- both scanners
+# should agree on what is and is not a real finding.
+#
+# Not added to branch protection as a required check yet. Once the
+# outstanding libthrift and bouncycastle findings are cleared, this
+# workflow should be marked required so the gate has teeth.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  pr-security-scan:
+    name: PR Security Scan
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      # Mirror the weekly scan's JFrog setup so dependency resolution uses
+      # the same proxy and credentials. Skipped on fork PRs (no OIDC token).
+      - name: Get JFrog OIDC token
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+
+          ID_TOKEN=$(curl -sLS \
+            -H "User-Agent: actions/oidc-client" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+          echo "::add-mask::${ID_TOKEN}"
+
+          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+          echo "::add-mask::${ACCESS_TOKEN}"
+
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "FAIL: Could not extract JFrog access token"
+            exit 1
+          fi
+
+          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+
+      - name: Configure maven
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << EOF
+          <settings>
+            <mirrors>
+              <mirror>
+                <id>jfrog-central</id>
+                <mirrorOf>*</mirrorOf>
+                <url>https://databricks.jfrog.io/artifactory/db-maven/</url>
+              </mirror>
+            </mirrors>
+            <servers>
+              <server>
+                <id>jfrog-central</id>
+                <username>gha-service-account</username>
+                <password>${JFROG_ACCESS_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      # Build the project to produce the cyclonedx aggregate SBOM that OSV
+      # will scan, and to make the resolved dependency tree visible to
+      # OWASP. -Ddependency-check.skip=true because OWASP runs as its own
+      # explicit step below; we don't want to run it twice.
+      - name: Build (generates cyclonedx SBOM)
+        run: mvn package -DskipTests -Ddependency-check.skip=true -B
+
+      # Each scanner runs even if the other failed, so the author sees both
+      # scanners' findings in one CI run. Each step exits non-zero on
+      # findings; the overall job fails if either reports a CVSS >= 7
+      # finding that isn't suppressed.
+
+      - name: Run OWASP Dependency Check
+        id: owasp
+        run: |
+          # failBuildOnCVSS=7 is configured in jdbc-core/pom.xml, so this
+          # naturally exits non-zero on any CVSS >= 7 finding not covered
+          # by owasp-suppressions.xml.
+          mvn -pl jdbc-core org.owasp:dependency-check-maven:check \
+            -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+
+      - name: Install osv-scanner
+        if: always()
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
+          chmod +x /tmp/osv-scanner
+          /tmp/osv-scanner --version
+
+      - name: Run OSV-Scanner
+        id: osv
+        if: always()
+        run: |
+          set -uo pipefail
+          # Scan only the aggregate SBOM at the repo root. Per-module SBOMs
+          # (jdbc-core/target/bom.json etc.) would just repeat findings
+          # for shared transitives; the aggregate is the de-duped view.
+          /tmp/osv-scanner scan source \
+            --recursive=false \
+            --config=osv-scanner.toml \
+            --format=json \
+            --output-file=/tmp/osv-out.json \
+            target/bom.json || true
+
+          # Filter to severity >= 7. OSV-Scanner's exit code by itself is
+          # not severity-aware (any unsuppressed finding fails), so we do
+          # the threshold filter here. Suppressed findings have already
+          # been stripped by osv-scanner.toml.
+          HIGH_FINDINGS=$(jq '[
+            .results[].packages[]? |
+            .package as $pkg |
+            .groups[]? |
+            select((.max_severity | tonumber? // 0) >= 7) |
+            {pkg: ($pkg.name + "@" + $pkg.version), ids: .ids, severity: .max_severity}
+          ]' /tmp/osv-out.json)
+
+          COUNT=$(echo "$HIGH_FINDINGS" | jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::OSV-Scanner found $COUNT unsuppressed CVSS>=7 finding(s):"
+            echo "$HIGH_FINDINGS" | jq -r '.[] | "  - \(.pkg) | \(.ids | join(",")) | severity \(.severity)"'
+            echo ""
+            echo "Fix by:"
+            echo "  1. Bumping the affected dependency to a patched version, or"
+            echo "  2. Adding a documented suppression entry to osv-scanner.toml"
+            echo "     AND owasp-suppressions.xml (keep both files in sync)."
+            exit 1
+          fi
+
+          echo "OSV-Scanner: no unsuppressed CVSS>=7 findings."
+
+      # Upload artifacts so reviewers can pull the full reports.
+      - name: Upload OWASP report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pr-security-owasp-report
+          path: |
+            jdbc-core/target/dependency-check-report.html
+            jdbc-core/target/dependency-check-report.json
+          if-no-files-found: ignore
+
+      - name: Upload OSV report + SBOM
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pr-security-osv-report
+          path: |
+            /tmp/osv-out.json
+            target/bom.json
+          if-no-files-found: ignore

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,81 @@
+# OSV-Scanner suppressions for the databricks-jdbc PR security gate.
+#
+# Mirror of owasp-suppressions.xml. Each entry suppresses a CVE that is a
+# documented CPE / ecosystem false positive against an artifact we ship.
+# When you add or remove an entry here, mirror the same change in
+# owasp-suppressions.xml so the two scanners report the same set of
+# findings on every PR.
+#
+# See google.github.io/osv-scanner/configuration/ for schema.
+
+# --- Apache Arrow ---
+# Both Arrow CVEs below come from the same CPE collision pattern: an advisory
+# scoped to Arrow C++ or Arrow R, matched against the Java arrow-* artifacts
+# via the shared "apache:arrow" identifier. Java Arrow is unaffected.
+
+[[IgnoredVulns]]
+id = "CVE-2026-25087"
+reason = """
+Use-After-Free in Apache Arrow C++ IPC file reader (variadic buffers). Does
+not affect the Java Arrow libraries (arrow-memory-core, arrow-vector, etc.)
+which are pure Java with no native C++ code. False positive via the shared
+apache:arrow CPE/identifier namespace.
+"""
+
+[[IgnoredVulns]]
+id = "CVE-2024-52338"
+reason = """
+Deserialization vulnerability in the Apache Arrow R package on CRAN
+(R 4.0.0 - 16.1.0, fixed in R 17.0.0). Apache advisory explicitly states it
+does not affect other Arrow implementations or bindings. Driver ships Java
+Arrow 18.3.0 -- wrong ecosystem and outside version range.
+See https://www.openwall.com/lists/oss-security/2024/11/28/3
+"""
+
+# --- gRPC ---
+[[IgnoredVulns]]
+id = "CVE-2026-33186"
+reason = """
+gRPC-Go server authorization bypass (google.golang.org/grpc, fixed in
+1.79.3). The Java gRPC libraries (io.grpc:grpc-api / grpc-context /
+grpc-stub) are a separate codebase with independent release lines and are
+not affected. The JDBC driver is a gRPC client only -- it does not run a
+gRPC server and has no server-side attack surface.
+"""
+
+# --- protobuf-java ---
+[[IgnoredVulns]]
+id = "CVE-2026-0994"
+reason = """
+Vulnerability in pip protobuf (Python) json_format.ParseDict(). Advisory
+record lists only the pip module as affected. False positive via the
+google:protobuf CPE namespace.
+"""
+
+# --- libthrift (non-Java bindings) ---
+# Several CVEs in the May 2026 Apache Thrift advisory batch are scoped to
+# non-Java bindings (Go, Node.js, C_glib, Rust). They get matched against
+# the Java libthrift jar via the shared apache:thrift identifier.
+# Remaining libthrift CVEs whose binding is unspecified or known to affect
+# Java are NOT suppressed and will be cleared by a follow-up bump to
+# libthrift 0.23.0.
+
+[[IgnoredVulns]]
+id = "CVE-2025-48431"
+reason = "libthrift C_glib (invalid free). Not Java. CPE namespace collision."
+
+[[IgnoredVulns]]
+id = "CVE-2026-41602"
+reason = "libthrift Go TFramedTransport. Not Java. CPE namespace collision."
+
+[[IgnoredVulns]]
+id = "CVE-2026-41636"
+reason = "libthrift Node.js skip() recursion. Not Java. CPE namespace collision."
+
+[[IgnoredVulns]]
+id = "CVE-2026-43868"
+reason = "libthrift Rust memory allocation excess size. Not Java. CPE namespace collision."
+
+[[IgnoredVulns]]
+id = "CVE-2026-43870"
+reason = "libthrift Node.js web_server.js multi-vuln. Not Java. CPE namespace collision."

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
     <spotless-maven-plugin.version>2.39.0</spotless-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 
     <!-- Dependency Versions -->
     <databricks-jdbc-version>3.3.3</databricks-jdbc-version>
@@ -171,6 +172,11 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -202,6 +208,38 @@
             </excludes>
           </java>
         </configuration>
+      </plugin>
+      <plugin>
+        <!--
+          Emits a CycloneDX SBOM (target/bom.json) per module + an aggregate
+          BOM at the root build dir during `mvn package`. The PR security
+          scan workflow feeds the aggregate BOM to osv-scanner so it scans
+          the actually-resolved local dependency tree, rather than relying
+          on deps.dev's metadata for the currently-published GA (which lags
+          behind whatever bumps are sitting on main).
+        -->
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>aggregate-bom</id>
+            <phase>package</phase>
+            <goals>
+              <goal>makeAggregateBom</goal>
+            </goals>
+            <configuration>
+              <outputFormat>json</outputFormat>
+              <schemaVersion>1.5</schemaVersion>
+              <!--
+                Override default: cyclonedx auto-skips modules with
+                maven.deploy.skip=true (like the parent and jdbc-core).
+                We want the SBOM for the security scan regardless of
+                deploy status.
+              -->
+              <skipNotDeployed>false</skipNotDeployed>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Summary

Adds a per-PR security gate (Phase 1 of the broader rollout). A new workflow runs on every PR to `main` and fails the job if either OWASP dependency-check or OSV-Scanner reports an unsuppressed CVSS ≥ 7 finding.

### Why two scanners

| Scanner | Source | Catches | Misses |
|---|---|---|---|
| OWASP dependency-check | NVD (CPE-based) | Anything with an NVD CPE entry. Reuses existing `owasp-suppressions.xml` and the `failBuildOnCVSS=7` threshold in `jdbc-core/pom.xml`. | GHSA-only advisories without an NVD CPE (e.g., CVE-2025-66566 in lz4-java — the lesson from #1455). |
| OSV-Scanner v2.3.8 | OSV.dev (purl-based; federates GHSA + NVD + PyPA + RustSec) | The GHSA-only gap. Already turned up a new finding I didn't know about: **bouncycastle CVE-2026-5598 (severity 8.9)** in bcprov-jdk18on 1.79, which OWASP doesn't see at all. | Findings without a CVSS score (rare for high-severity). |

Both scanners use suppression files (`owasp-suppressions.xml` and `osv-scanner.toml`) listing documented false positives. Each entry has a justification comment. Keep the two in sync when adding/removing entries.

### Why cyclonedx SBOM (and not just \`pom.xml\`)

OSV-Scanner's Maven resolver consults deps.dev's published-artifact metadata. For the project's *own* GA, that means it sees the previously-published 3.3.3 pom (with lz4@1.8.1, etc.) — not whatever bumps are sitting on \`main\`. Result: in CI, OSV would keep showing yesterday's released state instead of the PR branch's actual dependency tree.

Fix: produce a CycloneDX aggregate SBOM at build time (\`mvn package\`) and feed *that* to OSV. The SBOM captures the actually-resolved local tree.

Added \`cyclonedx-maven-plugin\` 2.9.1 to the parent pom, bound to the \`package\` phase, with \`skipNotDeployed=false\` to override its default behavior of skipping modules with \`maven.deploy.skip=true\` (parent and jdbc-core).

### Findings on \`main\` today

This workflow, run against current \`main\` (post-#1456, pre-#1458), reports 2 unsuppressed CVSS ≥ 7 findings:

1. \`org.bouncycastle:bcprov-jdk18on@1.79\` → GHSA-p93r-85wp-75v3 (CVE-2026-5598, severity 8.9). Fixed in bcprov-jdk18on 1.84. **Follow-up PR.**
2. \`org.apache.thrift:libthrift@0.19.0\` → GHSA-7pwc-h2j2-rjgj (covers CVE-2026-41603/04/05/43869, max severity 8.2). Cleared by the libthrift 0.19 → 0.23 follow-up. **Follow-up PR.**

So this PR's CI will be **red on its own scan** until those two follow-ups land. That's intentional and aligned with the rollout plan:

* This PR adds the workflow but does NOT mark it required-to-merge in branch protection. PRs are not blocked from merging by the red ❌.
* Once the bouncycastle and libthrift follow-ups land and the gate goes green, then flip it to required.

### What this PR is NOT

* It is **not** a required check. Branch protection is unchanged.
* It does **not** introduce a diff-mode (net-new findings only) gate. Every PR has to ship into a clean codebase — that's the design we agreed on, to force the team to actually burn down the backlog rather than just \"not make it worse.\"
* It does **not** include a Phase 2 design (override flags, severity tiers, auto-issue filing). Phase 2 is deferred until we have ~2 weeks of operational experience with Phase 1.

### Test plan

- [x] \`mvn package -DskipTests -Ddependency-check.skip=true\` produces \`target/bom.json\` with the expected resolved dependency tree (jackson 2.18.7, netty 4.2.13.Final, lz4 1.10.1, etc.).
- [x] Local OSV scan against the aggregate SBOM with the new \`osv-scanner.toml\` correctly suppresses the documented false positives (Arrow R-only, gRPC-Go-only, libthrift non-Java bindings, etc.) — only the 2 real findings remain.
- [x] Filter-to-severity-≥7 jq logic correctly excludes BC CVEs below 7 while keeping the 8.9 finding.
- [ ] CI run on this PR — expected to fail on the 2 known findings above. **The CI failure on this PR is the intended outcome.**
- [ ] Manual workflow_dispatch run post-merge.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.