### PR TITLE
Extract SPOG org-id from cluster httpPath for non-Thrift requests

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
+- Fixed silent telemetry loss on SPOG (custom-URL) hosts when connecting to an all-purpose cluster via a Thrift `httpPath` like `sql/protocolv1/o/<workspace-id>/<cluster-id>`. The driver now extracts the workspace ID from the cluster path segment (in addition to the existing `?o=<workspace-id>` query-param extraction) and sets it as the `x-databricks-org-id` header on every outgoing request. Without this, telemetry POSTs to `/telemetry-ext` were redirected to `/login` because the workspace context could not be inferred from the URL.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -1322,6 +1322,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   private static final String ORG_ID_HEADER = "x-databricks-org-id";
   private static final String ORG_ID_QUERY_PARAM = "o";
 
+  // Matches the workspace ID inside an all-purpose-compute Thrift path of the form
+  // [/]sql/protocolv1/o/<workspace-id>/<cluster-id>[/...][?...].
+  private static final java.util.regex.Pattern CLUSTER_PATH_ORG_ID_PATTERN =
+      java.util.regex.Pattern.compile("(?:^|/)sql/protocolv1/o/(\\d+)/[^/?]+");
+
   private Map<String, String> parseCustomHeaders(ImmutableMap<String, String> parameters) {
     String filterPrefix = DatabricksJdbcUrlParams.HTTP_HEADERS.getParamName();
 
@@ -1334,7 +1339,11 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
                         entry -> entry.getKey().substring(filterPrefix.length()),
                         Map.Entry::getValue)));
 
