### PR TITLE
Add remaining negative-suite gap cases (DML view / OTHER / TYPE_CONVERSION)

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementDmlProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementDmlProvider.java
@@ -58,6 +58,12 @@ public class NegativeStatementDmlProvider implements SuiteProvider {
               s -> "DELETE FROM " + s + ".__no_such__ WHERE id = 1"),
           new Case("executeUpdate on a SELECT (wrong method)", s -> "SELECT * FROM " + s + ".seed"),
           new Case(
+              "UPDATE a non-updatable view",
+              s -> "UPDATE " + s + ".seed_view SET name = 'x' WHERE id = 1"),
+          new Case(
+              "DELETE from a non-updatable view",
+              s -> "DELETE FROM " + s + ".seed_view WHERE id = 1"),
+          new Case(
               "Write overflow: CAST('123456' AS DECIMAL(2,0))",
               s ->
                   "INSERT INTO "
@@ -100,6 +106,9 @@ public class NegativeStatementDmlProvider implements SuiteProvider {
     exec(conn, "CREATE SCHEMA " + schema);
     exec(conn, "CREATE TABLE " + schema + ".seed (id INT NOT NULL, name STRING)");
     exec(conn, "INSERT INTO " + schema + ".seed VALUES (1, 'alice')");
+    // Views are read-only in Databricks/Spark, so UPDATE/DELETE against one must fail on both
+    // sides.
+    exec(conn, "CREATE VIEW " + schema + ".seed_view AS SELECT id, name FROM " + schema + ".seed");
   }
 
   private int execUpdate(Connection conn, String sql) throws Exception {

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementOtherProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementOtherProvider.java
@@ -36,6 +36,11 @@ public class NegativeStatementOtherProvider implements SuiteProvider {
             "DESCRIBE a non-existent table"),
         new TestCase("SET = 'x'", "SET with an invalid (empty) parameter name"),
         new TestCase(
+            "SET TIMEZONE = '__no_such_timezone__'",
+            "SET a valid conf to an invalid value (bad timezone)"),
+        new TestCase(
+            "SELECT 1; SELECT 2", "multi-statement script (;-separated) in a single execute()"),
+        new TestCase(
             "EXPLAIN SELECT __no_such_column__ FROM " + TABLE, "EXPLAIN of an invalid query"),
         new TestCase(GET_MORE_RESULTS, "getMoreResults() after all results are consumed"),
         new TestCase(GET_UPDATE_COUNT, "getUpdateCount() before execute()"));

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.comparator.suite;
 
+import com.databricks.jdbc.api.IDatabricksResultSet;
 import com.databricks.jdbc.comparator.ComparisonResult;
 import com.databricks.jdbc.comparator.error.CapturedOutcome;
 import com.databricks.jdbc.comparator.error.Captures;
@@ -68,7 +69,23 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
           new Case(
               "getBigDecimal() on a STRUCT column",
               "SELECT struct_column FROM " + TABLE + " WHERE struct_column IS NOT NULL LIMIT 1",
-              rs -> rs.getBigDecimal(1)));
+              rs -> rs.getBigDecimal(1)),
+          // Cross-type complex getters: the getter targets the WRONG complex type, so it hits an
+          // error path in both configs — the disabled-support guard when complex types are off, or
+          // a ClassCastException when they are on. (Type-matched getters would succeed under
+          // complex-enabled, giving a vacuous NOT_APPLICABLE pass with no value comparison.)
+          new Case(
+              "getMap() on an ARRAY column (wrong complex type)",
+              "SELECT array_column FROM " + TABLE + " WHERE array_column IS NOT NULL LIMIT 1",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getMap(1)),
+          new Case(
+              "getArray() on a MAP column (wrong complex type)",
+              "SELECT map_column FROM " + TABLE + " WHERE map_column IS NOT NULL LIMIT 1",
+              rs -> rs.getArray(1)),
+          new Case(
+              "getStruct() on an ARRAY column (wrong complex type)",
+              "SELECT array_column FROM " + TABLE + " WHERE array_column IS NOT NULL LIMIT 1",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getStruct(1)));
 
   @Override
   public List<TestCase> getTestCases() {


### PR DESCRIPTION
## What

Closes the small additive gaps from the error-comparison coverage cross-check, so the negative comparator suites match the plan case-for-case.

- **NEGATIVE_STATEMENT_DML** — `UPDATE` / `DELETE` on a **non-updatable view** (views are read-only in Databricks, so both endpoints must reject the write). Adds a `seed_view` to the per-run namespace; dropped by the existing `DROP SCHEMA ... CASCADE` teardown.
- **NEGATIVE_STATEMENT_OTHER** — `SET` a valid conf to an **invalid value** (`SET TIMEZONE = '__no_such_timezone__'`), and a **multi-statement** (`;`-separated) script in a single `execute()`.
- **NEGATIVE_TYPE_CONVERSION** — **cross-type** complex getters: `getMap()` on an ARRAY, `getArray()` on a MAP, `getStruct()` on an ARRAY. Using the *wrong* complex type keeps the case on an error path in **both** configs — the disabled-support guard when complex types are off, or a `ClassCastException` when on — rather than a vacuous success that never value-compares the returned object.

## Why cross-type getters (not type-matched)

A type-matched getter (`getArray` on ARRAY, etc.) *succeeds* under a complex-enabled config, so the error-comparison plumbing returns `NOT_APPLICABLE` and never value-compares the returned object — a false sense of coverage. Cross-type getters always land on a comparable error path. Verified via a direct probe against both endpoints: complex-off → both throw the identical "Complex datatype support is disabled" error; complex-on → both throw a matching `ClassCastException`.

## Validation

Ran live against the peco warehouse (Thrift-vs-SEA, `ERROR_COMPARISON_MODE=shadow`):
- DML / OTHER cases → genuine both-threw error comparisons (`DIFF, 1 error mismatch` — the known Thrift-Hive-wrapper vs SEA message-wording noise, same class/SQLState).
- TYPE_CONVERSION cross-type cases → both endpoints throw identically → `PASS`.

`mvn -pl jdbc-core test-compile` → BUILD SUCCESS. `mvn spotless:apply` clean.

## Notes

Test-only comparator tooling; no driver behavior change.

NO_CHANGELOG=true