### PR TITLE
Redact access token before logging in setClientInfoProperty

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Updated
 
 ### Fixed
+- Fixed access token exposure in DEBUG logs.
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
@@ -326,15 +326,15 @@ public class DatabricksSession implements IDatabricksSession {
 
   @Override
   public void setClientInfoProperty(String name, String value) {
+    if (name.equalsIgnoreCase(DatabricksJdbcUrlParams.AUTH_ACCESS_TOKEN.getParamName())) {
+      // refresh the access token if provided a new value in client info
+      this.databricksClient.resetAccessToken(value);
+      value = REDACTED_TOKEN; // mask access token before it is logged
+    }
     LOGGER.debug(
         String.format(
             "public void setClientInfoProperty(String name = {%s}, String value = {%s})",
             name, value));
-    if (name.equalsIgnoreCase(DatabricksJdbcUrlParams.AUTH_ACCESS_TOKEN.getParamName())) {
-      // refresh the access token if provided a new value in client info
-      this.databricksClient.resetAccessToken(value);
-      value = REDACTED_TOKEN; // mask access token
-    }
 
     // If application name is being set, update both telemetry and user agent
     if (name.equalsIgnoreCase(DatabricksJdbcUrlParams.APPLICATION_NAME.getParamName())) {


### PR DESCRIPTION
## Summary

Reorders `DatabricksSession.setClientInfoProperty` so the access-token redaction happens **before** the DEBUG trace line, preventing the token value from being written to logs. The real token is still passed to `resetAccessToken` for rotation.

## Changes
- `DatabricksSession`: move the token-handling block above the `LOGGER.debug` call; the logged value is now masked to `****`.

## Testing
- Manually verified the change against a live SQL warehouse (raw token no longer appears in the DEBUG log; `****` is logged instead).

Full detail tracked privately in the associated security ticket.

This pull request and its description were written by Isaac.