-    // Extract org ID from ?o= in httpPath for SPOG routing
+    // Extract org ID for SPOG routing. Two sources, in priority order:
+    //   1. ?o=<wsid> query parameter in httpPath (warehouse paths typically use this)
+    //   2. /sql/protocolv1/o/<wsid>/<cluster> path segment (all-purpose cluster paths)
+    // Without this, non-Thrift endpoints (e.g. /telemetry-ext) lack workspace context on
+    // SPOG hosts and PoPP redirects them to /login.
     if (!headers.containsKey(ORG_ID_HEADER)) {
       String httpPath =
           parameters.getOrDefault(
@@ -1357,6 +1366,18 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
         LOGGER.debug(
             "SPOG header extraction: malformed httpPath, skipping org-id extraction: "
                 + e.getMessage());
+      }
+
+      if (!headers.containsKey(ORG_ID_HEADER) && !httpPath.isEmpty()) {
+        Matcher clusterMatch = CLUSTER_PATH_ORG_ID_PATTERN.matcher(httpPath);
+        if (clusterMatch.find()) {
+          String orgId = clusterMatch.group(1);
+          headers.put(ORG_ID_HEADER, orgId);
+          LOGGER.debug(
+              "SPOG header extraction: injecting {}={} (extracted from cluster path segment)",
+              ORG_ID_HEADER,
+              orgId);
+        }
       }
     } else {
       LOGGER.debug(

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -1459,6 +1459,80 @@ class DatabricksConnectionContextTest {
   }
 
   @Test
+  void testSpogContext_extractsOrgIdFromClusterPathSegment() throws DatabricksSQLException {
+    // All-purpose-compute Thrift path embeds the workspace ID in /o/<wsid>/<cluster>.
+    // No ?o= query param — driver should still extract org-id so non-Thrift endpoints
+    // (e.g. /telemetry-ext) get the x-databricks-org-id header on SPOG hosts.
+    String url =
+        "jdbc:databricks://spog.cloud.databricks.com/default;ssl=1;AuthMech=3;"
+            + "httpPath=sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt";
+    Properties props = new Properties();
+    props.put("user", "token");
+    props.put("password", "test-token");
+    IDatabricksConnectionContext ctx = DatabricksConnectionContext.parse(url, props);
+
+    Map<String, String> headers = ctx.getCustomHeaders();
+    assertEquals("6051921418418893", headers.get("x-databricks-org-id"));
+  }
+
+  @Test
+  void testSpogContext_clusterPathWithLeadingSlashAlsoExtracts() throws DatabricksSQLException {
+    String url =
+        "jdbc:databricks://spog.cloud.databricks.com/default;ssl=1;AuthMech=3;"
+            + "httpPath=/sql/protocolv1/o/6051921418418893/0528-220959-uzmcn1qt";
+    Properties props = new Properties();
+    props.put("user", "token");
+    props.put("password", "test-token");
+    IDatabricksConnectionContext ctx = DatabricksConnectionContext.parse(url, props);
+
+    assertEquals("6051921418418893", ctx.getCustomHeaders().get("x-databricks-org-id"));
+  }
+
+  @Test
+  void testSpogContext_queryParamWinsOverClusterPathSegment() throws DatabricksSQLException {
+    // ?o= takes precedence when both forms are present (matches priority order in the code).
+    String url =
+        "jdbc:databricks://spog.cloud.databricks.com/default;ssl=1;AuthMech=3;"
+            + "httpPath=sql/protocolv1/o/111/0528-220959-uzmcn1qt?o=222";
+    Properties props = new Properties();
+    props.put("user", "token");
+    props.put("password", "test-token");
+    IDatabricksConnectionContext ctx = DatabricksConnectionContext.parse(url, props);
+
+    assertEquals("222", ctx.getCustomHeaders().get("x-databricks-org-id"));
+  }
+
+  @Test
+  void testSpogContext_explicitHeaderTakesPrecedenceOverClusterPath()
+      throws DatabricksSQLException {
+    String url =
+        "jdbc:databricks://spog.cloud.databricks.com/default;ssl=1;AuthMech=3;"
+            + "httpPath=sql/protocolv1/o/111/0528-220959-uzmcn1qt;"
+            + "http.header.x-databricks-org-id=fromheader";
+    Properties props = new Properties();
+    props.put("user", "token");
+    props.put("password", "test-token");
+    IDatabricksConnectionContext ctx = DatabricksConnectionContext.parse(url, props);
+
+    assertEquals("fromheader", ctx.getCustomHeaders().get("x-databricks-org-id"));
+  }
+
+  @Test
+  void testSpogContext_warehousePathWithoutQueryParamHasNoOrgId() throws DatabricksSQLException {
+    // Warehouse paths never embed the workspace ID, so without ?o= no header is set.
+    // Regression guard for the cluster-path fallback (it must not match warehouse paths).
+    String url =
+        "jdbc:databricks://spog.cloud.databricks.com/default;ssl=1;AuthMech=3;"
+            + "httpPath=/sql/1.0/warehouses/abc123";
+    Properties props = new Properties();
+    props.put("user", "token");
+    props.put("password", "test-token");
+    IDatabricksConnectionContext ctx = DatabricksConnectionContext.parse(url, props);
+
+    assertFalse(ctx.getCustomHeaders().containsKey("x-databricks-org-id"));
+  }
+
+  @Test
   public void testDefaultGetterCoverage() throws DatabricksSQLException {
     IDatabricksConnectionContext ctx =
         DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);


### PR DESCRIPTION
## Summary

- Fixes silent telemetry loss on SPOG (custom-URL) hosts when connecting to an all-purpose cluster via a Thrift `httpPath` like `sql/protocolv1/o/<workspace-id>/<cluster-id>`.
- `parseCustomHeaders` now extracts the workspace ID from the `/o/<wsid>/` path segment as a fallback when `?o=<wsid>` is not present, and sets it as the `x-databricks-org-id` header.
- Priority order preserved: explicit `http.header.x-databricks-org-id` ▶ `?o=` in `httpPath` ▶ `/sql/protocolv1/o/<wsid>/` path segment.

## Why

On a SPOG host the workspace identity has to be in either the URL or the `x-databricks-org-id` header so PoPP can route a request to the right workspace. For cluster Thrift this happens "for free" because the workspace ID is in the `/o/<wsid>/` segment of the path, so PoPP routes it correctly via `routing_reason=workspace-id` and the Thrift session opens fine without the user supplying `?o=`. The connection-level telemetry, feature-flag, and other helper requests, however, target different paths (`/telemetry-ext`, `/api/...`) that don't carry the workspace ID, and the driver only set the `x-databricks-org-id` header when `?o=` was present in `httpPath`. Result: those requests had no workspace context on SPOG, PoPP fell back to default (account) routing, and the response was an HTTP 303 redirect to `/login` — silently dropping telemetry.

Reproduced against `peco.azuredatabricks.net` (Prod SPOG), workspace `6436897454825492`, cluster `1214-195625-gtrwbe64`:

| URL `httpPath` | Thrift queries | Telemetry POST `/telemetry-ext` |
|---|---|---|
| `sql/protocolv1/o/<wsid>/<cluster>` (no `?o=`, no fix) | ✅ 200 | ❌ **303 → /login** (silent loss) |
| Same, with this fix | ✅ 200 | ✅ **200 OK** |

The fix only adds extraction logic; it does not modify the outgoing request URL or the routing path.

## What changes

`src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java`
- New static `CLUSTER_PATH_ORG_ID_PATTERN` regex matching `(?:^|/)sql/protocolv1/o/(\d+)/[^/?]+`.
- `parseCustomHeaders` falls back to that pattern when the `?o=` extraction does not yield a workspace ID. The existing precedence guard (explicit `http.header.x-databricks-org-id` already set by the caller wins) is unchanged. The fallback runs only when `httpPath` is non-empty.

`src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java`
- Five new tests under the existing "SPOG ?o= Tests" block covering:
  - Cluster path without `?o=` → header extracted from `/o/<wsid>/`
  - Cluster path with leading `/` → same
  - Cluster path **with** `?o=` → `?o=` value wins (priority)
  - Cluster path + explicit `http.header.x-databricks-org-id` → caller header wins
  - Warehouse path without `?o=` → no header (regression guard: the new regex must not match warehouse paths)

`NEXT_CHANGELOG.md`
- Added a `### Fixed` entry describing the change.

## Test plan

- [x] `mvn test -Dtest='DatabricksConnectionContextTest'` — 136 tests pass (5 new).
- [x] `mvn package -DskipTests` — uber jar builds; `spotless:apply` clean.
- [x] End-to-end verification against `peco.azuredatabricks.net` (Prod SPOG) all-purpose cluster `1214-195625-gtrwbe64` with PAT:
  - Outgoing wire log shows `x-databricks-org-id: 6436897454825492` on the telemetry POST.
  - Telemetry response flipped from `HTTP/1.1 303 See Other` (with `location: /login?next_url=%2Ftelemetry-ext`) to `HTTP/1.1 200 OK`.
  - All four Thrift operations (CREATE_SESSION, two EXECUTE_STATEMENT, DELETE_SESSION) continue to return 200 — behaviour unchanged.

## Out of scope

- Stg SPOG (`dogfood-spog.staging.azuredatabricks.net`) currently rejects PAT for cluster Thrift with `Authentication Error: Authorization header received from the client is empty.` regardless of `?o=` or header presence — the 401 is generated by the upstream cluster HS2 handler, not by PoPP (response carries `apiproxy-response-code-details: via_upstream`). This is a server-side workspace/cluster auth config issue and is not addressed here.
- The corresponding C# ADBC driver (`adbc-drivers/databricks`, `HiveServer2`-backed `DatabricksConnection`) has the same parsing limitation in `PropertyHelper.ParseOrgIdFromProperties`. That fix belongs in the ADBC repo.

This pull request and its description were written with assistance from Claude Code.