### PR TITLE
Run negative suites under more configs + add CloudFetch variants

### DIFF
--- a/src/test/java/com/databricks/jdbc/comparator/config/ConnectionConfig.java
+++ b/src/test/java/com/databricks/jdbc/comparator/config/ConnectionConfig.java
@@ -46,7 +46,9 @@ public enum ConnectionConfig {
       "ComplexTypes enabled",
       Map.of("EnableComplexDatatypeSupport", "1"),
       null,
-      EnumSet.of(TestSuite.COMPLEX_TYPES)),
+      // Also exercises NEGATIVE_TYPE_CONVERSION's complex getters with support ON (the wrong-type
+      // getters hit the Arrow ClassCastException path instead of the disabled-support guard).
+      EnumSet.of(TestSuite.COMPLEX_TYPES, TestSuite.NEGATIVE_TYPE_CONVERSION)),
 
   GEOSPATIAL_DISABLED(
       "Geospatial disabled",
@@ -70,7 +72,10 @@ public enum ConnectionConfig {
       "Direct results disabled",
       Map.of("EnableDirectResults", "0"),
       null,
-      EnumSet.of(TestSuite.STATEMENT_SELECT)),
+      // Also exercises NEGATIVE_STATEMENT_SELECT: with direct results off, Thrift surfaces runtime
+      // errors (div-by-zero, cast failure) via a different exception class/message than the
+      // default.
+      EnumSet.of(TestSuite.STATEMENT_SELECT, TestSuite.NEGATIVE_STATEMENT_SELECT)),
 
   VOLUME_OPERATIONS(
       "Volume operations",

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeResultSetProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeResultSetProvider.java
@@ -9,6 +9,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Negative ResultSet-iteration cases — mis-using a ResultSet after it (or its statement) is closed,
@@ -27,38 +28,88 @@ import java.util.List;
 public class NegativeResultSetProvider implements SuiteProvider {
 
   private static final String TABLE = "comparator_tests.oss_jdbc_tests.test_result_set_types";
+  private static final String INLINE_QUERY = "SELECT id FROM " + TABLE + " LIMIT 1";
+  // Wide + full-table scan → a CloudFetch-backed result (same pattern the positive SELECT suite
+  // uses), so the misuse runs against a chunk/link-backed ResultSet rather than an inline one.
+  private static final String CLOUDFETCH_QUERY = "SELECT * FROM " + TABLE + " ORDER BY id";
 
-  private static final String NEXT_AFTER_CLOSE = "next() after the ResultSet is closed";
-  private static final String GET_AFTER_CLOSE = "getObject() after the ResultSet is closed";
-  private static final String GET_AFTER_STMT_CLOSE = "next() after the Statement is closed";
-  private static final String COLUMN_OUT_OF_RANGE = "getObject() on an out-of-range column index";
+  private enum Kind {
+    NEXT_AFTER_CLOSE,
+    GET_AFTER_CLOSE,
+    GET_AFTER_STMT_CLOSE,
+    COLUMN_OUT_OF_RANGE
+  }
+
+  private static final class Case {
+    final String description;
+    final Kind kind;
+    final String query;
+
+    Case(String description, Kind kind, String query) {
+      this.description = description;
+      this.kind = kind;
+      this.query = query;
+    }
+  }
+
+  private static final List<Case> CASES =
+      Arrays.asList(
+          new Case("next() after the ResultSet is closed", Kind.NEXT_AFTER_CLOSE, INLINE_QUERY),
+          new Case("getObject() after the ResultSet is closed", Kind.GET_AFTER_CLOSE, INLINE_QUERY),
+          new Case("next() after the Statement is closed", Kind.GET_AFTER_STMT_CLOSE, INLINE_QUERY),
+          new Case(
+              "getObject() on an out-of-range column index",
+              Kind.COLUMN_OUT_OF_RANGE,
+              INLINE_QUERY),
+          // CloudFetch-backed variants: identical misuse on a large (CloudFetch) result. The errors
+          // are client-side, so they are expected to match inline — this exercises the CloudFetch
+          // result path for parity with the positive suites.
+          new Case(
+              "next() after the ResultSet is closed (CloudFetch)",
+              Kind.NEXT_AFTER_CLOSE,
+              CLOUDFETCH_QUERY),
+          new Case(
+              "getObject() after the ResultSet is closed (CloudFetch)",
+              Kind.GET_AFTER_CLOSE,
+              CLOUDFETCH_QUERY),
+          new Case(
+              "next() after the Statement is closed (CloudFetch)",
+              Kind.GET_AFTER_STMT_CLOSE,
+              CLOUDFETCH_QUERY),
+          new Case(
+              "getObject() on an out-of-range column index (CloudFetch)",
+              Kind.COLUMN_OUT_OF_RANGE,
+              CLOUDFETCH_QUERY));
 
   @Override
   public List<TestCase> getTestCases() {
-    return Arrays.asList(
-        new TestCase(NEXT_AFTER_CLOSE, NEXT_AFTER_CLOSE),
-        new TestCase(GET_AFTER_CLOSE, GET_AFTER_CLOSE),
-        new TestCase(GET_AFTER_STMT_CLOSE, GET_AFTER_STMT_CLOSE),
-        new TestCase(COLUMN_OUT_OF_RANGE, COLUMN_OUT_OF_RANGE));
+    return CASES.stream()
+        .map(c -> new TestCase(c.description, c.description))
+        .collect(Collectors.toList());
   }
 
   @Override
   public ComparisonResult execute(
       Connection conn1, Connection conn2, TestCase testCase, String label) throws Exception {
-    String id = testCase.getIdentifier();
-    CapturedOutcome left = Captures.capture(() -> runCase(conn1, id));
-    CapturedOutcome right = Captures.capture(() -> runCase(conn2, id));
-    ComparisonResult result = new ComparisonResult(label, id, testCase.getArgs());
+    Case c =
+        CASES.stream()
+            .filter(x -> x.description.equals(testCase.getIdentifier()))
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalArgumentException("Unknown case: " + testCase.getIdentifier()));
+    CapturedOutcome left = Captures.capture(() -> runCase(conn1, c));
+    CapturedOutcome right = Captures.capture(() -> runCase(conn2, c));
+    ComparisonResult result = new ComparisonResult(label, c.description, testCase.getArgs());
     ErrorDiffs.foldInto(result, left, right, "result ", "");
     return result;
   }
 
-  private Object runCase(Connection conn, String id) throws Exception {
-    switch (id) {
+  private Object runCase(Connection conn, Case c) throws Exception {
+    switch (c.kind) {
       case NEXT_AFTER_CLOSE:
         {
           Statement s = conn.createStatement();
-          ResultSet rs = s.executeQuery("SELECT id FROM " + TABLE + " LIMIT 1");
+          ResultSet rs = s.executeQuery(c.query);
           rs.close();
           try {
             return rs.next(); // ResultSet closed
@@ -69,7 +120,7 @@ public class NegativeResultSetProvider implements SuiteProvider {
       case GET_AFTER_CLOSE:
         {
           Statement s = conn.createStatement();
-          ResultSet rs = s.executeQuery("SELECT id FROM " + TABLE + " LIMIT 1");
+          ResultSet rs = s.executeQuery(c.query);
           rs.next();
           rs.close();
           try {
@@ -81,20 +132,20 @@ public class NegativeResultSetProvider implements SuiteProvider {
       case GET_AFTER_STMT_CLOSE:
         {
           Statement s = conn.createStatement();
-          ResultSet rs = s.executeQuery("SELECT id FROM " + TABLE + " LIMIT 1");
+          ResultSet rs = s.executeQuery(c.query);
           s.close(); // closing the statement closes the ResultSet
           return rs.next();
         }
       case COLUMN_OUT_OF_RANGE:
         {
           try (Statement s = conn.createStatement();
-              ResultSet rs = s.executeQuery("SELECT id FROM " + TABLE + " LIMIT 1")) {
+              ResultSet rs = s.executeQuery(c.query)) {
             rs.next();
             return rs.getObject(999); // out-of-range column index
           }
         }
       default:
-        throw new IllegalArgumentException("Unknown case: " + id);
+        throw new IllegalArgumentException("Unknown kind: " + c.kind);
     }
   }
 }

--- a/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
+++ b/src/test/java/com/databricks/jdbc/comparator/suite/NegativeTypeConversionProvider.java
@@ -34,11 +34,17 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
     final String description;
     final String query;
     final Getter getter;
+    final Boolean expectCloudFetch;
 
     Case(String description, String query, Getter getter) {
+      this(description, query, getter, null);
+    }
+
+    Case(String description, String query, Getter getter, Boolean expectCloudFetch) {
       this.description = description;
       this.query = query;
       this.getter = getter;
+      this.expectCloudFetch = expectCloudFetch;
     }
   }
 
@@ -86,12 +92,30 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
           new Case(
               "getStruct() on an ARRAY column (wrong complex type)",
               "SELECT array_column FROM " + TABLE + " WHERE array_column IS NOT NULL LIMIT 1",
-              rs -> rs.unwrap(IDatabricksResultSet.class).getStruct(1)));
+              rs -> rs.unwrap(IDatabricksResultSet.class).getStruct(1)),
+          // CloudFetch variants: force a large (CloudFetch) result with SELECT * over the full
+          // table, then apply the wrong complex getter to the complex column (read by name). These
+          // exercise the Arrow/CloudFetch complex path at scale, mirroring the positive suites.
+          new Case(
+              "getMap() on an ARRAY column (wrong complex type, CloudFetch)",
+              "SELECT * FROM " + TABLE + " ORDER BY id",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getMap(rs.findColumn("array_column")),
+              true),
+          new Case(
+              "getArray() on a MAP column (wrong complex type, CloudFetch)",
+              "SELECT * FROM " + TABLE + " ORDER BY id",
+              rs -> rs.getArray(rs.findColumn("map_column")),
+              true),
+          new Case(
+              "getStruct() on an ARRAY column (wrong complex type, CloudFetch)",
+              "SELECT * FROM " + TABLE + " ORDER BY id",
+              rs -> rs.unwrap(IDatabricksResultSet.class).getStruct(rs.findColumn("array_column")),
+              true));
 
   @Override
   public List<TestCase> getTestCases() {
     return CASES.stream()
-        .map(c -> new TestCase(c.description, c.description))
+        .map(c -> new TestCase(c.description, new Object[0], c.description, c.expectCloudFetch))
         .collect(Collectors.toList());
   }
 
@@ -109,6 +133,8 @@ public class NegativeTypeConversionProvider implements SuiteProvider {
         Statement s2 = conn2.createStatement();
         ResultSet rs1 = s1.executeQuery(c.query);
         ResultSet rs2 = s2.executeQuery(c.query)) {
+      // For CloudFetch variants, verify the large result actually used CloudFetch on both sides.
+      assertCloudFetchExpectation(testCase, rs1, rs2);
       // Both queries must return the same shape; if a side has no row, the getter can't run — that
       // is a harness/data problem, so let it propagate (fail loudly) rather than compare noise.
       boolean has1 = rs1.next();


### PR DESCRIPTION
## Summary

Extends the negative (error-comparison) suites to exercise the connection-config and result-format combinations the positive suites already cover, so error behavior is compared across the paths that actually change it.

- **`ConnectionConfig`:** run `NEGATIVE_TYPE_CONVERSION` under `COMPLEX_TYPES_ENABLED` (complex getters take the Arrow path instead of the disabled-support guard) and `NEGATIVE_STATEMENT_SELECT` under `DIRECT_RESULTS_DISABLED` (Thrift surfaces runtime errors via a different path). Both suites still run under `DEFAULT_PARAMS` too.
- **`NEGATIVE_TYPE_CONVERSION`:** add CloudFetch (large `SELECT *`) variants of the wrong-complex-type getters, with a CloudFetch assertion, mirroring the positive SELECT suite's inline-vs-CloudFetch coverage.
- **`NEGATIVE_RESULTSET`:** add CloudFetch-backed variants of the misuse cases.

## Why it's useful

The `NEGATIVE_RESULTSET` CloudFetch variant localizes the out-of-range-column divergence to the **Arrow path**: `getObject()` on an out-of-range column **DIFFs** on an inline result (Thrift inline throws `DatabricksSQLException` vs SEA Arrow leaking a raw `IndexOutOfBoundsException`) but **matches** on a CloudFetch result (both transports use Arrow, so both leak the same exception). The other added combinations broaden coverage (complex-enabled getters, direct-results-off) and guard against future divergence, matching the positive-suite philosophy.

## Scope

- Test-harness only (comparator suites/config under `src/test/...`); no driver behavior change.

NO_CHANGELOG=true

## Test plan

- [x] Ran `NEGATIVE_TYPE_CONVERSION` + `NEGATIVE_RESULTSET` against the peco comparator warehouse: all TYPE_CONVERSION cases (incl. CloudFetch variants, under both configs) PASS; RESULTSET CloudFetch assertion passes and the out-of-range case DIFFs inline / matches on CloudFetch as expected.
- [x] `mvn test-compile` / lint clean.