### PR TITLE
Fix supportsBatchUpdates() to honor EnableBatchedInserts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.
+- Fixed `DatabricksDatabaseMetaData.supportsBatchUpdates()` always returning `false`, which caused batch-aware JDBC clients (e.g. Apache Hop) to skip `executeBatch()` and fall back to one INSERT per row. It now returns `true` when `EnableBatchedInserts=1`, so those clients use the optimized multi-row INSERT path.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaData.java
@@ -1278,7 +1278,9 @@ public class DatabricksDatabaseMetaData implements DatabaseMetaData {
   public boolean supportsBatchUpdates() throws SQLException {
     LOGGER.debug("public boolean supportsBatchUpdates()");
     throwExceptionIfConnectionIsClosed();
-    return false;
+    // Advertise batch support only when the multi-row INSERT optimization is enabled, so
+    // batch-aware clients use executeBatch() instead of one executeUpdate() per row.
+    return session.getConnectionContext().isBatchedInsertsEnabled();
   }
 
   @Override

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksDatabaseMetaDataTest.java
@@ -95,9 +95,19 @@ public class DatabricksDatabaseMetaDataTest {
   }
 
   @Test
-  public void supportsBatchUpdates_returnsFalse() throws Exception {
+  public void supportsBatchUpdates_returnsFalseByDefault() throws Exception {
+    // Default EnableBatchedInserts=0, so batch support is not advertised
     boolean supportsBatchUpdates = metaData.supportsBatchUpdates();
     assertFalse(supportsBatchUpdates);
+  }
+
+  @Test
+  public void supportsBatchUpdates_returnsTrueWhenBatchedInsertsEnabled() throws Exception {
+    String urlWithBatchedInserts = WAREHOUSE_JDBC_URL + ";EnableBatchedInserts=1";
+    when(session.getConnectionContext())
+        .thenReturn(DatabricksConnectionContext.parse(urlWithBatchedInserts, new Properties()));
+    boolean supportsBatchUpdates = metaData.supportsBatchUpdates();
+    assertTrue(supportsBatchUpdates);
   }
 
   @Test


### PR DESCRIPTION
## Summary

`DatabricksDatabaseMetaData.supportsBatchUpdates()` was hard-coded to return `false`. Batch-aware JDBC clients (e.g. Apache Hop) call this method *before* batching; when it returns `false` they never call `executeBatch()` and instead fall back to one `executeUpdate()` per row. As a result, the multi-row INSERT optimization gated by `EnableBatchedInserts` (added in #944) never runs — even when the customer explicitly sets `EnableBatchedInserts=1`.

This PR makes `supportsBatchUpdates()` return `true` when `EnableBatchedInserts=1`, so batch-aware clients take the optimized `executeBatch()` path.

Fixes ES-1963495.

## Why gate on `EnableBatchedInserts` rather than return `true` unconditionally

- **Zero change for existing users.** With the flag off (the default), the method still returns `false`, so default behavior is untouched. This preserves the deliberate "safe rollout" posture chosen in #944.
- **Advertises support exactly when batching actually engages.** With the flag on, `executeBatch()` routes INSERTs through the optimized multi-row path; the metadata answer now matches real behavior.
- **Consistent with existing code.** `supportsTransactions()` in the same class is already derived from a connection parameter (`IgnoreTransactions`), so a context-driven capability method is an established pattern here.

## Spec / conformance notes

- The JDBC spec states batch support is optional, but *if* a driver supports it, `supportsBatchUpdates()` must return `true`. The driver does implement a working `executeBatch()` (it handles all DML types; only INSERTs are optimized, others fall back to per-row), so `true` is the conformant value.
- The spec imposes no per-statement-type requirement and does not require atomicity — non-atomic, app-managed (auto-commit) batches are the expected model. INSERT-only optimization does not preclude returning `true`.
- This matches MySQL Connector/J and PostgreSQL pgjdbc, which both return `true` while gating their multi-row INSERT rewrite behind a separate flag (`rewriteBatchedStatements` / `reWriteBatchedInserts`, both default-off).

## Changes

- `DatabricksDatabaseMetaData.supportsBatchUpdates()` returns `isBatchedInsertsEnabled()` instead of `false`.
- Added test `supportsBatchUpdates_returnsTrueWhenBatchedInsertsEnabled`; renamed the existing case to `supportsBatchUpdates_returnsFalseByDefault`.
- `NEXT_CHANGELOG.md` entry under `### Fixed`.

## Testing

`mvn test -pl jdbc-core -Dtest=DatabricksDatabaseMetaDataTest` → 249 run, 0 failures, 0 skipped (both new/updated cases included).
