### PR TITLE
Make Connection.setReadOnly a no-op instead of throwing

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `getColumns()` flooding the `DriverManager` log writer with caught-and-recovered `Invalid column index` stack traces.
 - Fixed timezone-shifted TIMESTAMP values when retrieving nested complex types (STRUCT/ARRAY/MAP) with `EnableComplexDatatypeSupport=1`.
 - Fixed `DatabricksDatabaseMetaData.supportsBatchUpdates()` always returning `false`, which caused batch-aware JDBC clients (e.g. Apache Hop) to skip `executeBatch()` and fall back to one INSERT per row. It now returns `true` when `EnableBatchedInserts=1`, so those clients use the optimized multi-row INSERT path.
+- Fixed `Connection.setReadOnly(true)` throwing `DatabricksSQLFeatureNotSupportedException`, which broke clients (e.g. Trino/Starburst GenericJDBC, HikariCP, DBCP) that call it during connection initialization. Per the JDBC spec, `setReadOnly` is a hint the driver may ignore; it is now a no-op and `isReadOnly()` continues to return `false`.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -466,12 +466,14 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
 
   @Override
   public void setReadOnly(boolean readOnly) throws SQLException {
-    LOGGER.debug("public void setReadOnly(boolean readOnly)");
+    LOGGER.debug("public void setReadOnly(boolean readOnly = {})", readOnly);
     throwExceptionIfConnectionIsClosed();
-    if (readOnly) {
-      throw new DatabricksSQLFeatureNotSupportedException(
-          "Databricks OSS JDBC does not support readOnly mode.");
-    }
+    // Per the JDBC spec, setReadOnly is a hint used to enable database optimizations. The
+    // Databricks
+    // backend does not enforce a connection-level read-only mode, so this is treated as a no-op
+    // rather than throwing. isReadOnly() continues to report false since the hint is not enforced.
+    // Throwing here breaks common clients (e.g. HikariCP, DBCP, Trino/Starburst) that call
+    // setReadOnly(true) during connection initialization.
   }
 
   @Override

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
@@ -625,9 +625,11 @@ public class DatabricksConnectionTest {
   void testReadOnlyAndAbort() throws SQLException {
     connection = new DatabricksConnection(connectionContext, databricksClient);
     connection.open();
+    // setReadOnly is a JDBC hint; the driver does not enforce read-only mode, so both values are
+    // accepted as no-ops (see JDBC spec). isReadOnly() continues to report false.
     assertDoesNotThrow(() -> connection.setReadOnly(false));
-    assertThrows(
-        DatabricksSQLFeatureNotSupportedException.class, () -> connection.setReadOnly(true));
+    assertDoesNotThrow(() -> connection.setReadOnly(true));
+    assertFalse(connection.isReadOnly());
     ExecutorService executorService = Executors.newFixedThreadPool(1);
     assertDoesNotThrow(() -> connection.abort(executorService));
     connection.close();


### PR DESCRIPTION
## Summary

`Connection.setReadOnly(true)` threw `DatabricksSQLFeatureNotSupportedException`, which breaks JDBC clients that call `setReadOnly(true)` during connection initialization — e.g. the Trino/Starburst GenericJDBC connector, HikariCP, and DBCP connection pools. This was reported via an internal support thread for a Starburst GenericJDBC integration.

Per the JDBC spec, `setReadOnly` is a **hint** used to enable database optimizations; a driver that does not enforce a connection-level read-only mode is permitted to ignore it. The Databricks backend does not enforce read-only mode, so throwing here is non-conformant.

### Fix

- `setReadOnly(true)` is now a no-op (it still validates the connection is open, matching the prior behavior of `throwExceptionIfConnectionIsClosed()`).
- `isReadOnly()` continues to return `false`, since the hint is not actually enforced — this remains accurate.

## Test plan

- Updated `DatabricksConnectionTest#testReadOnlyAndAbort`:
  - `setReadOnly(false)` — no throw (unchanged)
  - `setReadOnly(true)` — now asserts no throw (was previously asserting `DatabricksSQLFeatureNotSupportedException`)
  - `isReadOnly()` still returns `false`
- Ran the full `DatabricksConnectionTest` class — all pass.
- Closed-connection behavior preserved: `isReadOnly()` on a closed connection still throws `DatabricksSQLException` (existing test at line 353).

NO_CHANGELOG=false