### PR TITLE
[ES-1915324] Map untyped NULL columns to Types.NULL instead of Types.VARCHAR 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `getColumns()` flooding the `DriverManager` log writer with caught-and-recovered `Invalid column index` stack traces.
 - Fixed timezone-shifted TIMESTAMP values when retrieving nested complex types (STRUCT/ARRAY/MAP) with `EnableComplexDatatypeSupport=1`.
 - Fixed `DatabricksDatabaseMetaData.supportsBatchUpdates()` always returning `false`, which caused batch-aware JDBC clients (e.g. Apache Hop) to skip `executeBatch()` and fall back to one INSERT per row. It now returns `true` when `EnableBatchedInserts=1`, so those clients use the optimized multi-row INSERT path.
+- Fixed untyped `NULL` literal columns (e.g. `SELECT NULL AS col`, server type name `VOID`/`NULL`) reporting `Types.VARCHAR`. They now report `Types.NULL`, matching the JDBC spec. This unblocks Spark V2 JDBC federation, where the previous mapping made Spark resolve the column to `StringType` and fail a `Cast.canCast(StringType, NullType)` assertion, wedging pushed-down `SELECT DISTINCT ..., NULL AS col` queries.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksTypeUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksTypeUtil.java
@@ -183,8 +183,14 @@ public class DatabricksTypeUtil {
       case STRING:
       case MAP:
       case INTERVAL:
-      case NULL:
         return Types.VARCHAR;
+      case NULL:
+        // An untyped NULL literal column (e.g. SELECT NULL AS col, server type name VOID/NULL)
+        // must report Types.NULL, not a concrete type. Reporting VARCHAR made Spark's V2 JDBC
+        // federation map the column to StringType and fail Cast.canCast(StringType, NullType),
+        // wedging pushed-down "SELECT DISTINCT ..., NULL AS col" queries (ES-1915324). Types.NULL
+        // lets Spark fall back gracefully, matching the JDBC spec and MySQL/H2.
+        return Types.NULL;
       case TIMESTAMP:
         return Types.TIMESTAMP;
       case DATE:

--- a/src/test/java/com/databricks/jdbc/common/util/DatabricksTypeUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DatabricksTypeUtilTest.java
@@ -84,7 +84,7 @@ class DatabricksTypeUtilTest {
             Map.entry(ColumnInfoTypeName.STRING, Types.VARCHAR),
             Map.entry(ColumnInfoTypeName.MAP, Types.VARCHAR),
             Map.entry(ColumnInfoTypeName.INTERVAL, Types.VARCHAR),
-            Map.entry(ColumnInfoTypeName.NULL, Types.VARCHAR),
+            Map.entry(ColumnInfoTypeName.NULL, Types.NULL),
             Map.entry(ColumnInfoTypeName.TIMESTAMP, Types.TIMESTAMP),
             Map.entry(ColumnInfoTypeName.DATE, Types.DATE),
             Map.entry(ColumnInfoTypeName.STRUCT, Types.STRUCT),
@@ -101,6 +101,22 @@ class DatabricksTypeUtilTest {
                 DatabricksTypeUtil.getColumnType(typeName),
                 () -> "Unexpected type for " + typeName));
     assertEquals(Types.OTHER, DatabricksTypeUtil.getColumnType(null));
+  }
+
+  /**
+   * Regression test for ES-1915324: an untyped {@code NULL} literal column (e.g. {@code SELECT NULL
+   * AS col}) must map to {@link Types#NULL}, not a concrete type. When the driver reported {@link
+   * Types#VARCHAR} here, Spark's V2 JDBC federation mapped it to {@code StringType} and {@code
+   * Cast.canCast(StringType, NullType)} failed, wedging pushed-down {@code SELECT DISTINCT ...,
+   * NULL AS col} queries. Reporting {@link Types#NULL} lets Spark fall back gracefully, which
+   * matches the JDBC spec and MySQL/H2.
+   */
+  @Test
+  void testGetColumnTypeForNullIsSqlNull() {
+    assertEquals(Types.NULL, DatabricksTypeUtil.getColumnType(ColumnInfoTypeName.NULL));
+    // VOID is the server's type name for the same untyped-null literal and resolves to NULL.
+    assertEquals(ColumnInfoTypeName.NULL, DatabricksTypeUtil.getColumnInfoType("VOID"));
+    assertEquals(ColumnInfoTypeName.NULL, DatabricksTypeUtil.getColumnInfoType("NULL"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

An untyped `NULL` literal column — e.g. `SELECT NULL AS col`, which the server reports with type name `VOID`/`NULL` — was mapped to `java.sql.Types.VARCHAR` by `DatabricksTypeUtil.getColumnType(ColumnInfoTypeName.NULL)`.

In **Spark V2 JDBC federation** (Databricks-to-Databricks, UC foreign catalog over the JDBC connector) this caused a hard failure: Spark's `JdbcUtils` maps `VARCHAR` → `StringType`, but Catalyst still expects `NullType` for the original `Literal(null, NullType)`. `Cast.canCast(StringType, NullType)` is `false`, so the V2 pushdown assertion fires and the query wedges with `[INTERNAL_ERROR] / XX000`. Reported as **ES-1915324** for:

```sql
SELECT DISTINCT ..., NULL AS col FROM <foreign_view>
```

This PR maps `ColumnInfoTypeName.NULL` → `Types.NULL`, so Spark instead hits its "unsupported type" branch and **falls back gracefully** (non-pushed DISTINCT). This aligns with the JDBC spec and other drivers — MySQL Connector/J and H2 map untyped NULL to `Types.NULL`; Postgres uses `Types.OTHER` for the same effect.

The change is a single switch branch. The value-reading path is unaffected — a `NULL` column only ever carries `null`, and `ConverterHelper.convertSqlTypeToSpecificJavaType` short-circuits on `null` before any type-specific conversion (and its `default` branch already treats unknown SQL types as String).

## Test plan

- Added `DatabricksTypeUtilTest#testGetColumnTypeForNullIsSqlNull` — a regression test asserting `getColumnType(ColumnInfoTypeName.NULL) == Types.NULL` and that the `VOID`/`NULL` type names resolve to `ColumnInfoTypeName.NULL`. **Fails before the fix** (`expected <0> but was <12>`), passes after.
- Updated the existing `testGetColumnType` mapping assertion (`NULL` → `Types.NULL`).
- `mvn test -pl jdbc-core` for the type/converter/metadata/resultset suites — **984 tests pass**, no regressions. The separate Thrift `NULL_TYPE → STRING` mapping is intentionally left untouched (federation uses the type-name path).

Refs: ES-1915324