### PR TITLE
Fix TYPE_CONVERSION error-mode gate; add NEGATIVE_CONNECTION cases

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
+++ b/src/test/java/com/databricks/jdbc/comparator/ResultSetComparator.java
@@ -156,9 +156,9 @@ public class ResultSetComparator {
 
   /**
    * When {@code ERROR_COMPARISON_MODE} is on and at least one side is a {@link Throwable}, compares
-   * the errors deeply (class + SQLState + code + serverCode + message) and folds any diffs into
-   * {@code result}. Returns true when it handled the comparison; false (a no-op) when the gate is
-   * off or neither side threw, so the legacy branches below take over unchanged.
+   * the errors deeply (class + SQLState + code + message) and folds any diffs into {@code result}.
+   * Returns true when it handled the comparison; false (a no-op) when the gate is off or neither
+   * side threw, so the legacy branches below take over unchanged.
    */
   private static boolean compareErrorsDeeply(
       String queryType,

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeConnectionProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeConnectionProvider.java
@@ -43,6 +43,19 @@ public class NegativeConnectionProvider implements SuiteProvider {
           new Case(
               "Bad token (auth failure)",
               (url, token) -> new String[] {url, "dapi0000000000000000000000000000badx"}),
+          new Case("Blank token (missing credential)", (url, token) -> new String[] {url, ""}),
+          new Case(
+              "Invalid authMech",
+              (url, token) ->
+                  new String[] {url.replaceFirst("authMech=[^;]*", "authMech=99"), token}),
+          new Case(
+              "Non-existent cluster id",
+              (url, token) ->
+                  new String[] {
+                    url.replaceFirst(
+                        "httpPath=[^;]*", "httpPath=/sql/protocolv1/o/0/0000-000000-nosuchcl"),
+                    token
+                  }),
           new Case(
               "Unknown host",
               (url, token) ->

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementDmlProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementDmlProvider.java
@@ -58,6 +58,12 @@ public class NegativeStatementDmlProvider implements SuiteProvider {
               s -> "DELETE FROM " + s + ".__no_such__ WHERE id = 1"),
           new Case("executeUpdate on a SELECT (wrong method)", s -> "SELECT * FROM " + s + ".seed"),
           new Case(
+              "UPDATE a non-updatable view",
+              s -> "UPDATE " + s + ".seed_view SET name = 'x' WHERE id = 1"),
+          new Case(
+              "DELETE from a non-updatable view",
+              s -> "DELETE FROM " + s + ".seed_view WHERE id = 1"),
+          new Case(
               "Write overflow: CAST('123456' AS DECIMAL(2,0))",
               s ->
                   "INSERT INTO "
@@ -100,6 +106,9 @@ public class NegativeStatementDmlProvider implements SuiteProvider {
     exec(conn, "CREATE SCHEMA " + schema);
     exec(conn, "CREATE TABLE " + schema + ".seed (id INT NOT NULL, name STRING)");
     exec(conn, "INSERT INTO " + schema + ".seed VALUES (1, 'alice')");
+    // Views are read-only in Databricks/Spark, so UPDATE/DELETE against one must fail on both
+    // sides.
+    exec(conn, "CREATE VIEW " + schema + ".seed_view AS SELECT id, name FROM " + schema + ".seed");
   }
 
   private int execUpdate(Connection conn, String sql) throws Exception {

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementOtherProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeStatementOtherProvider.java
@@ -36,6 +36,11 @@ public class NegativeStatementOtherProvider implements SuiteProvider {
             "DESCRIBE a non-existent table"),
         new TestCase("SET = 'x'", "SET with an invalid (empty) parameter name"),
         new TestCase(
+            "SET TIMEZONE = '__no_such_timezone__'",
+            "SET a valid conf to an invalid value (bad timezone)"),
+        new TestCase(
+            "SELECT 1; SELECT 2", "multi-statement script (;-separated) in a single execute()"),
+        new TestCase(
             "EXPLAIN SELECT __no_such_column__ FROM " + TABLE, "EXPLAIN of an invalid query"),
         new TestCase(GET_MORE_RESULTS, "getMoreResults() after all results are consumed"),
         new TestCase(GET_UPDATE_COUNT, "getUpdateCount() before execute()"));

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.comparator.suite;
 
+import com.databricks.jdbc.api.IDatabricksResultSet;
 import com.databricks.jdbc.comparator.ComparisonResult;
 import com.databricks.jdbc.comparator.error.CapturedOutcome;
 import com.databricks.jdbc.comparator.error.Captures;
@@ -68,7 +69,23 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
           new Case(
               "getBigDecimal() on a STRUCT column",
               "SELECT struct_column FROM " + TABLE + " WHERE struct_column IS NOT NULL LIMIT 1",
-              rs -> rs.getBigDecimal(1)));
+              rs -> rs.getBigDecimal(1)),
+          // Cross-type complex getters: the getter targets the WRONG complex type, so it hits an
+          // error path in both configs — the disabled-support guard when complex types are off, or
+          // a ClassCastException when they are on. (Type-matched getters would succeed under
+          // complex-enabled, giving a vacuous NOT_APPLICABLE pass with no value comparison.)
+          new Case(
+              "getMap() on an ARRAY column (wrong complex type)",
+              "SELECT array_column FROM " + TABLE + " WHERE array_column IS NOT NULL LIMIT 1",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getMap(1)),
+          new Case(
+              "getArray() on a MAP column (wrong complex type)",
+              "SELECT map_column FROM " + TABLE + " WHERE map_column IS NOT NULL LIMIT 1",
+              rs -> rs.getArray(1)),
+          new Case(
+              "getStruct() on an ARRAY column (wrong complex type)",
+              "SELECT array_column FROM " + TABLE + " WHERE array_column IS NOT NULL LIMIT 1",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getStruct(1)));
 
   @Override
   public List<TestCase> getTestCases() {

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
@@ -4,6 +4,7 @@ import com.databricks.jdbc.api.IDatabricksResultSet;
 import com.databricks.jdbc.comparator.ComparisonResult;
 import com.databricks.jdbc.comparator.error.CapturedOutcome;
 import com.databricks.jdbc.comparator.error.Captures;
+import com.databricks.jdbc.comparator.error.ErrorDiffs;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -124,8 +125,12 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
       }
       CapturedOutcome left = Captures.capture(() -> c.getter.get(rs1));
       CapturedOutcome right = Captures.capture(() -> c.getter.get(rs2));
-      return Captures.compareCall(
-          label, c.description, testCase.getArgs(), left, right, v -> "value " + v);
+      // Route through ErrorDiffs (not Captures.compareCall) so the ERROR_COMPARISON_MODE=off kill
+      // switch is honored here too: off falls back to the legacy class-only check, on compares
+      // deeply. foldInto also preserves the one-sided/field-mismatch metadata/data split.
+      ComparisonResult result = new ComparisonResult(label, c.description, testCase.getArgs());
+      ErrorDiffs.foldInto(result, left, right, "value ", "");
+      return result;
     }
   }
 }


