### PR TITLE
List mismatched error fields in comparator CSV summary

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/ComparisonResult.java
+++ b/src/test/java/com/databricks/jdbc/comparator/ComparisonResult.java
@@ -54,13 +54,17 @@ public class ComparisonResult {
             .count();
     if (rowMismatches > 0) parts.add(rowMismatches + " data mismatches");
 
-    // Count error-field mismatches (e.g., "Error SQLState mismatch: ...") emitted by
-    // ErrorComparator for both-threw cases.
-    long errorMismatches =
+    // List which error fields mismatched (e.g., "Error SQLState mismatch: ...") emitted by
+    // ErrorComparator for both-threw cases. With only four comparable fields (class, SQLState,
+    // code, message) naming them stays short and is far more useful than a bare count.
+    List<String> errorFields =
         dataDifferences.stream()
-            .filter(d -> d.startsWith("Error ") && d.contains("mismatch"))
-            .count();
-    if (errorMismatches > 0) parts.add(errorMismatches + " error mismatches");
+            .filter(d -> d.startsWith("Error ") && d.contains(" mismatch"))
+            .map(d -> d.substring("Error ".length(), d.indexOf(" mismatch")))
+            .collect(Collectors.toList());
+    if (!errorFields.isEmpty()) {
+      parts.add("error mismatch: " + String.join(", ", errorFields));
+    }
 
     return parts.isEmpty() ? "" : String.join(", ", parts);
   }


### PR DESCRIPTION
## Summary

The comparator's CSV diff summary (`ComparisonResult.csvSummary()`) reported both-threw error mismatches as an opaque count — e.g. `3 error mismatches`. Since there are only four comparable error fields (`class`, `SQLState`, `code`, `message`), this change lists *which* fields differ instead of counting them, e.g. `error mismatch: class, SQLState, message`.

Why it helps:
- A row reading exactly `error mismatch: message` is the expected transport message-wording noise (Thrift bakes server detail into the message; SEA emits a generic string) — easy to triage/skip.
- Any structured-field mismatch (`class` / `SQLState` / `code`) now stands out at a glance without opening the full report. For example, `NEGATIVE_CONNECTION`'s `Invalid authMech` case surfaces `error mismatch: class, ...` (one side throws `StackOverflowError`), which the bare count hid.

Fields are listed in the stable order `ErrorComparator` emits them (class → SQLState → code → message).

## Scope

- Test-harness only (`src/test/.../comparator/ComparisonResult.java`); no driver behavior change.

NO_CHANGELOG=true

## Test plan

- [x] `ErrorComparatorTest` passes (`mvn test -pl jdbc-core -Dtest=ErrorComparatorTest`).
- [ ] Re-run a negative suite in shadow mode and confirm the CSV `Diff Summary` shows named fields.