### PR TITLE
Surface truncated flag from SEA result manifest

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -44,6 +45,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
   private final long totalRows;
   private Long chunkCount;
   private final boolean isCloudFetchUsed;
+  private final boolean truncated;
 
   /**
    * Constructs a {@code DatabricksResultSetMetaData} object for a SEA result set.
@@ -144,6 +146,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.totalRows = resultManifest.getTotalRowCount();
     this.chunkCount = resultManifest.getTotalChunkCount();
     this.isCloudFetchUsed = usesExternalLinks;
+    this.truncated = Objects.requireNonNullElse(resultManifest.getTruncated(), false);
   }
 
   /**
@@ -260,6 +263,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.totalRows = rows;
     this.chunkCount = chunkCount;
     this.isCloudFetchUsed = getIsCloudFetchFromManifest(resultManifest);
+    this.truncated = false;
   }
 
   /**
@@ -309,6 +313,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
+    this.truncated = false;
   }
 
   /**
@@ -361,6 +366,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
+    this.truncated = false;
   }
 
   /**
@@ -419,6 +425,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
     this.totalRows = totalRows;
     this.isCloudFetchUsed = false;
+    this.truncated = false;
   }
 
   /**
@@ -487,6 +494,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
     }
     this.statementId = statementId;
     this.isCloudFetchUsed = false;
+    this.truncated = false;
     this.totalRows = -1;
     this.columns = columnsBuilder.build();
     this.columnNameIndex = CaseInsensitiveImmutableMap.copyOf(columnNameToIndexMap);
@@ -637,6 +645,10 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
 
   private boolean getIsCloudFetchFromManifest(TGetResultSetMetadataResp resultManifest) {
     return resultManifest.getResultFormat() == TSparkRowSetType.URL_BASED_SET;
+  }
+
+  public boolean getIsTruncated() {
+    return truncated;
   }
 
   public Long getChunkCount() {

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -468,6 +468,7 @@ public class DatabricksResultSetMetaDataTest {
     } else {
       assertFalse(metaData.getIsCloudFetchUsed());
     }
+    assertFalse(metaData.getIsTruncated());
   }
 
   @Test
@@ -481,6 +482,26 @@ public class DatabricksResultSetMetaDataTest {
     metaData =
         new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
     assertFalse(metaData.getIsCloudFetchUsed());
+  }
+
+  @Test
+  public void testSdkTruncated() {
+    ResultManifest resultManifest = getResultManifest();
+    resultManifest.setTruncated(null);
+
+    DatabricksResultSetMetaData metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, true, connectionContext);
+    assertFalse(metaData.getIsTruncated());
+
+    resultManifest.setTruncated(true);
+    metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
+    assertTrue(metaData.getIsTruncated());
+
+    resultManifest.setTruncated(false);
+    metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
+    assertFalse(metaData.getIsTruncated());
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/SqlExecApiHybridResultsIntegrationTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/fakeservice/tests/SqlExecApiHybridResultsIntegrationTests.java
@@ -52,6 +52,7 @@ public class SqlExecApiHybridResultsIntegrationTests extends AbstractFakeService
       assertEquals(maxRows, metaData.getTotalRows());
       // For small query, arrow results are received inline in hybrid mode
       assertFalse(metaData.getIsCloudFetchUsed());
+      assertFalse(metaData.getIsTruncated());
 
       // For small query, arrow results are received inline in hybrid mode so no cloud fetch calls
       // are made
@@ -93,6 +94,7 @@ public class SqlExecApiHybridResultsIntegrationTests extends AbstractFakeService
       assertEquals(maxRows, metaData.getTotalRows());
       // For large query, arrow results are fetched using cloud fetch
       assertTrue(metaData.getIsCloudFetchUsed());
+      assertFalse(metaData.getIsTruncated());
 
       // The number of cloud fetch calls should be equal to the number of chunks
       final int cloudFetchCalls =


### PR DESCRIPTION
## Summary
- Propagate the `truncated` field from the SEA `ResultManifest` into `DatabricksResultSetMetaData` via a new `getIsTruncated()` accessor, allowing callers to detect when query results have been truncated by the server.
- Defaults to `false` for all Thrift and non-SEA code paths.
- Based on community contribution from PR #1351 by @tom-s-powell — applied cleanly on latest `main` with all errors resolved.

## Test plan
- [x] Unit test `testSdkTruncated` covers null, true, and false values from the manifest
- [x] Existing `testGetDispositionThrift` extended to assert `getIsTruncated() == false` for Thrift paths
- [x] Integration tests (`SqlExecApiHybridResultsIntegrationTests`) assert `getIsTruncated() == false` for both inline and CloudFetch hybrid result paths
- [x] All tests pass locally

NO_CHANGELOG=true

This pull request was co-authored by Isaac.