### PR TITLE
Use offline cache for Security Scan on fork PRs

### DIFF
--- a/.github/workflows/securityScan.yml
+++ b/.github/workflows/securityScan.yml
@@ -55,66 +55,39 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
 
-      # JFrog OIDC + maven proxy: skipped on fork PRs (no OIDC token from
-      # GitHub's perspective). Fork PRs still work because all of the
-      # driver's direct dependencies are published to public Maven Central
-      # (verified against jdbc-core/pom.xml); without ~/.m2/settings.xml,
-      # Maven falls through to Central directly. JFrog is just a faster
-      # mirror, not a source of any artifact the build genuinely needs.
-      - name: Get JFrog OIDC token
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Check if fork
+        id: fork-check
+        shell: bash
         run: |
-          set -euo pipefail
-
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "This is a forked PR — will use cached dependencies"
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+            echo "This is a same-repo PR or push — will use JFrog OIDC"
           fi
 
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-
-      - name: Configure maven
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << EOF
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>jfrog-central</id>
-                <mirrorOf>*</mirrorOf>
-                <url>https://databricks.jfrog.io/artifactory/db-maven/</url>
-              </mirror>
-            </mirrors>
-            <servers>
-              <server>
-                <id>jfrog-central</id>
-                <username>gha-service-account</username>
-                <password>${JFROG_ACCESS_TOKEN}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
+      # Resolve dependencies the same way every other CI job does: fork PRs
+      # restore the warmed offline cache and run Maven offline (the protected
+      # runners cannot reach Maven Central directly — TLS handshakes are
+      # terminated), while same-repo runs authenticate to JFrog. Previously
+      # this job tried Central directly for forks and always failed at the
+      # SBOM build before ever reaching the CVE scan.
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          is-fork: ${{ steps.fork-check.outputs.is_fork }}
 
       # Build the project to produce the cyclonedx aggregate SBOM that OSV
       # will scan. -Ddependency-check.skip=true because the OWASP plugin


### PR DESCRIPTION
## Problem

The **Security Scan** check fails on **every fork PR** (e.g. #1507), and not on a CVE finding — it dies earlier, at the SBOM build:

```
spotless-maven-plugin:pom:2.39.0 (absent): Could not transfer ... from central
(https://repo.maven.apache.org/maven2): Remote host terminated the handshake
```

`securityScan.yml` skips JFrog auth for fork PRs (no OIDC token) on the assumption — see the old comment — that Maven can fetch everything from **Maven Central** directly. On the `databricks-protected-runner-group`, that assumption is false: connections to `repo.maven.apache.org` are refused (`Remote host terminated the handshake`). So `mvn package` can't resolve build plugins and the job fails before `osv-scanner` ever runs. The CVE step is `skipped`. This blocks fork PRs regardless of their actual CVE posture.

## Fix

Switch the job to the same dependency-resolution flow every other CI job already uses — `fork-check` + `./.github/actions/setup-maven`:

- **Fork PRs** restore the warmed offline cache and run Maven offline (no Central, no JFrog creds needed).
- **Same-repo runs** authenticate to JFrog as before.

The cache warmer already downloads the plugins the SBOM build needs — verified in a warm run that both `cyclonedx-maven-plugin:2.9.1` and `spotless-maven-plugin:2.39.0` are cached.

This also aligns the checkout with the rest of CI (checks out the fork's head ref).

## Note on the CVE baseline

Separately, the scheduled (non-fork) Security Scan on `main` can fail on real OSV-Scanner CVE findings — that's a genuine dependency-CVE signal and unaffected by this change. This PR only fixes the fork-PR case where the build couldn't even run.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.