### PR TITLE
Bump Databricks SDK for Java from 0.106.0 to 0.118.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Updated
+- Bumped the Databricks SDK for Java dependency from `0.106.0` to `0.118.0`.
 
 ### Fixed
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration.version>2.15.0</commons-configuration.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <databricks-sdk.version>0.106.0</databricks-sdk.version>
+    <databricks-sdk.version>0.118.0</databricks-sdk.version>
     <httpclient.version>4.5.14</httpclient.version>
     <async-httpclient.version>5.5.2</async-httpclient.version>
     <httpcore5.version>5.3.6</httpcore5.version>


### PR DESCRIPTION
## Summary

Bumps the `databricks-sdk-java` dependency from `0.106.0` to `0.118.0` (`databricks-sdk.version` in `pom.xml`).

## Changes
- `pom.xml`: `databricks-sdk.version` `0.106.0` → `0.118.0`
- `NEXT_CHANGELOG.md`: added an entry under `### Updated`

## Testing
- `mvn clean install -DskipTests` builds green against 0.118.0 across all reactor modules.
- Full `mvn test` suite was run locally; relying on CI for the authoritative result.