### PR TITLE
Bump shaded jackson 2.18.7 to 2.18.8 to fix CVE-2026-54512 and CVE-2026-54513 in uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <httpcore5.version>5.3.6</httpcore5.version>
     <thrift.version>0.23.0</thrift.version>
     <slf4j.version>2.0.13</slf4j.version>
-    <jackson.version>2.18.7</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <gson.version>2.13.2</gson.version>
     <google.guava.version>33.0.0-jre</google.guava.version>
     <google.findbugs.annotations.version>3.0.1</google.findbugs.annotations.version>


### PR DESCRIPTION
## Summary
- Bumps shaded `jackson.version` 2.18.7 → 2.18.8 to fix CVE-2026-54512 and CVE-2026-54513 (`PolymorphicTypeValidator` bypass) bundled in the uber jar.
- `jackson-databind`/`jackson-core`/`jackson-annotations` are relocated under `com.databricks.internal.fasterxml` in the uber jar, so consumers cannot override them via Maven dependency management — the bump must happen at the source.
- Patch-level upgrade within the 2.18.x line; no API changes.

## Relationship to #1485
Dependabot #1485 bumps the same property to **2.22** (a minor-version upgrade, currently open). This PR is the **minimal security patch** (2.18.8) that targets only CVE-2026-54512 / CVE-2026-54513, for a low-risk, fast-to-review fix. Maintainers can take whichever they prefer.

## Test plan
- [x] `mvn -pl assembly-uber -am package -DskipTests` builds clean
- [x] uber jar bundles relocated `jackson-databind` 2.18.8 (verified via `META-INF/.../pom.properties` and class paths under `com/databricks/internal/fasterxml/jackson/databind`)
- [ ] CI unit tests pass

NO_CHANGELOG=true
