### PR TITLE
Run NEGATIVE_TRANSACTION with transactions actually enabled

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/config/ConnectionConfig.java
+++ b/src/test/java/com/databricks/jdbc/comparator/config/ConnectionConfig.java
@@ -25,7 +25,10 @@ public enum ConnectionConfig {
           TestSuite.COMPLEX_TYPES,
           TestSuite.GEOSPATIAL,
           TestSuite.VOLUME_OPERATIONS,
-          TestSuite.NEGATIVE_VOLUME)),
+          TestSuite.NEGATIVE_VOLUME,
+          // Runs under TRANSACTIONS_ENABLED instead — under default params IgnoreTransactions=1
+          // makes commit/rollback/setAutoCommit no-ops, so the suite would test nothing.
+          TestSuite.NEGATIVE_TRANSACTION)),
 
   COMPRESSION_DISABLED(
       "Compression disabled",
@@ -74,6 +77,15 @@ public enum ConnectionConfig {
       Map.of("VolumeOperationAllowedLocalPaths", "/tmp"),
       null,
       EnumSet.of(TestSuite.VOLUME_OPERATIONS, TestSuite.NEGATIVE_VOLUME)),
+
+  // Transactions actually engaged (driver default IgnoreTransactions=1 makes setAutoCommit/commit/
+  // rollback no-ops, so the transaction suites are inert by default). Set to 0 to exercise the real
+  // transaction path.
+  TRANSACTIONS_ENABLED(
+      "Transactions enabled",
+      Map.of("IgnoreTransactions", "0"),
+      null,
+      EnumSet.of(TestSuite.NEGATIVE_TRANSACTION)),
 
   PRO_WAREHOUSE(
       "Pro warehouse",


### PR DESCRIPTION
## Summary

The driver defaults `IgnoreTransactions=1`, which makes `setAutoCommit`/`commit`/`rollback` **no-ops**. Under `DEFAULT_PARAMS`, the `NEGATIVE_TRANSACTION` suite therefore exercised nothing — every case "passed" only because the transaction calls were silently ignored, masking the real server behavior (and any Thrift-vs-SEA differences).

This adds a `TRANSACTIONS_ENABLED` connection config (`IgnoreTransactions=0`) and routes `NEGATIVE_TRANSACTION` to it (excluded from `DEFAULT_PARAMS`), so the suite runs the real transaction path.

With transactions enabled, the cases now surface genuine server behavior (verified against the peco comparator warehouse):
- `commit()` with no active transaction → `NO_ACTIVE_TRANSACTION` (SQLSTATE 25000)
- DDL inside a manual transaction → `TRANSACTION_NOT_SUPPORTED.COMMAND` (SQLSTATE 0A000) — matches the documented "DDL not supported in transactions"
- `rollback()` in autocommit mode → client-side rejection (identical on both transports)

The remaining DIFFs are the usual message-packaging differences (Thrift dumps the raw server struct; SEA returns a concise message) — the underlying server error is identical on both transports.

## Scope

- Test-harness only (`src/test/.../comparator/config/ConnectionConfig.java`); no driver behavior change.

NO_CHANGELOG=true

## Test plan

- [x] Ran `NEGATIVE_TRANSACTION` under `TRANSACTIONS_ENABLED` against the working tree — cases now hit the real transaction path (NO_ACTIVE_TRANSACTION / TRANSACTION_NOT_SUPPORTED) instead of no-op PASSes.
- [x] `mvn test-compile -pl jdbc-core` passes.