### PR TITLE
Fix metadata identifiers containing backticks

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
+- Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/CommandConstants.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/CommandConstants.java
@@ -132,7 +132,11 @@ public class CommandConstants {
         .build();
   }
 
+  public static String escapeSqlIdentifier(String identifier) {
+    return identifier == null ? null : identifier.replace("`", "``");
+  }
+
   private static String getCatalogPrefix(String catalog) {
-    return (catalog == null) ? "system" : "`" + catalog + "`";
+    return (catalog == null) ? "system" : "`" + escapeSqlIdentifier(catalog) + "`";
   }
 }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
@@ -87,7 +87,7 @@ public class CommandBuilder {
       // Per JDBC spec, null catalog means "do not narrow the search" — list across all catalogs
       showSchemasSQL = SHOW_SCHEMAS_IN_ALL_CATALOGS_SQL;
     } else {
-      showSchemasSQL = String.format(SHOW_SCHEMAS_IN_CATALOG_SQL, catalogName);
+      showSchemasSQL = String.format(SHOW_SCHEMAS_IN_CATALOG_SQL, escapeSqlIdentifier(catalogName));
     }
     if (schemaPattern != null) {
       showSchemasSQL += String.format(LIKE_SQL, schemaPattern);
@@ -107,7 +107,7 @@ public class CommandBuilder {
       // Per JDBC spec, null catalog means "do not narrow the search" — list across all catalogs
       showTablesSQL = SHOW_TABLES_IN_ALL_CATALOGS_SQL;
     } else {
-      showTablesSQL = String.format(SHOW_TABLES_SQL, catalogName);
+      showTablesSQL = String.format(SHOW_TABLES_SQL, escapeSqlIdentifier(catalogName));
     }
     if (schemaPattern != null) {
       showTablesSQL += String.format(SCHEMA_LIKE_SQL, schemaPattern);
@@ -125,7 +125,7 @@ public class CommandBuilder {
             catalogName, schemaPattern, tablePattern, columnPattern, sessionContext);
     LOGGER.debug(contextString);
     throwErrorIfNull(Collections.singletonMap(CATALOG, catalogName), contextString);
-    String showColumnsSQL = String.format(SHOW_COLUMNS_SQL, catalogName);
+    String showColumnsSQL = String.format(SHOW_COLUMNS_SQL, escapeSqlIdentifier(catalogName));
 
     if (schemaPattern != null) {
       showColumnsSQL += String.format(SCHEMA_LIKE_SQL, schemaPattern);
@@ -149,7 +149,7 @@ public class CommandBuilder {
 
     LOGGER.debug(contextString);
     throwErrorIfNull(Collections.singletonMap(CATALOG, catalogName), contextString);
-    String showFunctionsSQL = String.format(SHOW_FUNCTIONS_SQL, catalogName);
+    String showFunctionsSQL = String.format(SHOW_FUNCTIONS_SQL, escapeSqlIdentifier(catalogName));
     if (schemaPattern != null) {
       showFunctionsSQL += String.format(SCHEMA_LIKE_SQL, schemaPattern);
     }
@@ -174,7 +174,11 @@ public class CommandBuilder {
     hashMap.put(SCHEMA, schemaName);
     hashMap.put(TABLE, tableName);
     throwErrorIfNull(hashMap, contextString);
-    return String.format(SHOW_PRIMARY_KEYS_SQL, catalogName, schemaName, tableName);
+    return String.format(
+        SHOW_PRIMARY_KEYS_SQL,
+        escapeSqlIdentifier(catalogName),
+        escapeSqlIdentifier(schemaName),
+        escapeSqlIdentifier(tableName));
   }
 
   private String fetchForeignKeysSQL() throws DatabricksSQLException {
@@ -188,7 +192,11 @@ public class CommandBuilder {
     hashMap.put(SCHEMA, schemaName);
     hashMap.put(TABLE, tableName);
     throwErrorIfNull(hashMap, contextString);
-    return String.format(SHOW_FOREIGN_KEYS_SQL, catalogName, schemaName, tableName);
+    return String.format(
+        SHOW_FOREIGN_KEYS_SQL,
+        escapeSqlIdentifier(catalogName),
+        escapeSqlIdentifier(schemaName),
+        escapeSqlIdentifier(tableName));
   }
 
   public String getSQLString(CommandName command) throws DatabricksSQLException {

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/CommandConstantsTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/CommandConstantsTest.java
@@ -1,0 +1,23 @@
+package com.databricks.jdbc.dbclient.impl.common;
+
+import static com.databricks.jdbc.dbclient.impl.common.CommandConstants.buildProceduresSQL;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.databricks.jdbc.api.impl.ImmutableSqlParameter;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommandConstantsTest {
+
+  @Test
+  @DisplayName("Should escape backticks in information schema catalog prefix")
+  void shouldEscapeBackticksInInformationSchemaCatalogPrefix() {
+    Map<Integer, ImmutableSqlParameter> params = new HashMap<>();
+
+    String sql = buildProceduresSQL("cat`alog", null, null, params);
+
+    assertTrue(sql.contains(" FROM `cat``alog`.information_schema.routines"));
+  }
+}

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilderTest.java
@@ -49,6 +49,17 @@ class CommandBuilderTest {
     }
 
     @Test
+    @DisplayName("Should escape backticks in identifiers for primary keys")
+    void shouldEscapeBackticksInIdentifiersForPrimaryKeys() throws SQLException {
+      CommandBuilder builder =
+          new CommandBuilder("cat`alog", mockSession).setSchema("sch`ema").setTable("tab`le");
+
+      String sql = builder.getSQLString(CommandName.LIST_PRIMARY_KEYS);
+
+      assertEquals("SHOW KEYS IN CATALOG `cat``alog` IN SCHEMA `sch``ema` IN TABLE `tab``le`", sql);
+    }
+
+    @Test
     @DisplayName("Should throw SQLException when catalog is null for primary keys")
     void shouldThrowExceptionWhenCatalogIsNullForPrimaryKeys() {
       CommandBuilder builder =
@@ -151,6 +162,16 @@ class CommandBuilderTest {
     }
 
     @Test
+    @DisplayName("Should escape backticks in catalog identifier for tables")
+    void shouldEscapeBackticksInCatalogIdentifierForTables() throws SQLException {
+      CommandBuilder builder = new CommandBuilder("cat`alog", mockSession);
+
+      String sql = builder.getSQLString(CommandName.LIST_TABLES);
+
+      assertEquals("SHOW TABLES IN CATALOG `cat``alog`", sql);
+    }
+
+    @Test
     @DisplayName("Should generate SCHEMA LIKE clause for empty string schema pattern")
     void shouldGenerateSchemaLikeClauseForEmptyStringSchemaPattern() throws SQLException {
       CommandBuilder builder = new CommandBuilder(TEST_CATALOG, mockSession).setSchemaPattern("");
@@ -202,6 +223,18 @@ class CommandBuilderTest {
     }
 
     @Test
+    @DisplayName("Should escape backticks in identifiers for foreign keys")
+    void shouldEscapeBackticksInIdentifiersForForeignKeys() throws SQLException {
+      CommandBuilder builder =
+          new CommandBuilder("cat`alog", mockSession).setSchema("sch`ema").setTable("tab`le");
+
+      String sql = builder.getSQLString(CommandName.LIST_FOREIGN_KEYS);
+
+      assertEquals(
+          "SHOW FOREIGN KEYS IN CATALOG `cat``alog` IN SCHEMA `sch``ema` IN TABLE `tab``le`", sql);
+    }
+
+    @Test
     @DisplayName("Should throw SQLException when catalog is null for foreign keys")
     void shouldThrowExceptionWhenCatalogIsNullForForeignKeys() {
       CommandBuilder builder =
@@ -225,6 +258,18 @@ class CommandBuilderTest {
 
       assertThrows(SQLException.class, () -> builder.getSQLString(CommandName.LIST_FOREIGN_KEYS));
     }
+  }
+
+  @Test
+  @DisplayName("Should escape backticks in catalog identifiers for other metadata commands")
+  void shouldEscapeBackticksInCatalogIdentifiersForOtherMetadataCommands() throws SQLException {
+    CommandBuilder builder = new CommandBuilder("cat`alog", mockSession);
+
+    assertEquals("SHOW SCHEMAS IN `cat``alog`", builder.getSQLString(CommandName.LIST_SCHEMAS));
+    assertEquals(
+        "SHOW COLUMNS IN CATALOG `cat``alog`", builder.getSQLString(CommandName.LIST_COLUMNS));
+    assertEquals(
+        "SHOW FUNCTIONS IN CATALOG `cat``alog`", builder.getSQLString(CommandName.LIST_FUNCTIONS));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Escape literal backticks before interpolating catalog, schema, and table identifiers into metadata SQL commands.
- Apply the same escaping to information_schema catalog prefixes used by procedure metadata.
- Add regression coverage for primary keys, foreign keys, other metadata commands, and information_schema catalog prefixes.

## Test plan
- mvn test -pl jdbc-core -Dtest=CommandBuilderTest,CommandConstantsTest

Fixes #1471