### PR TITLE
Fix unbounded growth of closed-connection tracking in client factories

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Updated
 
 ### Fixed
+- Fixed memory leaks where closing connections left per-connection entries (HTTP client tracking and telemetry close-tracking) in static maps that were never reclaimed, causing unbounded growth (and eventual `OutOfMemoryError`) in high-churn/connection-pool scenarios.
 - Fixed `setCatalog()` and `setSchema()` producing invalid SQL (e.g. `SET CATALOG ``name``) when the catalog or schema name was passed already wrapped in backticks. Backticks are now stripped before wrapping, and `getCatalog()`/`getSchema()` return the bare identifier name.
 - Fixed metadata SQL generation for catalog, schema, and table identifiers containing backticks.
 - Fixed SEA result truncation when direct results are disabled. Large, highly-compressible results that span multiple chunks were delivered inline via the old hybrid path and truncated to the first chunk. The SQL Execution path now uses an async (`0s`) wait timeout when direct results are disabled, so results are returned via external links and fetched in full.

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientFactory.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientFactory.java
@@ -9,6 +9,9 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DatabricksHttpClientFactory {
@@ -17,14 +20,20 @@ public class DatabricksHttpClientFactory {
   private static final DatabricksHttpClientFactory INSTANCE = new DatabricksHttpClientFactory();
 
   /**
-   * Maps (connectionUuid, type) → HTTP client. On {@link #closeConnection}, real clients are
-   * replaced with {@link ClosedConnectionHttpClient#INSTANCE} tombstones. {@link #getClient}'s
-   * {@code computeIfAbsent} returns the tombstone for closed connections (key already exists) and
-   * creates a real client for new keys. No parallel sets needed — the closed marker lives in the
-   * map itself, bounded by live (uuid, type) pairs. See issue #1325.
+   * Maps (connectionUuid, type) → live HTTP client. Entries are removed on {@link
+   * #closeConnection}.
    */
   private final ConcurrentHashMap<SimpleEntry<String, HttpClientType>, IDatabricksHttpClient>
       instances = new ConcurrentHashMap<>();
+
+  /**
+   * Connection UUIDs that have been closed. Lets {@link #getClient} return the {@link
+   * ClosedConnectionHttpClient} sentinel instead of recreating a client for a closed connection
+   * (issue #1325). Weak keys: an entry is reclaimed once the connection's UUID becomes unreachable
+   * (the closed connection can no longer be used), so this does not grow without bound.
+   */
+  private final Set<String> closedConnections =
+      Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<String, Boolean>()));
 
   private DatabricksHttpClientFactory() {
     // Private constructor to prevent instantiation
@@ -46,24 +55,33 @@ public class DatabricksHttpClientFactory {
    */
   public IDatabricksHttpClient getClient(
       IDatabricksConnectionContext context, HttpClientType type) {
-    return instances.computeIfAbsent(
-        getClientKey(context.getConnectionUuid(), type),
-        k -> new DatabricksHttpClient(context, type));
+    String uuid = context.getConnectionUuid();
+    if (closedConnections.contains(uuid)) {
+      return ClosedConnectionHttpClient.INSTANCE;
+    }
+    SimpleEntry<String, HttpClientType> key = getClientKey(uuid, type);
+    IDatabricksHttpClient client =
+        instances.computeIfAbsent(key, k -> new DatabricksHttpClient(context, type));
+    if (closedConnections.contains(uuid)) {
+      // Connection was closed concurrently with creation; undo so we don't leak a live client.
+      if (instances.remove(key, client)) {
+        closeQuietly(client);
+      }
+      return ClosedConnectionHttpClient.INSTANCE;
+    }
+    return client;
   }
 
   /**
-   * Permanently closes all HTTP clients for the given connection and replaces them with tombstone
-   * sentinels that reject further use. Called from {@link
-   * com.databricks.jdbc.api.impl.DatabricksConnection#close()}.
+   * Permanently closes all HTTP clients for the given connection, removes their entries, and marks
+   * the connection closed so {@link #getClient} returns the {@link ClosedConnectionHttpClient}
+   * sentinel. Called from {@link com.databricks.jdbc.api.impl.DatabricksConnection#close()}.
    */
   public void closeConnection(IDatabricksConnectionContext context) {
     String uuid = context.getConnectionUuid();
+    closedConnections.add(uuid);
     for (HttpClientType type : HttpClientType.values()) {
-      SimpleEntry<String, HttpClientType> key = getClientKey(uuid, type);
-      IDatabricksHttpClient old = instances.put(key, ClosedConnectionHttpClient.INSTANCE);
-      if (old != null && !(old instanceof ClosedConnectionHttpClient)) {
-        closeQuietly(old);
-      }
+      closeQuietly(instances.remove(getClientKey(uuid, type)));
     }
   }
 
@@ -76,8 +94,9 @@ public class DatabricksHttpClientFactory {
 
   @VisibleForTesting
   public void removeClient(IDatabricksConnectionContext context, HttpClientType type) {
-    IDatabricksHttpClient instance =
-        instances.remove(getClientKey(context.getConnectionUuid(), type));
+    String uuid = context.getConnectionUuid();
+    closedConnections.remove(uuid);
+    IDatabricksHttpClient instance = instances.remove(getClientKey(uuid, type));
     if (instance != null && !(instance instanceof ClosedConnectionHttpClient)) {
       closeQuietly(instance);
     }
@@ -86,13 +105,15 @@ public class DatabricksHttpClientFactory {
   /** Resets all state. For test cleanup only. */
   @VisibleForTesting
   public void reset() {
-    instances.forEach(
-        (key, client) -> {
-          if (!(client instanceof ClosedConnectionHttpClient)) {
-            closeQuietly(client);
-          }
-        });
+    instances.forEach((key, client) -> closeQuietly(client));
     instances.clear();
+    closedConnections.clear();
+  }
+
+  /** Number of live HTTP client entries currently tracked. For test/leak assertions only. */
+  @VisibleForTesting
+  public int liveClientCount() {
+    return instances.size();
   }
 
   private static void closeQuietly(IDatabricksHttpClient client) {

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryClientFactory.java
@@ -11,8 +11,10 @@ import com.databricks.jdbc.telemetry.latency.TelemetryCollector;
 import com.databricks.jdbc.telemetry.latency.TelemetryCollectorManager;
 import com.databricks.sdk.core.DatabricksConfig;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,10 +39,12 @@ public class TelemetryClientFactory {
   /**
    * Tracks connection UUIDs that have been closed. {@link #getTelemetryClient} checks this set and
    * returns {@link NoopTelemetryClient} for closed connections, preventing re-creation of orphaned
-   * TelemetryClients (issue #1325). Growth is bounded by total connections closed over JVM lifetime
-   * (~80 bytes per UUID) — negligible for typical connection pool sizes.
+   * TelemetryClients (issue #1325). Weak keys: an entry is reclaimed once the connection's UUID
+   * becomes unreachable, so this does not grow without bound.
    */
-  @VisibleForTesting final Set<String> closedConnectionUuids = ConcurrentHashMap.newKeySet();
+  @VisibleForTesting
+  final Set<String> closedConnectionUuids =
+      Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<String, Boolean>()));
 
   private final ExecutorService telemetryExecutorService;
   private ScheduledExecutorService sharedSchedulerService;

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClientTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.HttpClientType;
 import com.databricks.jdbc.dbclient.IDatabricksHttpClient;
 import com.databricks.jdbc.exception.DatabricksDriverException;
 import com.databricks.jdbc.exception.DatabricksHttpException;
@@ -307,6 +308,35 @@ public class DatabricksHttpClientTest {
             clientList.get(j),
             "HTTP client instances should be unique per connection");
       }
+    }
+  }
+
+  // SEC-20597: closing connections must not accumulate entries in the static map, while
+  // use-after-close still returns the sentinel (issue #1325).
+  @Test
+  public void testCloseConnectionDoesNotLeakInstances() {
+    DatabricksHttpClientFactory factory = DatabricksHttpClientFactory.getInstance();
+    factory.reset();
+    System.setProperty(IS_FAKE_SERVICE_TEST_PROP, "true");
+    try {
+      int n = 50;
+      for (int i = 0; i < n; i++) {
+        IDatabricksConnectionContext ctx = mock(IDatabricksConnectionContext.class);
+        when(ctx.getConnectionUuid()).thenReturn("leak-uuid-" + i);
+        when(ctx.getHttpMaxConnectionsPerRoute()).thenReturn(100);
+
+        factory.getClient(ctx, HttpClientType.COMMON);
+        factory.closeConnection(ctx);
+
+        // use-after-close still returns the sentinel
+        assertInstanceOf(
+            ClosedConnectionHttpClient.class, factory.getClient(ctx, HttpClientType.COMMON));
+      }
+      // No live-client entries accumulate across many open/close cycles.
+      assertEquals(0, factory.liveClientCount());
+    } finally {
+      System.clearProperty(IS_FAKE_SERVICE_TEST_PROP);
+      factory.reset();
     }
   }
 }


### PR DESCRIPTION
## Summary

`DatabricksHttpClientFactory.closeConnection()` left a tombstone entry per `(uuid, type)` in its static map and never removed it (3 per closed connection), and `TelemetryClientFactory` tracked closed UUIDs in an unbounded set. Both grew without bound in high-churn / connection-pool deployments, eventually causing `OutOfMemoryError`. (The HTTP clients themselves were already closed — what leaked was the per-connection map/set entries.)

## Changes
- `DatabricksHttpClientFactory`: `closeConnection()` now **removes** the live client entries instead of replacing them with tombstones. Closed-connection detection moved to a `WeakHashMap`-backed set keyed by the connection UUID, so entries are reclaimed once the connection is unreachable. `getClient()` returns the `ClosedConnectionHttpClient` sentinel for closed connections, with a guard for the close-during-create race.
- `TelemetryClientFactory`: same `WeakHashMap`-backed set for `closedConnectionUuids` (was an unbounded `newKeySet()`).
- Added a regression test asserting the HTTP client map does not accumulate entries across many open/close cycles, while use-after-close still returns the sentinel.

## Behavior preserved
The use-after-close protection from #1325/#1333 is intact: after `close()`, `getClient` returns the sentinel and `getTelemetryClient` returns `NoopTelemetryClient`. The closed-marker is keyed by the connection UUID (unique per connection), so pooled connections sharing a URL are not affected.

## Testing
- `DatabricksHttpClientTest`, `TelemetryHttpClientLeakTest`, telemetry suites — all pass.
- Verified against a live SQL warehouse: 5 open/close cycles previously left 15 residual entries; now leaves 0.

This pull request and its description were written by Isaac.