### PR DESCRIPTION
## What

Follow-up fixes from a coverage cross-check of the negative comparator suites.

- **NEGATIVE_TYPE_CONVERSION now honors the `ERROR_COMPARISON_MODE=off` kill switch.** It was the *only* suite calling `Captures.compareCall` → `ErrorComparator.compare` directly (ungated), so `off` still emitted deep SQLState/code/message diffs instead of the legacy class-only check. Now routes through `ErrorDiffs.foldInto` like every other negative suite, so `off` is a true kill switch everywhere.
- **NEGATIVE_CONNECTION** gained three cases from the plan that were missing: **blank/missing token**, **invalid `authMech`**, and **non-existent cluster id** (previously only bad-token / unknown-host / malformed-URL / bad-warehouse / bad-ConnCatalog / bad-ConnSchema). Connect/login timeout stays deferred — not deterministically reproducible from a client.
- Removed a stale `serverCode` mention from the `compareErrorsDeeply` javadoc in `ResultSetComparator` (`ErrorFacts` has no such field).

## Validation (live, peco warehouse, Thrift-vs-SEA)

- **Gate fix:** ran NEGATIVE_TYPE_CONVERSION in `off` and `shadow` — identical rows (all PASS), confirming the routing change is behavior-preserving where both sides throw the same class, and that `off` no longer emits deep diffs.
- **New connection cases (shadow):** blank-token → DIFF (both threw, message wording differs); non-existent cluster id → DIFF; invalid authMech → PASS. Probed authMech=99 directly: it throws an identical `DatabricksSQLException` on both endpoints (a genuine both-threw match, not a vacuous connect).

`mvn -pl jdbc-core test-compile` → BUILD SUCCESS. `mvn spotless:apply` clean.

## Notes

Test-only comparator tooling; no driver behavior change.

NO_CHANGELOG=true