### PR TITLE
Bump databricks-sdk-java from 0.69.0 to 0.106.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -59,6 +59,7 @@ upgrading. These changes do not affect metadata on All-Purpose Clusters.
   protocol. To revert to native Thrift metadata RPCs, set `UseQueryForMetadata=0`.
 
 ### Updated
+- Bump `databricks-sdk-java` from 0.69.0 to 0.106.0. The driver's own `AgentDetector` injection in `UserAgentManager.setUserAgent` is removed because SDK 0.106 now natively emits the `agent/<name>` User-Agent token via its built-in `UserAgent.agentProvider()`; keeping both layered produced a duplicate token on every SDK-routed request. The bootstrap `buildUserAgentForConnectorService` path retains its own `AgentDetector` call because it bypasses `UserAgent.asString()`.
 - `getColumnTypeName()` for DECIMAL columns now preserves precision/scale suffix (e.g., `"DECIMAL(10,2)"`) consistently across both Thrift and SEA backends.
 - `EnableGeoSpatialSupport` no longer requires `EnableComplexDatatypeSupport=1`. Geospatial types (GEOMETRY, GEOGRAPHY) can now be enabled independently of complex type support (ARRAY, MAP, STRUCT).
 - Arrow schema deserialization failures (Thrift metadata path) now surface a dedicated driver error code `ARROW_SCHEMA_PARSING_ERROR` (vendor code `22000`) and a proper SQLSTATE `22000` (Data Exception) on the thrown `SQLException`, instead of the generic `RESULT_SET_ERROR` (1004) and the enum name as SQLSTATE. The exception message is unchanged.

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration.version>2.15.0</commons-configuration.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <databricks-sdk.version>0.69.0</databricks-sdk.version>
+    <databricks-sdk.version>0.106.0</databricks-sdk.version>
     <httpclient.version>4.5.14</httpclient.version>
     <async-httpclient.version>5.5.2</async-httpclient.version>
     <httpcore5.version>5.3.6</httpcore5.version>

--- a/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
+++ b/src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java
@@ -63,9 +63,6 @@ public class UserAgentManager {
         }
       }
     }
-
-    // Detect AI coding agent and append to user agent
-    AgentDetector.detect().ifPresent(product -> UserAgent.withOtherInfo(AGENT_KEY, product));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Bumps `databricks-sdk-java` from **0.69.0 → 0.106.0** (37 minor versions).
- Removes the driver-side `AgentDetector.detect()` call in `UserAgentManager.setUserAgent()` to avoid duplicate `agent/<name>` User-Agent tokens. SDK 0.106 introduced native AI-coding-agent detection in `com.databricks.sdk.core.UserAgent` (new `agentProvider()` + 9-agent `listKnownAgents()`); layering the driver's own injection on top produced `agent/×2` on every SDK-routed request.

## Why this is safe to ship

Bytecode-diffed every driver-imported SDK class between 0.69 and 0.106. All 38 imports survive to 0.106 with compatible signatures (compile passes unchanged).

The `agent/<name>` collision was the **only** behavior-impacting delta on the driver's hot path. The other 0.69→0.106 deltas either don't reach driver code paths (driver bypasses SDK service impls via `apiClient.execute()` direct, so SDK's new `X-Databricks-Org-Id` auto-injection on `StatementExecutionImpl`/`AppsImpl`/etc. never fires for us), or only populate when the corresponding `DatabricksConfig` field is `null` (driver-set values continue to win — verified by reading `resolveHostMetadata()` source).

The bootstrap `buildUserAgentForConnectorService` path retains its own `AgentDetector.detect()` call because that UA is hand-built via `StringBuilder` and never goes through `UserAgent.asString()`. Mitm-verified `agent/×1` on every wire request after the fix.

## What changed

**3 files, +2 / -4 lines total:**

```
pom.xml                                                             | 2 +-
src/main/java/com/databricks/jdbc/common/util/UserAgentManager.java | 3 ---
NEXT_CHANGELOG.md                                                   | 1 +
```

## Test plan

- [x] `mvn install` builds clean on SDK 0.106 with no other source changes
- [x] Mitm wire verified: `agent/×2` on SDK 0.106 pre-fix → `agent/×1` after, on both SEA and Thrift
- [x] PAT, M2M Databricks-OIDC, AAD SP — live PASS on pecotesting (Azure SPOG + Legacy) on SDK 0.106
- [x] U2M browser flow — live PASS on Azure SPOG, Azure Legacy, AWS workspace
- [x] U2M refresh-token cache reuse — live PASS on AWS (first run opens browser + caches; second run reuses cache, no browser, 6× faster)
- [x] Statement execution e2e: SELECT 1, NULL, multi-row 100, **10k-row multi-chunk**, prepared statement, ResultSetMetaData — all PASS
- [x] DatabaseMetaData APIs: `getCatalogs`, `getSchemas`, `getTableTypes`, `getDatabaseProductName` — all PASS
- [x] Complex types round-trip: ARRAY, MAP, STRUCT, DECIMAL+DATE — all PASS
- [x] 50× connection lifecycle on both PAT and M2M — no leaks, no token-cache pollution
- [x] Mocked: `CachedTokenSourceRefreshTest`, `AzureMsiMockTest`, `OidcDiscoveryTest`, `ErrorMappingTest`, `DefaultProfileResolutionTest`, `UserAgentTest` — all PASS

## Coverage gaps (not blocking — for transparency)

- **GCP workspace not live-tested**: SDK's `GoogleCredentialsCredentialsProvider`/`GoogleIdCredentialsProvider` bytecode is essentially unchanged 0.69 → 0.106 (logger refactor only). Recommend canary on GCP customers.
- **Real Azure MSI flow**: only mocked-IMDS test; needs an Azure VM for live coverage.

## Pre-existing driver issues observed but NOT addressed by this PR

These reproduce identically on SDK 0.69 — not introduced by the bump. Each should be filed separately:

1. `EnableTokenFederation=1` default breaks vanilla U2M (workaround: set `EnableTokenFederation=0`). Wraps `ExternalBrowserCredentialsProvider` with `DatabricksTokenFederationProvider` which expects an external IdP token that vanilla U2M doesn't have.
2. Cross-cloud federation rejected by the `Cloud.AZURE`-only check at `ClientConfigurator.java:172` (blocks AAD external IdP → GCP/AWS workspace federation).
3. OAuth-M2M scope is not pluggable via JDBC URL — driver's `Auth_Scope` applies only to U2M and JWT M2M paths, not OAuth M2M `client_credentials`. Breaks federation when the external IdP is Azure AAD because AAD requires `<resource>/.default` and the SDK sends `all-apis` from `DatabricksConfig.getScopes()` default.

NO_CHANGELOG=false

This pull request was AI-assisted by Isaac.