### PR TITLE
Flatten multi-line error messages to one line in comparator diffs

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/error/ErrorComparator.java
+++ b/src/test/java/com/databricks/jdbc/comparator/error/ErrorComparator.java
@@ -57,7 +57,8 @@ public final class ErrorComparator {
       dataDiffs.add("Error code mismatch: " + l.vendorCode + " vs " + r.vendorCode);
     }
     if (!equalsNullSafe(l.message, r.message)) {
-      dataDiffs.add("Error message mismatch: '" + l.message + "' vs '" + r.message + "'");
+      dataDiffs.add(
+          "Error message mismatch: '" + oneLine(l.message) + "' vs '" + oneLine(r.message) + "'");
     }
 
     ErrorComparison.Verdict verdict =
@@ -67,6 +68,15 @@ public final class ErrorComparator {
 
   private static boolean equalsNullSafe(Object a, Object b) {
     return a == null ? b == null : a.equals(b);
+  }
+
+  /**
+   * Collapses embedded line breaks to a literal {@code \n} so a multi-line driver message (e.g. the
+   * connect wrapper "…: <host>\n<cause>") stays on a single line in the report/CSV. Comparison is
+   * still done on the raw message; only the rendered diff string is flattened.
+   */
+  private static String oneLine(String s) {
+    return s == null ? null : s.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n");
   }
 
   /**


### PR DESCRIPTION
## Summary

Driver connect failures build their message with an embedded newline — `Driver.connect` formats `"…: <host>\n<cause>"` — so an `Error message mismatch: '<left>' vs '<right>'` entry wrapped across several physical lines in the comparator report, making a single diff hard to read.

This escapes embedded line breaks (`\r\n` / `\n` / `\r`) to a literal `\n` when rendering the message diff, so each mismatch stays on one line.

- **Comparison is unchanged** — equality still runs on the raw messages; only the rendered diff string is flattened, so a genuine newline difference is still reported.
- Scoped to the error message diff in `ErrorComparator` (a new `oneLine()` helper).

## Scope

- Test-harness only (`src/test/.../comparator/error/ErrorComparator.java`); no driver behavior change.

NO_CHANGELOG=true

## Test plan

- [x] `ErrorComparatorTest` passes (`mvn test -pl jdbc-core -Dtest=ErrorComparatorTest`); the `startsWith("Error message mismatch:")` assertion still holds.
- [x] `isaac review --uncommitted` — no actionable findings.