### PR TITLE
Redact Azure and GCS presigned URL credentials in logs

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Updated
 
 ### Fixed
+- Fixed presigned URL credentials not being fully redacted in logs.
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/http/RequestSanitizer.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/http/RequestSanitizer.java
@@ -3,11 +3,25 @@ package com.databricks.jdbc.dbclient.impl.http;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.http.client.methods.HttpUriRequest;
 
 public class RequestSanitizer {
-  private static final List<String> SENSITIVE_QUERY_PARAMS =
-      List.of("X-Amz-Security-Token", "X-Amz-Signature", "X-Amz-Credential");
+  // Signature/credential params in AWS, Azure (sig) and GCS presigned URLs.
+  private static final Set<String> SENSITIVE_QUERY_PARAMS =
+      new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+  static {
+    SENSITIVE_QUERY_PARAMS.addAll(
+        List.of(
+            "X-Amz-Security-Token",
+            "X-Amz-Signature",
+            "X-Amz-Credential",
+            "sig",
+            "X-Goog-Signature",
+            "X-Goog-Credential"));
+  }
 
   public static String sanitizeRequest(HttpUriRequest request) {
     try {

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/http/RequestSanitizerTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/http/RequestSanitizerTest.java
@@ -26,6 +26,41 @@ public class RequestSanitizerTest {
   }
 
   @Test
+  public void testSanitizeRequest_withAzureSasSignature() {
+    String originalUri =
+        "https://acct.blob.core.windows.net/c/chunk.arrow?sv=2021-08-06&se=2026-06-18T00:00Z&sr=b&sp=r&sig=secretSasSignature";
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(new HttpGet(originalUri));
+
+    // sig (the SAS credential) is redacted; non-secret metadata is preserved.
+    String expectedUri =
+        "https://acct.blob.core.windows.net/c/chunk.arrow?sv=2021-08-06&se=2026-06-18T00:00Z&sr=b&sp=r&sig=REDACTED";
+    assertEquals(expectedUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withGcsV4Signature() {
+    String originalUri =
+        "https://storage.googleapis.com/bucket/chunk.arrow?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=svc&X-Goog-Signature=secretSig";
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(new HttpGet(originalUri));
+
+    String expectedUri =
+        "https://storage.googleapis.com/bucket/chunk.arrow?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=REDACTED&X-Goog-Signature=REDACTED";
+    assertEquals(expectedUri, sanitizedUri);
+  }
+
+  @Test
+  public void testSanitizeRequest_withLowercaseGcsSignature() {
+    // GCS tooling may emit lowercase param names; matching must be case-insensitive.
+    String originalUri =
+        "https://storage.googleapis.com/bucket/chunk.arrow?x-goog-credential=svc&x-goog-signature=secretSig";
+    String sanitizedUri = RequestSanitizer.sanitizeRequest(new HttpGet(originalUri));
+
+    String expectedUri =
+        "https://storage.googleapis.com/bucket/chunk.arrow?x-goog-credential=REDACTED&x-goog-signature=REDACTED";
+    assertEquals(expectedUri, sanitizedUri);
+  }
+
+  @Test
   public void testSanitizeRequest_withNoSensitiveParams() {
     String originalUri = "https://example.com/api?param1=value1&param2=value2";
     HttpUriRequest request = new HttpGet(originalUri);


### PR DESCRIPTION
## Summary

`RequestSanitizer` previously redacted only three AWS query parameters, and matched them case-sensitively. As a result, presigned URLs for other cloud backends were logged with their credentials intact. This extends redaction to cover the signature/credential parameters of all supported clouds and matches them case-insensitively.

## Changes
- `RequestSanitizer`: add Azure and GCS signature/credential query params to the redaction set; switch the lookup to case-insensitive (`TreeSet` with `String.CASE_INSENSITIVE_ORDER`).
- Added regression tests for Azure, GCS, and a lowercase-cased variant. Existing AWS behavior is unchanged; non-secret metadata params remain visible.

## Testing
- `RequestSanitizerTest` — all pass (8 tests).
- Manually verified against representative presigned URLs (signatures redacted, metadata preserved).

Full detail tracked privately in the associated security ticket.

This pull request and its description were written by Isaac.