### PR TITLE
Fix MAP columns dropping complex values with EnableArrow=1 (#1505)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Updated
 
 ### Fixed
+- Fixed `MAP` columns whose values are complex types (`ARRAY`/`STRUCT`/`MAP`) returning empty values (e.g. `{0:}` instead of `{0:[34277,0]}`) with `EnableArrow=1` when complex datatype support is disabled. The string formatter now reproduces nested values correctly; null nested values inside maps and arrays are also handled (#1505).
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.

--- a/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
@@ -337,10 +337,17 @@ public class ComplexDataTypeParser {
     try {
       JsonNode node = JsonUtil.getMapper().readTree(jsonString);
       if (node.isArray() && node.size() > 0 && node.get(0).has("key")) {
-        String[] kv = new String[] {"STRING", "STRING"};
+        // When the MAP type metadata is available, delegate to the recursive typed parser so
+        // that nested complex values (ARRAY/STRUCT/MAP) are formatted correctly. The
+        // hand-rolled loop below calls JsonNode.asText(), which returns "" for container nodes
+        // and therefore drops nested values (issue #1505). DatabricksMap#toString reproduces
+        // the same {key:value} output for scalar maps.
         if (mapMetadata != null && mapMetadata.startsWith(DatabricksTypeUtil.MAP)) {
-          kv = MetadataParser.parseMapMetadata(mapMetadata).split(",", 2);
+          return parseToMap(node, mapMetadata).toString();
         }
+
+        // Fallback for missing/non-MAP metadata: treat keys and values as strings.
+        String[] kv = new String[] {"STRING", "STRING"};
 
         String keyType = kv[0].trim();
         String valueType = kv[1].trim();

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksArray.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksArray.java
@@ -48,6 +48,10 @@ public class DatabricksArray implements Array {
 
     for (int i = 0; i < elements.size(); i++) {
       Object element = elements.get(i);
+      if (element == null) {
+        convertedElements[i] = null;
+        continue;
+      }
       try {
         if (elementType.startsWith(DatabricksTypeUtil.STRUCT)) {
           if (element instanceof Map) {

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksMap.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksMap.java
@@ -69,6 +69,9 @@ public class DatabricksMap<K, V> implements Map<K, V> {
    * @return the converted value
    */
   private V convertValue(V value, String valueType) {
+    if (value == null) {
+      return null;
+    }
     try {
       LOGGER.debug("Converting value of type: {}", valueType);
       if (valueType.startsWith(DatabricksTypeUtil.STRUCT)) {

--- a/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeParserTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeParserTest.java
@@ -413,4 +413,63 @@ public class ComplexDataTypeParserTest {
     String result = parser.formatMapString(jsonString, "MAP<STRING,INT>");
     assertEquals(expected, result);
   }
+
+  /**
+   * Regression test for issue #1505: when complex datatype support is disabled, a map whose values
+   * are arrays previously rendered the value as empty (e.g. {@code {0:}}) because the formatter
+   * called {@code JsonNode.asText()} on the array node, which returns "".
+   */
+  @Test
+  void testFormatMapString_withIntKeyAndArrayValue() {
+    String jsonString = "[{\"key\":0,\"value\":[34277,0]}]";
+    String expected = "{0:[34277,0]}";
+
+    String result = parser.formatMapString(jsonString, "MAP<INT,ARRAY<BIGINT>>");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatMapString_withStringKeyAndArrayValues() {
+    String jsonString = "[{\"key\":\"arr1\",\"value\":[1,2]},{\"key\":\"arr2\",\"value\":[3,4,5]}]";
+    String expected = "{\"arr1\":[1,2],\"arr2\":[3,4,5]}";
+
+    String result = parser.formatMapString(jsonString, "MAP<STRING,ARRAY<INT>>");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatMapString_withStructValue() {
+    String jsonString = "[{\"key\":\"k\",\"value\":{\"a\":1,\"b\":\"x\"}}]";
+    String expected = "{\"k\":{\"a\":1,\"b\":\"x\"}}";
+
+    String result = parser.formatMapString(jsonString, "MAP<STRING,STRUCT<a:INT,b:STRING>>");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatMapString_withNestedMapValue() {
+    String jsonString = "[{\"key\":0,\"value\":[{\"key\":\"a\",\"value\":1}]}]";
+    String expected = "{0:{\"a\":1}}";
+
+    String result = parser.formatMapString(jsonString, "MAP<INT,MAP<STRING,INT>>");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatMapString_withNullComplexValue() {
+    String jsonString = "[{\"key\":0,\"value\":null}]";
+    String expected = "{0:null}";
+
+    String result = parser.formatMapString(jsonString, "MAP<INT,ARRAY<INT>>");
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFormatComplexTypeString_withMapOfArrays() {
+    String jsonString = "[{\"key\":0,\"value\":[34277,0]}]";
+    String expected = "{0:[34277,0]}";
+
+    String result = parser.formatComplexTypeString(jsonString, "MAP", "MAP<INT,ARRAY<BIGINT>>");
+    assertEquals(expected, result);
+  }
 }

--- a/src/test/java/com/databricks/jdbc/integration/e2e/ComplexTypeQueryTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/e2e/ComplexTypeQueryTests.java
@@ -320,8 +320,14 @@ public class ComplexTypeQueryTests {
         Object obj = rs.getObject("mapOfArrays");
         assertTrue(obj instanceof String);
         String text = (String) obj;
-        assertTrue(text.contains("arr1"));
-        assertTrue(text.contains("3"));
+        // Both keys and every array element must survive. Issue #1505 dropped the array
+        // values entirely on the Arrow path (e.g. "{arr1:,arr2:}"); 3, 4 and 5 only appear
+        // inside the array values, so their presence guards against that regression.
+        assertTrue(text.contains("arr1"), text);
+        assertTrue(text.contains("arr2"), text);
+        assertTrue(text.contains("3"), text);
+        assertTrue(text.contains("4"), text);
+        assertTrue(text.contains("5"), text);
       }
     }
   }


### PR DESCRIPTION
## Summary

With `EnableArrow=1` (and complex datatype support disabled, which is the default), selecting a `MAP` column whose values are complex types returned malformed data — the map **value** was dropped while the key survived:

```
SELECT MAP(0, ARRAY(34277,0))
-- expected: {0:[34277,0]}
-- actual:   {0:}
```

With `EnableArrow=0` the server returns the value pre-formatted as a string, so only the Arrow path was affected.

## Root cause

When complex datatype support is disabled, `ArrowStreamResult.getObjectWithComplexTypeHandling` reads the map as raw Arrow JSON (entry-array form, e.g. `[{"key":0,"value":[34277,0]}]`) and formats it via `ComplexDataTypeParser.formatMapString`. That hand-rolled formatter called `JsonNode.asText()` on the value node, which returns `""` for any container (array/object) node — so array/struct/nested-map values were rendered empty.

## Fix

Delegate map formatting to the **existing recursive** parser: `parseToMap(node, mapMetadata).toString()`. `parseToMap` builds a `DatabricksMap` whose nested values are recursively converted to `DatabricksArray` / `DatabricksMap` / `DatabricksStruct`, and their `toString()` methods already emit the canonical `{key:value}` / `[a,b]` format. This:

- Produces `{0:[34277,0]}` for the reported case.
- Reproduces byte-for-byte identical output for scalar maps (verified against all existing `formatMapString` tests).
- Covers **all** map-rooted columns with arbitrary nesting (arrays, structs, nested maps, deep nesting).

Also hardened `DatabricksMap.convertValue` and `DatabricksArray.convertElements` against `null` nested values (previously threw an NPE on `value.getClass()`), so e.g. a null array value in a map now renders as `null`.

## Scope / follow-up

Scoped to MAP-rooted columns (the reported bug). Top-level `ARRAY`/`STRUCT` columns whose elements/fields are themselves maps still pass through raw Arrow output — a separate latent gap that can be addressed in a follow-up if desired.

## Test plan

- New unit tests in `ComplexDataTypeParserTest` covering the exact repro plus map-of-arrays, map-of-struct, nested-map, and null-complex-value cases, and the existing scalar-map regressions.
- Strengthened the disabled-support assertions in the `testMapOfArrays` e2e test so dropped array values would be caught.
- `mvn test -pl jdbc-core` passes (3493 run; the single unrelated failure is a pre-existing DST/timezone test, `Slf4jFormatterTest`, expecting `EST` for a June date). `spotless:check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
