### PR TITLE
Stream CloudFetch chunk decompression to bound memory and prevent OOM on large results

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/ArrowResultChunk.java
@@ -101,15 +101,16 @@ public class ArrowResultChunk extends AbstractArrowResultChunk {
           chunkLink.getExternalLink(),
           speedThreshold);
 
-      // Decompress (if needed) and parse
+      // Decompress and parse. The decompression is streamed straight into the Arrow reader so the
+      // full decompressed payload is never materialized on-heap alongside the compressed bytes.
       long decompressStart = System.nanoTime();
       try {
         String ctx =
             String.format(
                 "Data decompression for chunk index [%d] and statement [%s]",
                 this.chunkIndex, this.statementId);
-        InputStream data = DecompressionUtil.decompressToStream(compressed, compressionCodec, ctx);
-        initializeData(data);
+        initializeData(
+            DecompressionUtil.decompressToInputStream(compressed, compressionCodec, ctx));
       } catch (Exception e) {
         handleFailure(e, ChunkStatus.PROCESSING_FAILED);
       }

--- a/src/main/java/com/databricks/jdbc/common/util/DecompressionUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DecompressionUtil.java
@@ -53,11 +53,24 @@ public class DecompressionUtil {
     }
   }
 
-  public static InputStream decompressToStream(
+  /**
+   * Returns a stream that decompresses {@code compressedInput} lazily as it is read, so the full
+   * decompressed payload is never materialized alongside the compressed bytes. Only LZ4_FRAME is
+   * wrapped in a decompressing decorator; a {@code null}/NONE codec returns the raw bytes as-is.
+   *
+   * <p>Any {@link IOException} from constructing the LZ4 decoder propagates to the caller ({@code
+   * ArrowResultChunk.downloadData}), which handles it as a chunk-processing failure — the same
+   * terminal path as any other decompression error.
+   */
+  public static InputStream decompressToInputStream(
       byte[] compressedInput, CompressionCodec compressionCodec, String context)
-      throws DatabricksSQLException {
-    byte[] uncompressed = decompress(compressedInput, compressionCodec, context);
-    return new ByteArrayInputStream(uncompressed);
+      throws IOException {
+    if (compressionCodec == CompressionCodec.LZ4_FRAME) {
+      LOGGER.debug("Streaming LZ4 Frame decompression. Context: {}", context);
+      return new LZ4FrameInputStream(new ByteArrayInputStream(compressedInput));
+    }
+    // null / NONE codec: no decompression needed.
+    return new ByteArrayInputStream(compressedInput);
   }
 
   public static InputStream decompress(

--- a/src/test/java/com/databricks/jdbc/common/util/DecompressionUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DecompressionUtilTest.java
@@ -40,6 +40,49 @@ public class DecompressionUtilTest {
   }
 
   @Test
+  public void testDecompressToInputStreamLZ4Frame() throws Exception {
+    byte[] uncompressed = INITIAL_STRING.getBytes();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (LZ4FrameOutputStream lz4 = new LZ4FrameOutputStream(out)) {
+      lz4.write(uncompressed);
+    }
+    InputStream resultStream =
+        DecompressionUtil.decompressToInputStream(
+            out.toByteArray(), CompressionCodec.LZ4_FRAME, CONTEXT);
+    assertTrue(
+        IOUtils.contentEquals(resultStream, new ByteArrayInputStream(uncompressed)),
+        "Streaming decompression should yield the original bytes");
+  }
+
+  @Test
+  public void testDecompressToInputStreamNoneReturnsRawBytes() throws Exception {
+    byte[] raw = INITIAL_STRING.getBytes();
+    InputStream resultStream =
+        DecompressionUtil.decompressToInputStream(raw, CompressionCodec.NONE, CONTEXT);
+    assertTrue(IOUtils.contentEquals(resultStream, new ByteArrayInputStream(raw)));
+  }
+
+  @Test
+  public void testDecompressToInputStreamNullCodecReturnsRawBytes() throws Exception {
+    // A null codec is treated as no compression: the raw bytes are returned unchanged.
+    byte[] raw = INITIAL_STRING.getBytes();
+    InputStream resultStream = DecompressionUtil.decompressToInputStream(raw, null, CONTEXT);
+    assertTrue(IOUtils.contentEquals(resultStream, new ByteArrayInputStream(raw)));
+  }
+
+  @Test
+  public void testDecompressToInputStreamMalformedLz4FailsOnRead() throws Exception {
+    // LZ4FrameInputStream validates the frame lazily as it is read, so decompressToInputStream
+    // returns the streaming decorator successfully and the IOException surfaces on read. The
+    // caller (ArrowResultChunk.downloadData) catches it and routes it through handleFailure.
+    byte[] notLz4 = "this-is-not-a-valid-lz4-frame-payload".getBytes();
+    InputStream resultStream =
+        DecompressionUtil.decompressToInputStream(notLz4, CompressionCodec.LZ4_FRAME, CONTEXT);
+    assertNotNull(resultStream, "A streaming decorator should be returned before any read");
+    assertThrows(IOException.class, () -> IOUtils.toByteArray(resultStream));
+  }
+
+  @Test
   public void testDecompressLZ4FrameSkipsCompression() throws Exception {
     assertEquals(
         decompressionUtil.decompress(compressedInputStream, CompressionCodec.NONE, CONTEXT),


### PR DESCRIPTION
## Summary

Fixes #1508.

Downloading a large query result via CloudFetch on the 3.x driver could exhaust the JVM heap and throw `java.lang.OutOfMemoryError: Java heap space` (surfaced as `Failed to ready chunk` / `Download failed for chunk index 0`), where the 2.x driver succeeded at the same heap. This was a 2.x → 3.x regression.

## Root cause

The `OutOfMemoryError` is on-heap. Each chunk was decompressed by materializing the **entire decompressed Arrow payload into an on-heap `byte[]`** (several times the compressed size) before parsing. With up to `cloudFetchThreadPoolSize` (default 16) chunks decompressing in parallel, transient on-heap usage scaled with download concurrency rather than with available heap.

(The parsed Arrow vectors themselves are off-heap, so they were not the cause — the transient on-heap decompression buffers were.)

## Fix

**Streamed decompression.** Decompression is now streamed directly into the Arrow reader via `DecompressionUtil.decompressToInputStream` (a lazy `LZ4FrameInputStream`), so the decompressed payload is never materialized on-heap alongside the compressed bytes. Peak per-chunk on-heap cost drops from `compressed + full-decompressed` to `compressed + one LZ4 block`. Chunks are still downloaded, decompressed, and parsed in parallel ahead of consumption — throughput is unaffected.

This is the same `LZ4FrameInputStream` the 2.x Simba driver feeds its decompression through; this change simply pipes it into Arrow instead of buffering the output.

### For constrained heaps

If a workload still hits OOM on a very small heap (many concurrent chunks × per-chunk cost), lower the existing **`cloudFetchThreadPoolSize`** connection property (default 16) to reduce the number of chunks buffered concurrently — this is the memory-vs-throughput lever. No new connection property is introduced.

## Scope note

An earlier revision of this PR also added an in-memory byte-budget scheduler (`cloudFetchMaxBytesInMemory`). It was **removed** after testing showed it was redundant with the existing `cloudFetchThreadPoolSize` limit and its heuristic default did not reliably bind (the manifest reports compressed size, while the OOM is driven by decompressed + parse transients). Streaming decompression is the robust fix; concurrency is already tunable via `cloudFetchThreadPoolSize`.

## Testing

Verified against a SQL warehouse on the issue's 26-column, 169,769-row repro table:

- **Memory:** the unpatched 3.x driver OOMs at `-Xmx128m`; the patched driver streams the full result at `-Xmx128m` (peak ~99 MB), and down to `-Xmx48m` with `cloudFetchThreadPoolSize=1` (peak ~42 MB) — below where the 2.7.5 / 2.8.1 Simba drivers OOM.
- **Correctness:** a cell checksum over the full result is **byte-identical** between the patched driver, the unpatched driver, and the 2.7.5 / 2.8.1 Simba drivers, across SEA/Thrift paths, the LZ4_FRAME and NONE codecs, complex types (struct/array/map, decimal, binary, NULLs), and heap sizes — no truncation or corruption. Verified with a position-sensitive (ordered, chained) row digest.
- **Unit tests:** added streaming-decompression coverage (LZ4 frame + NONE) in `DecompressionUtilTest`; the `jdbc-core` unit suite passes.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.
