### PR TITLE
Use shared setup-maven action in Security Scan workflow

### DIFF
--- a/.github/workflows/securityScan.yml
+++ b/.github/workflows/securityScan.yml
@@ -61,60 +61,24 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
 
-      # JFrog OIDC + maven proxy: skipped on fork PRs (no OIDC token from
-      # GitHub's perspective). Fork PRs still work because all of the
-      # driver's direct dependencies are published to public Maven Central
-      # (verified against jdbc-core/pom.xml); without ~/.m2/settings.xml,
-      # Maven falls through to Central directly. JFrog is just a faster
-      # mirror, not a source of any artifact the build genuinely needs.
-      - name: Get JFrog OIDC token
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Check if fork
+        id: fork-check
+        shell: bash
         run: |
-          set -euo pipefail
-
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "This is a forked PR — will use cached dependencies"
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+            echo "This is a same-repo PR or push — will use JFrog OIDC"
           fi
 
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-
-      - name: Configure maven
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << EOF
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>jfrog-central</id>
-                <mirrorOf>*</mirrorOf>
-                <url>https://databricks.jfrog.io/artifactory/db-maven/</url>
-              </mirror>
-            </mirrors>
-            <servers>
-              <server>
-                <id>jfrog-central</id>
-                <username>gha-service-account</username>
-                <password>${JFROG_ACCESS_TOKEN}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          is-fork: ${{ steps.fork-check.outputs.is_fork }}
 
       # Build the project to produce the cyclonedx aggregate SBOM that OSV
       # will scan. -Ddependency-check.skip=true because the OWASP plugin


### PR DESCRIPTION
## Summary
- Replace inline JFrog OIDC + Maven proxy setup in `securityScan.yml` with the shared `.github/actions/setup-maven` composite action, consistent with `prCheck.yml`, `coverageReport.yml`, `prIntegrationTests.yml`, and all other workflows.
- The inline setup diverged from the shared action: when proxy steps were skipped (fork PRs), Maven fell through to `repo.maven.apache.org` which is now blocked by supply chain security policy, causing the build step to fail.
- Also removes the redundant `cache: maven` from `setup-java` since `setup-maven` handles cache restoration.

## Test plan
- [ ] Security Scan CI passes on this PR (Maven resolves through JFrog proxy)
- [ ] Verify scheduled/manual dispatch triggers still work (non-fork path uses JFrog OIDC)

NO_CHANGELOG=true

This pull request and its description were written by Isaac.