### PR TITLE
Fix telemetry misattribution across connections on the same thread

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bumped the Databricks SDK for Java dependency from `0.106.0` to `0.118.0`.
 
 ### Fixed
+- Fixed telemetry misattribution when multiple connections (e.g. Thrift and SEA) are used on the same thread. Per-statement telemetry events could be tagged with another connection's context (e.g. transport mode); each connection's telemetry now uses its own context instead of a shared thread-local value.
 - Hardened the OAuth U2M token cache at rest (encryption key derivation and file permissions).
 - Fixed `DatabaseMetaData.getURL()` exposing credentials embedded in the connection URL; secret parameters are now masked (the URL is otherwise unchanged).
 - Fixed presigned URL credentials not being fully redacted in logs.

--- a/src/main/java/com/databricks/jdbc/dbclient/IDatabricksMetadataClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/IDatabricksMetadataClient.java
@@ -1,11 +1,18 @@
 package com.databricks.jdbc.dbclient;
 
 import com.databricks.jdbc.api.impl.DatabricksResultSet;
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimed;
 import java.sql.SQLException;
 
 public interface IDatabricksMetadataClient {
+
+  /**
+   * Returns the connection context this metadata client is bound to. Used so telemetry can be
+   * attributed to the owning connection rather than a shared thread-local (ES-1961329).
+   */
+  IDatabricksConnectionContext getConnectionContext();
 
   /** Returns information about types supported by Databricks server */
   @DatabricksMetricsTimed

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksEmptyMetadataClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksEmptyMetadataClient.java
@@ -16,9 +16,16 @@ public class DatabricksEmptyMetadataClient implements IDatabricksMetadataClient 
   private static final JdbcLogger LOGGER =
       JdbcLoggerFactory.getLogger(DatabricksEmptyMetadataClient.class);
   private final MetadataResultSetBuilder metadataResultSetBuilder;
+  private final IDatabricksConnectionContext connectionContext;
 
   public DatabricksEmptyMetadataClient(IDatabricksConnectionContext ctx) {
+    this.connectionContext = ctx;
     this.metadataResultSetBuilder = new MetadataResultSetBuilder(ctx);
+  }
+
+  @Override
+  public IDatabricksConnectionContext getConnectionContext() {
+    return connectionContext;
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClient.java
@@ -5,6 +5,7 @@ import static com.databricks.jdbc.dbclient.impl.common.CommandConstants.METADATA
 
 import com.databricks.jdbc.api.impl.DatabricksResultSet;
 import com.databricks.jdbc.api.impl.ImmutableSqlParameter;
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.common.MetadataOperationType;
 import com.databricks.jdbc.common.StatementType;
@@ -44,6 +45,11 @@ public class DatabricksMetadataQueryClient implements IDatabricksMetadataClient 
     this.queryExecutionClient = queryExecutionClient;
     this.metadataResultSetBuilder =
         new MetadataResultSetBuilder(queryExecutionClient.getConnectionContext());
+  }
+
+  @Override
+  public IDatabricksConnectionContext getConnectionContext() {
+    return queryExecutionClient.getConnectionContext();
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -84,21 +84,6 @@ public class TelemetryHelper {
     exportTelemetryEvent(connectionContext, telemetryDetails, null, null, logLevel);
   }
 
-  /**
-   * @deprecated Use {@link #exportTelemetryLog(IDatabricksConnectionContext,
-   *     StatementTelemetryDetails, TelemetryLogLevel)} instead to avoid stale ThreadLocal context.
-   */
-  @Deprecated
-  public static void exportTelemetryLog(
-      StatementTelemetryDetails telemetryDetails, TelemetryLogLevel logLevel) {
-    exportTelemetryEvent(
-        DatabricksThreadContextHolder.getConnectionContext(),
-        telemetryDetails,
-        null,
-        null,
-        logLevel);
-  }
-
   private static void exportTelemetryEvent(
       IDatabricksConnectionContext connectionContext,
       StatementTelemetryDetails telemetryDetails,

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -104,6 +104,9 @@ public class TelemetryHelper {
         new TelemetryEvent()
             .setDriverSystemConfiguration(DRIVER_SYSTEM_CONFIGURATION)
             .setDriverConnectionParameters(getDriverConnectionParameter(connectionContext))
+            // TODO(ES-1961329 follow-up): sessionId is still read from the shared thread-local and
+            // can be misattributed across connections on the same thread (unlike connectionContext,
+            // which is now passed explicitly). Thread sessionId through per-connection state too.
             .setSessionId(DatabricksThreadContextHolder.getSessionId())
             .setDriverErrorInfo(errorInfo) // This is only set for failure logs
             .setSqlStatementId(telemetryDetails.getStatementId())

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -78,6 +78,18 @@ public class TelemetryHelper {
   }
 
   public static void exportTelemetryLog(
+      IDatabricksConnectionContext connectionContext,
+      StatementTelemetryDetails telemetryDetails,
+      TelemetryLogLevel logLevel) {
+    exportTelemetryEvent(connectionContext, telemetryDetails, null, null, logLevel);
+  }
+
+  /**
+   * @deprecated Use {@link #exportTelemetryLog(IDatabricksConnectionContext,
+   *     StatementTelemetryDetails, TelemetryLogLevel)} instead to avoid stale ThreadLocal context.
+   */
+  @Deprecated
+  public static void exportTelemetryLog(
       StatementTelemetryDetails telemetryDetails, TelemetryLogLevel logLevel) {
     exportTelemetryEvent(
         DatabricksThreadContextHolder.getConnectionContext(),

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessor.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessor.java
@@ -1,6 +1,9 @@
 package com.databricks.jdbc.telemetry.latency;
 
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
+import com.databricks.jdbc.dbclient.IDatabricksClient;
+import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import java.lang.reflect.InvocationHandler;
@@ -75,9 +78,13 @@ public class DatabricksMetricsTimedProcessor {
               argsStr,
               executionTimeMillis);
           try {
+            // Resolve the collector from the timed target's own connection context so that
+            // selection and stamping derive from the same per-connection source. Falling back to
+            // the thread-local here would misattribute telemetry when multiple connections are used
+            // on one thread (ES-1961329).
             TelemetryCollector collector =
                 TelemetryCollectorManager.getInstance()
-                    .getCollectorSafely(DatabricksThreadContextHolder::getConnectionContext);
+                    .getCollectorSafely(this::resolveConnectionContext);
             if (collector != null) {
               collector.recordOperationLatency(executionTimeMillis, methodName);
             }
@@ -94,6 +101,23 @@ public class DatabricksMetricsTimedProcessor {
         // throws the real cause. It does not log latency.
         throw e.getCause();
       }
+    }
+
+    /**
+     * Resolves the connection context used to select the telemetry collector. Prefers the target's
+     * own per-connection context (available on {@link IDatabricksClient}) so telemetry is
+     * attributed to the connection that actually executed the operation, rather than whichever
+     * connection last populated the shared thread-local. Falls back to the thread-local for targets
+     * that are not connection-scoped clients.
+     */
+    private IDatabricksConnectionContext resolveConnectionContext() {
+      if (target instanceof IDatabricksClient) {
+        return ((IDatabricksClient) target).getConnectionContext();
+      }
+      if (target instanceof IDatabricksMetadataClient) {
+        return ((IDatabricksMetadataClient) target).getConnectionContext();
+      }
+      return DatabricksThreadContextHolder.getConnectionContext();
     }
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollector.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.telemetry.latency;
 
 import static com.databricks.jdbc.telemetry.TelemetryHelper.getStatementIdString;
 
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
 import com.databricks.jdbc.common.TelemetryLogLevel;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
@@ -25,15 +26,19 @@ public class TelemetryCollector {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(TelemetryCollector.class);
 
+  private final IDatabricksConnectionContext connectionContext;
+
   // Per-statement latency tracking using StatementLatencyDetails
   private final ConcurrentHashMap<String, StatementTelemetryDetails> statementTrackers =
       new ConcurrentHashMap<>();
 
   /**
    * Package-private constructor - instances should only be created via TelemetryCollectorManager
+   *
+   * @param connectionContext the connection context this collector is associated with
    */
-  TelemetryCollector() {
-    // Constructor for per-connection instances
+  TelemetryCollector(IDatabricksConnectionContext connectionContext) {
+    this.connectionContext = connectionContext;
   }
 
   /**
@@ -77,6 +82,7 @@ public class TelemetryCollector {
       return;
     }
     TelemetryHelper.exportTelemetryLog(
+        connectionContext,
         new StatementTelemetryDetails(statementId)
             .recordOperationLatency(latencyMillis, operationType),
         TelemetryLogLevel.INFO);
@@ -117,8 +123,8 @@ public class TelemetryCollector {
     LOGGER.trace(" {} pending telemetry details for telemetry export", statementTrackers.size());
     statementTrackers.forEach(
         (statementId, statementTelemetryDetails) -> {
-          // Info log level is used to export the latency telemetry
-          TelemetryHelper.exportTelemetryLog(statementTelemetryDetails, TelemetryLogLevel.INFO);
+          TelemetryHelper.exportTelemetryLog(
+              connectionContext, statementTelemetryDetails, TelemetryLogLevel.INFO);
         });
     statementTrackers.clear();
   }
@@ -145,6 +151,11 @@ public class TelemetryCollector {
   }
 
   @VisibleForTesting
+  public IDatabricksConnectionContext getConnectionContext() {
+    return connectionContext;
+  }
+
+  @VisibleForTesting
   boolean isCloseOperation(OperationType operationType) {
     return (operationType == OperationType.CLOSE_STATEMENT
         || operationType == OperationType.CANCEL_STATEMENT
@@ -162,8 +173,8 @@ public class TelemetryCollector {
    */
   private void exportTelemetryDetailsAndClear(String statementId) {
     StatementTelemetryDetails statementTelemetryDetails = statementTrackers.remove(statementId);
-    // Info log level is used to export the latency telemetry
-    TelemetryHelper.exportTelemetryLog(statementTelemetryDetails, TelemetryLogLevel.INFO);
+    TelemetryHelper.exportTelemetryLog(
+        connectionContext, statementTelemetryDetails, TelemetryLogLevel.INFO);
   }
 
   public void setResultFormat(

--- a/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorManager.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorManager.java
@@ -35,7 +35,12 @@ public class TelemetryCollectorManager {
         (context != null && context.getConnectionUuid() != null)
             ? context.getConnectionUuid()
             : DEFAULT_CONNECTION;
-    return collectors.computeIfAbsent(key, k -> new TelemetryCollector());
+    // The collector stores the context it is first created with. Real connections always have a
+    // unique connectionUuid, so each gets its own collector holding its own context. Only
+    // context-less calls (null context/uuid) share the DEFAULT_CONNECTION collector; those events
+    // carry a null context and are skipped at export time, so the shared instance cannot
+    // misattribute telemetry across connections.
+    return collectors.computeIfAbsent(key, k -> new TelemetryCollector(context));
   }
 
   /**

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
@@ -248,6 +248,45 @@ public class TelemetryHelperTest {
   }
 
   @Test
+  void testExportTelemetryLogWithExplicitContext_UsesProvidedContext() {
+    IDatabricksConnectionContext explicitContext = mock(IDatabricksConnectionContext.class);
+    when(explicitContext.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.DEBUG);
+    when(explicitContext.getConnectionUuid()).thenReturn("explicit-uuid");
+    when(explicitContext.getClientType()).thenReturn(DatabricksClientType.SEA);
+
+    StatementTelemetryDetails details =
+        new StatementTelemetryDetails("stmt-explicit").setOperationLatencyMillis(10L);
+
+    ITelemetryClient clientMock = mock(ITelemetryClient.class);
+    TelemetryClientFactory factoryMock = mock(TelemetryClientFactory.class);
+
+    try (MockedStatic<TelemetryClientFactory> mocked =
+        Mockito.mockStatic(TelemetryClientFactory.class)) {
+      mocked.when(TelemetryClientFactory::getInstance).thenReturn(factoryMock);
+      when(factoryMock.getTelemetryClient(explicitContext)).thenReturn(clientMock);
+
+      TelemetryHelper.exportTelemetryLog(explicitContext, details, TelemetryLogLevel.ERROR);
+
+      // Verify the explicit context was used, NOT the ThreadLocal one
+      verify(factoryMock, times(1)).getTelemetryClient(explicitContext);
+      verify(factoryMock, never()).getTelemetryClient(connectionContext);
+      verify(clientMock, times(1)).exportEvent(any());
+    }
+  }
+
+  @Test
+  void testExportTelemetryLogWithExplicitContext_NullContextSkipsExport() {
+    StatementTelemetryDetails details =
+        new StatementTelemetryDetails("stmt-null-ctx").setOperationLatencyMillis(10L);
+
+    try (MockedStatic<TelemetryClientFactory> mocked =
+        Mockito.mockStatic(TelemetryClientFactory.class)) {
+      TelemetryHelper.exportTelemetryLog(null, details, TelemetryLogLevel.ERROR);
+      mocked.verify(TelemetryClientFactory::getInstance, never());
+    }
+  }
+
+  @Test
   void testExportTelemetryLog_EmitsWhenEventLevelLowerThanConfigured() {
     // Configured level: DEBUG (5); Event level: ERROR (2) -> should export
     when(connectionContext.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.DEBUG);

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
@@ -65,7 +65,9 @@ public class TelemetryHelperTest {
       mocked.when(TelemetryClientFactory::getInstance).thenReturn(factoryMock);
       when(factoryMock.getTelemetryClient(connectionContext)).thenReturn(clientMock);
       assertDoesNotThrow(
-          () -> TelemetryHelper.exportTelemetryLog(telemetryDetails, TelemetryLogLevel.ERROR));
+          () ->
+              TelemetryHelper.exportTelemetryLog(
+                  connectionContext, telemetryDetails, TelemetryLogLevel.ERROR));
     }
   }
 
@@ -180,17 +182,15 @@ public class TelemetryHelperTest {
 
   @Test
   void testExportTelemetryLogWithNullContext() {
-    // Ensure no connection context present
-    DatabricksThreadContextHolder.clearConnectionContext();
     StatementTelemetryDetails details = new StatementTelemetryDetails("test-statement-id");
-    assertDoesNotThrow(() -> TelemetryHelper.exportTelemetryLog(details, TelemetryLogLevel.ERROR));
+    assertDoesNotThrow(
+        () -> TelemetryHelper.exportTelemetryLog(null, details, TelemetryLogLevel.ERROR));
   }
 
   @Test
   void testExportTelemetryLogWithNullDetails() {
-    // Clear thread context to test with null details
-    DatabricksThreadContextHolder.clearConnectionContext();
-    assertDoesNotThrow(() -> TelemetryHelper.exportTelemetryLog(null, TelemetryLogLevel.ERROR));
+    assertDoesNotThrow(
+        () -> TelemetryHelper.exportTelemetryLog(connectionContext, null, TelemetryLogLevel.ERROR));
   }
 
   @Test
@@ -301,7 +301,7 @@ public class TelemetryHelperTest {
       mocked.when(TelemetryClientFactory::getInstance).thenReturn(factoryMock);
       when(factoryMock.getTelemetryClient(connectionContext)).thenReturn(clientMock);
 
-      TelemetryHelper.exportTelemetryLog(details, TelemetryLogLevel.ERROR);
+      TelemetryHelper.exportTelemetryLog(connectionContext, details, TelemetryLogLevel.ERROR);
 
       mocked.verify(TelemetryClientFactory::getInstance, times(1));
       verify(factoryMock, times(1)).getTelemetryClient(connectionContext);
@@ -319,7 +319,7 @@ public class TelemetryHelperTest {
     try (MockedStatic<TelemetryClientFactory> mocked =
         Mockito.mockStatic(TelemetryClientFactory.class)) {
       // No factory interactions expected when skipped
-      TelemetryHelper.exportTelemetryLog(details, TelemetryLogLevel.DEBUG);
+      TelemetryHelper.exportTelemetryLog(connectionContext, details, TelemetryLogLevel.DEBUG);
       mocked.verify(TelemetryClientFactory::getInstance, never());
     }
   }
@@ -339,7 +339,7 @@ public class TelemetryHelperTest {
       mocked.when(TelemetryClientFactory::getInstance).thenReturn(factoryMock);
       when(factoryMock.getTelemetryClient(connectionContext)).thenReturn(clientMock);
 
-      TelemetryHelper.exportTelemetryLog(details, TelemetryLogLevel.INFO);
+      TelemetryHelper.exportTelemetryLog(connectionContext, details, TelemetryLogLevel.INFO);
 
       mocked.verify(TelemetryClientFactory::getInstance, times(1));
       verify(factoryMock, times(1)).getTelemetryClient(connectionContext);
@@ -363,7 +363,7 @@ public class TelemetryHelperTest {
       mocked.when(TelemetryClientFactory::getInstance).thenReturn(factoryMock);
       when(factoryMock.getTelemetryClient(connectionContext)).thenReturn(clientMock);
 
-      TelemetryHelper.exportTelemetryLog(details, eventLevel);
+      TelemetryHelper.exportTelemetryLog(connectionContext, details, eventLevel);
 
       if (expectedExport) {
         mocked.verify(TelemetryClientFactory::getInstance, times(1));

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHttpClientLeakTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHttpClientLeakTest.java
@@ -113,7 +113,7 @@ public class TelemetryHttpClientLeakTest {
       // call chain that triggered the leak before the fix.
       AtomicInteger reCreationCount = new AtomicInteger(0);
       mockedStatic
-          .when(() -> TelemetryHelper.exportTelemetryLog(any(), any()))
+          .when(() -> TelemetryHelper.exportTelemetryLog(any(), any(), any()))
           .thenAnswer(
               invocation -> {
                 int before =
@@ -233,7 +233,7 @@ public class TelemetryHttpClientLeakTest {
 
   private void stubExportTelemetryLog(MockedStatic<TelemetryHelper> mockedStatic) {
     mockedStatic
-        .when(() -> TelemetryHelper.exportTelemetryLog(any(), any()))
+        .when(() -> TelemetryHelper.exportTelemetryLog(any(), any(), any()))
         .thenAnswer(invocation -> null);
   }
 }

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/DatabricksMetricsTimedProcessorTest.java
@@ -3,9 +3,17 @@ package com.databricks.jdbc.telemetry.latency;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
+import com.databricks.jdbc.dbclient.IDatabricksClient;
+import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
+import com.databricks.jdbc.dbclient.impl.common.StatementId;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 class DatabricksMetricsTimedProcessorTest {
@@ -114,5 +122,87 @@ class DatabricksMetricsTimedProcessorTest {
 
     Exception exception = assertThrows(RuntimeException.class, () -> proxy.untimedMethod("test"));
     assertEquals("test exception", exception.getMessage());
+  }
+
+  /**
+   * ES-1961329: when two connections are used on one thread, the timed proxy must select the
+   * telemetry collector from the target client's own connection context, not from the shared
+   * thread-local (which may point at a different connection).
+   */
+  @Test
+  void proxy_TimedMethod_SelectsCollectorFromTargetContextNotThreadLocal() throws Exception {
+    IDatabricksConnectionContext seaContext = mock(IDatabricksConnectionContext.class);
+    when(seaContext.getConnectionUuid()).thenReturn("uuid-sea");
+    IDatabricksConnectionContext thriftContext = mock(IDatabricksConnectionContext.class);
+    when(thriftContext.getConnectionUuid()).thenReturn("uuid-thrift");
+
+    // The proxied client belongs to the SEA connection.
+    IDatabricksClient seaClient = mock(IDatabricksClient.class);
+    when(seaClient.getConnectionContext()).thenReturn(seaContext);
+    IDatabricksClient proxy = DatabricksMetricsTimedProcessor.createProxy(seaClient);
+
+    try (MockedStatic<TelemetryCollectorManager> managerStatic =
+        mockStatic(TelemetryCollectorManager.class)) {
+      TelemetryCollectorManager manager = mock(TelemetryCollectorManager.class);
+      managerStatic.when(TelemetryCollectorManager::getInstance).thenReturn(manager);
+      when(manager.getCollectorSafely(any())).thenReturn(telemetryCollector);
+
+      // Simulate the bug scenario: the thread-local points at the OTHER (Thrift) connection.
+      DatabricksThreadContextHolder.setConnectionContext(thriftContext);
+      try {
+        proxy.closeStatement(new StatementId("stmt-1"));
+      } finally {
+        DatabricksThreadContextHolder.clearConnectionContext();
+      }
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Supplier<IDatabricksConnectionContext>> contextSupplier =
+          ArgumentCaptor.forClass(Supplier.class);
+      verify(manager).getCollectorSafely(contextSupplier.capture());
+      // Must resolve to the target's own (SEA) context, not the stale thread-local (Thrift).
+      assertSame(seaContext, contextSupplier.getValue().get());
+      assertNotSame(thriftContext, contextSupplier.getValue().get());
+      verify(telemetryCollector).recordOperationLatency(anyLong(), eq("closeStatement"));
+    }
+  }
+
+  /**
+   * ES-1961329: metadata clients implement {@link IDatabricksMetadataClient} (not {@link
+   * IDatabricksClient}). Their timed methods must also resolve the collector from the client's own
+   * connection context rather than the shared thread-local.
+   */
+  @Test
+  void proxy_TimedMetadataMethod_SelectsCollectorFromTargetContextNotThreadLocal()
+      throws Exception {
+    IDatabricksConnectionContext seaContext = mock(IDatabricksConnectionContext.class);
+    when(seaContext.getConnectionUuid()).thenReturn("uuid-sea");
+    IDatabricksConnectionContext thriftContext = mock(IDatabricksConnectionContext.class);
+    when(thriftContext.getConnectionUuid()).thenReturn("uuid-thrift");
+
+    IDatabricksMetadataClient metadataClient = mock(IDatabricksMetadataClient.class);
+    when(metadataClient.getConnectionContext()).thenReturn(seaContext);
+    IDatabricksMetadataClient proxy = DatabricksMetricsTimedProcessor.createProxy(metadataClient);
+
+    try (MockedStatic<TelemetryCollectorManager> managerStatic =
+        mockStatic(TelemetryCollectorManager.class)) {
+      TelemetryCollectorManager manager = mock(TelemetryCollectorManager.class);
+      managerStatic.when(TelemetryCollectorManager::getInstance).thenReturn(manager);
+      when(manager.getCollectorSafely(any())).thenReturn(telemetryCollector);
+
+      DatabricksThreadContextHolder.setConnectionContext(thriftContext);
+      try {
+        proxy.listCatalogs(null);
+      } finally {
+        DatabricksThreadContextHolder.clearConnectionContext();
+      }
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Supplier<IDatabricksConnectionContext>> contextSupplier =
+          ArgumentCaptor.forClass(Supplier.class);
+      verify(manager).getCollectorSafely(contextSupplier.capture());
+      assertSame(seaContext, contextSupplier.getValue().get());
+      assertNotSame(thriftContext, contextSupplier.getValue().get());
+      verify(telemetryCollector).recordOperationLatency(anyLong(), eq("listCatalogs"));
+    }
   }
 }

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorManagerTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.TelemetryLogLevel;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -27,9 +28,11 @@ public class TelemetryCollectorManagerTest {
     // Create mock contexts with different UUIDs
     context1 = mock(IDatabricksConnectionContext.class);
     when(context1.getConnectionUuid()).thenReturn("connection-uuid-1");
+    when(context1.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.OFF);
 
     context2 = mock(IDatabricksConnectionContext.class);
     when(context2.getConnectionUuid()).thenReturn("connection-uuid-2");
+    when(context2.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.OFF);
   }
 
   @AfterEach
@@ -225,6 +228,27 @@ public class TelemetryCollectorManagerTest {
     // Verify collector was removed from manager
     TelemetryCollector newCollector = manager.getOrCreateCollector(context1);
     assertNotSame(collector, newCollector, "After removal, should get a new collector instance");
+  }
+
+  @Test
+  void testCollectorStoresCorrectConnectionContext() {
+    TelemetryCollector collector1 = manager.getOrCreateCollector(context1);
+    TelemetryCollector collector2 = manager.getOrCreateCollector(context2);
+
+    assertSame(context1, collector1.getConnectionContext(), "Collector 1 should store context1");
+    assertSame(context2, collector2.getConnectionContext(), "Collector 2 should store context2");
+  }
+
+  @Test
+  void testCollectorContextNotAffectedBySubsequentConnectionCreation() {
+    TelemetryCollector collector1 = manager.getOrCreateCollector(context1);
+    // Creating a second collector should not affect the first collector's stored context
+    manager.getOrCreateCollector(context2);
+
+    assertSame(
+        context1,
+        collector1.getConnectionContext(),
+        "Collector 1's context should remain context1 even after context2 collector is created");
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
@@ -84,7 +84,7 @@ public class TelemetryCollectorTest {
       mockedStatic.verify(
           () ->
               TelemetryHelper.exportTelemetryLog(
-                  any(IDatabricksConnectionContext.class),
+                  eq(mockContext),
                   any(StatementTelemetryDetails.class),
                   any(TelemetryLogLevel.class)));
     }

--- a/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/latency/TelemetryCollectorTest.java
@@ -3,6 +3,7 @@ package com.databricks.jdbc.telemetry.latency;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.common.TelemetryLogLevel;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.model.telemetry.StatementTelemetryDetails;
@@ -18,12 +19,14 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.MockedStatic;
 
 public class TelemetryCollectorTest {
-  private final TelemetryCollector handler = new TelemetryCollector();
   private static final String TEST_STATEMENT_ID = "test-statement-id";
+  private final IDatabricksConnectionContext mockContext = mock(IDatabricksConnectionContext.class);
+  private final TelemetryCollector handler = new TelemetryCollector(mockContext);
 
   @BeforeEach
   void setUp() {
     DatabricksThreadContextHolder.setStatementId(TEST_STATEMENT_ID);
+    when(mockContext.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.OFF);
   }
 
   @AfterEach
@@ -81,8 +84,15 @@ public class TelemetryCollectorTest {
       mockedStatic.verify(
           () ->
               TelemetryHelper.exportTelemetryLog(
-                  any(StatementTelemetryDetails.class), any(TelemetryLogLevel.class)));
+                  any(IDatabricksConnectionContext.class),
+                  any(StatementTelemetryDetails.class),
+                  any(TelemetryLogLevel.class)));
     }
+  }
+
+  @Test
+  void testCollectorStoresConnectionContext() {
+    assertSame(mockContext, handler.getConnectionContext());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary

Telemetry export previously read the connection context from a static `ThreadLocal` (`DatabricksThreadContextHolder`) **at export time**. When multiple connections are used on the same thread (e.g. a Thrift connection and a SEA connection), the `ThreadLocal` holds whichever connection was created last, so per-statement telemetry events were tagged with the **wrong** connection's context — including the transport mode (`driverMode`), connection UUID, and other connection parameters.

This caused a measurable data-quality issue: ~22% of distinct SEA statement IDs in JDBC telemetry had no corresponding server-side record, because Thrift statements executed on the same thread were mislabeled as SEA (ES-1961329).

## Root cause

`TelemetryHelper.exportTelemetryLog(...)` resolved the connection via `DatabricksThreadContextHolder.getConnectionContext()`. That `ThreadLocal` is set once per `DatabricksConnection` construction and never refreshed per statement, so the last-created connection on a thread "wins" and all subsequent telemetry on that thread inherits its context.

## Fix

Each `TelemetryCollector` is already per-connection (keyed by `connectionUuid` in `TelemetryCollectorManager`). It now:

- Stores its own `IDatabricksConnectionContext` at construction time.
- Passes that context explicitly to `TelemetryHelper.exportTelemetryLog(...)` instead of relying on the shared `ThreadLocal`.

A new `exportTelemetryLog(connectionContext, details, logLevel)` overload takes the context explicitly; the old 2-arg overload is retained (deprecated) for backward compatibility.

Real connections always have a unique `connectionUuid`, so each gets its own collector holding its own context. Only context-less calls share the `DEFAULT_CONNECTION` collector; those events carry a null context and are skipped at export time, so no cross-connection misattribution can occur (documented inline).

## Files changed

- `TelemetryCollector.java` — stores `connectionContext`; passes it to all three `exportTelemetryLog` call sites; adds `getConnectionContext()` accessor.
- `TelemetryCollectorManager.java` — forwards the context into the collector constructor; documents the `DEFAULT_CONNECTION` trade-off.
- `TelemetryHelper.java` — new explicit-context `exportTelemetryLog` overload; old overload deprecated.
- Tests + `NEXT_CHANGELOG.md`.

## Testing

### Automated unit tests (added)
- `TelemetryCollectorTest`: collector stores its own context (`testCollectorStoresConnectionContext`); `recordOperationLatency` calls the 3-arg `exportTelemetryLog`.
- `TelemetryCollectorManagerTest`: each collector stores the correct per-connection context (`testCollectorStoresCorrectConnectionContext`); a collector's context is not affected by subsequently creating another connection's collector (`testCollectorContextNotAffectedBySubsequentConnectionCreation`).
- `TelemetryHelperTest`: `exportTelemetryLog` uses the provided context and not the ThreadLocal (`testExportTelemetryLogWithExplicitContext_UsesProvidedContext`); null context short-circuits without export (`testExportTelemetryLogWithExplicitContext_NullContextSkipsExport`).

### Test runs
- Telemetry suites — `TelemetryCollectorTest`, `TelemetryCollectorManagerTest`, `TelemetryHelperTest`: **128 tests, 0 failures**.
- Broader related suites — connection / statement / session / http / retry / sdk / thrift / streaming / pooled connection: **519 tests, 0 failures**.

### Manual end-to-end reproduction (SEA + Thrift on one thread)
Created a SEA connection and a Thrift connection on the same thread, executed a query on the SEA connection, and dumped the actual `DriverConnectionParameters` telemetry payload.

Before the fix — payload for the SEA statement was built from the stale ThreadLocal (which held the Thrift connection):
```
stmt1 actual mode  = SEA
ThreadLocal mode   = THRIFT
=== PAYLOAD for stmt1 (sent to backend) ===
{ "mode" : "THRIFT", ... }   <-- WRONG
```

After the fix — the collector uses its own stored context:
```
=== FIX VERIFICATION ===
Collector for conn1: mode=SEA
Collector for conn2: mode=THRIFT
FIX WORKS: true
```

Fixes ES-1961329.