### PR TITLE
Fix timezone-shifted TIMESTAMP in nested complex types (ES-1978662)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.
+- Fixed timezone-shifted TIMESTAMP values when retrieving nested complex types (STRUCT/ARRAY/MAP) with `EnableComplexDatatypeSupport=1`.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
@@ -20,6 +20,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Iterator;
@@ -241,7 +242,9 @@ public class ComplexDataTypeParser {
             long seconds = Math.floorDiv(micros, 1_000_000L);
             long microsRemainder = Math.floorMod(micros, 1_000_000L);
             Instant instant = Instant.ofEpochSecond(seconds, microsRemainder * 1_000);
-            return Timestamp.from(instant);
+            // Build from the UTC wall-clock; Timestamp.from(instant) gets re-rendered in the JVM
+            // default timezone, shifting nested TIMESTAMP fields (ES-1978662).
+            return Timestamp.valueOf(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
           } catch (NumberFormatException nfe) {
             LOGGER.error(e, "Failed to parse TIMESTAMP value '{}' as epoch microseconds", text);
             throw e;

--- a/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.sql.*;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 
 public class ComplexDataTypeTest {
@@ -642,5 +644,54 @@ public class ComplexDataTypeTest {
 
     assertTrue(attrs[6] instanceof byte[]);
     assertArrayEquals("binaryData".getBytes(), (byte[]) attrs[6]);
+  }
+
+  /**
+   * ES-1978662: a nested TIMESTAMP serialized as epoch microseconds must not be timezone-shifted.
+   * The JVM default zone is forced to a fixed UTC-5 zone so the shift is caught on any host/CI.
+   */
+  @Test
+  public void testStructTimestampFromEpochMicrosIsNotTimezoneShifted() throws SQLException {
+    TimeZone originalTimeZone = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Bogota"));
+
+      // Epoch micros for 2017-03-26 01:01:02.345 UTC.
+      long epochMicros = Instant.parse("2017-03-26T01:01:02.345Z").toEpochMilli() * 1_000L;
+      String json = "{\"ts_field\":" + epochMicros + "}";
+      String metadata = "STRUCT<ts_field:TIMESTAMP>";
+
+      DatabricksStruct struct =
+          new ComplexDataTypeParser().parseJsonStringToDbStruct(json, metadata);
+      Object value = struct.getAttributes()[0];
+
+      assertTrue(value instanceof Timestamp);
+      assertEquals(Timestamp.valueOf("2017-03-26 01:01:02.345"), value);
+      assertEquals("2017-03-26 01:01:02.345", value.toString());
+    } finally {
+      TimeZone.setDefault(originalTimeZone);
+    }
+  }
+
+  /** Same fix applies to TIMESTAMP elements inside an ARRAY. */
+  @Test
+  public void testArrayTimestampFromEpochMicrosIsNotTimezoneShifted() throws SQLException {
+    TimeZone originalTimeZone = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Bogota"));
+
+      long epochMicros = Instant.parse("2017-03-26T01:01:02.345Z").toEpochMilli() * 1_000L;
+      String json = "[" + epochMicros + "]";
+      String metadata = "ARRAY<TIMESTAMP>";
+
+      DatabricksArray array = new ComplexDataTypeParser().parseJsonStringToDbArray(json, metadata);
+      Object value = ((Object[]) array.getArray())[0];
+
+      assertTrue(value instanceof Timestamp);
+      assertEquals(Timestamp.valueOf("2017-03-26 01:01:02.345"), value);
+      assertEquals("2017-03-26 01:01:02.345", value.toString());
+    } finally {
+      TimeZone.setDefault(originalTimeZone);
+    }
   }
 }


### PR DESCRIPTION
## Problem

With `EnableComplexDatatypeSupport=1`, retrieving a TIMESTAMP field nested inside a complex type (STRUCT/ARRAY/MAP) returned a timezone-shifted value, while scalar TIMESTAMP retrieval was correct.

For example, on a JVM with a UTC-5 default timezone, a scalar timestamp returned `2017-03-26 01:01:02.345` (correct), but the same value inside a STRUCT returned `2017-03-25 20:01:02.345` (a -5h shift). Both `getString()` and `getObject()` were affected.

## Root cause

Arrow serializes nested TIMESTAMP fields as epoch microseconds. `ComplexDataTypeParser.convertPrimitive()` built the value with `Timestamp.from(instant)`, which anchors an absolute instant. `getString()`/`getObject()` then re-render it in the JVM default timezone, producing the offset. The scalar path (`ArrowToJavaObjectConverter.convertToTimestamp`) avoids this by rebuilding a `LocalDateTime` and using `Timestamp.valueOf(...)`, so the JVM zone cancels out on render.

## Fix

Build the `Timestamp` from the UTC wall-clock (`Timestamp.valueOf(LocalDateTime.ofInstant(instant, ZoneOffset.UTC))`), mirroring the scalar path. Since `convertPrimitive()` is shared by struct/array/map parsing, this fixes nested timestamps in all three.

This is a no-op for UTC JVMs (where `Timestamp.from` already produced the correct result), so there is no regression for the previously-correct case.

## Tests

Added unit tests for the STRUCT and ARRAY paths that force a non-UTC JVM default timezone (`America/Bogota`, UTC-5, no DST) and assert no shift. Verified they fail against the old code (`expected: <2017-03-26 01:01:02.345> but was: <2017-03-25 20:01:02.345>`) and pass with the fix.

This pull request and its description were written by Isaac.