### PR TITLE
Fix NPE reading STRING COLLATE columns via Arrow

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.
 
+- Fixed `NullPointerException` when reading collated string columns (e.g. `STRING COLLATE UTF8_LCASE`) over Arrow. Such columns report a `type_name` that does not map to a `ColumnInfoTypeName`, leaving it null; the value read now recovers `STRING` from the type text and the result set metadata reports `VARCHAR` instead of `OTHER`, while `getColumnTypeName()` still preserves the collated type text.
+
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -105,13 +105,15 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
           }
 
           // For collated string columns (e.g. "STRING COLLATE UTF8_LCASE") getTypeName() returns
-          // null because the collated type name does not map to a ColumnInfoTypeName. Recover STRING
-          // from the typeText prefix so the java.sql type resolves to VARCHAR instead of OTHER; the
+          // null because the collated type name does not map to a ColumnInfoTypeName. Recover
+          // STRING from the typeText so the java.sql type resolves to VARCHAR instead of OTHER; the
           // original typeText is preserved so getColumnTypeName() still reports the collated type.
-          if (columnTypeName == null
-              && columnInfo.getTypeText() != null
-              && columnInfo.getTypeText().toUpperCase().startsWith(STRING)) {
-            columnTypeName = ColumnInfoTypeName.STRING;
+          if (columnTypeName == null) {
+            ColumnInfoTypeName recovered =
+                DatabricksTypeUtil.recoverStringType(columnInfo.getTypeText());
+            if (recovered != null) {
+              columnTypeName = recovered;
+            }
           }
 
           // Check if we need to convert geospatial types to string when geospatial support is

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -109,11 +109,7 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
           // STRING from the typeText so the java.sql type resolves to VARCHAR instead of OTHER; the
           // original typeText is preserved so getColumnTypeName() still reports the collated type.
           if (columnTypeName == null) {
-            ColumnInfoTypeName recovered =
-                DatabricksTypeUtil.recoverStringType(columnInfo.getTypeText());
-            if (recovered != null) {
-              columnTypeName = recovered;
-            }
+            columnTypeName = DatabricksTypeUtil.recoverStringType(columnInfo.getTypeText());
           }
 
           // Check if we need to convert geospatial types to string when geospatial support is

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaData.java
@@ -104,6 +104,16 @@ public class DatabricksResultSetMetaData implements ResultSetMetaData {
             }
           }
 
+          // For collated string columns (e.g. "STRING COLLATE UTF8_LCASE") getTypeName() returns
+          // null because the collated type name does not map to a ColumnInfoTypeName. Recover STRING
+          // from the typeText prefix so the java.sql type resolves to VARCHAR instead of OTHER; the
+          // original typeText is preserved so getColumnTypeName() still reports the collated type.
+          if (columnTypeName == null
+              && columnInfo.getTypeText() != null
+              && columnInfo.getTypeText().toUpperCase().startsWith(STRING)) {
+            columnTypeName = ColumnInfoTypeName.STRING;
+          }
+
           // Check if we need to convert geospatial types to string when geospatial support is
           // disabled
           String typeText = columnInfo.getTypeText();

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
@@ -92,9 +92,9 @@ public class ArrowToJavaObjectConverter {
       }
       // A collated string column (e.g. "STRING COLLATE UTF8_LCASE") is reported with a type_name
       // that does not map to any ColumnInfoTypeName, leaving requiredType null. Recover the type
-      // from the metadata prefix so the value is read as a string instead of throwing an NPE below.
-      if (requiredType == null && arrowMetadata.startsWith(STRING)) {
-        requiredType = ColumnInfoTypeName.STRING;
+      // from the metadata so the value is read as a string instead of throwing an NPE below.
+      if (requiredType == null) {
+        requiredType = recoverStringType(arrowMetadata);
       }
     }
     if (object == null) {

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
@@ -90,9 +90,23 @@ public class ArrowToJavaObjectConverter {
       if (arrowMetadata.startsWith(GEOGRAPHY)) {
         requiredType = ColumnInfoTypeName.GEOGRAPHY;
       }
+      // A collated string column (e.g. "STRING COLLATE UTF8_LCASE") is reported with a type_name
+      // that does not map to any ColumnInfoTypeName, leaving requiredType null. Recover the type
+      // from the metadata prefix so the value is read as a string instead of throwing an NPE below.
+      if (requiredType == null && arrowMetadata.startsWith(STRING)) {
+        requiredType = ColumnInfoTypeName.STRING;
+      }
     }
     if (object == null) {
       return null;
+    }
+    if (requiredType == null) {
+      String errorMessage =
+          String.format(
+              "Unable to determine column type for value %s with metadata %s",
+              object, arrowMetadata);
+      LOGGER.error(errorMessage);
+      throw new DatabricksValidationException(errorMessage);
     }
     switch (requiredType) {
       case BYTE:

--- a/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverter.java
@@ -101,10 +101,9 @@ public class ArrowToJavaObjectConverter {
       return null;
     }
     if (requiredType == null) {
+      // Do not log the raw cell value, which may contain sensitive data; log only the metadata.
       String errorMessage =
-          String.format(
-              "Unable to determine column type for value %s with metadata %s",
-              object, arrowMetadata);
+          String.format("Unable to determine column type from metadata %s", arrowMetadata);
       LOGGER.error(errorMessage);
       throw new DatabricksValidationException(errorMessage);
     }

--- a/src/main/java/com/databricks/jdbc/common/util/DatabricksTypeUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/DatabricksTypeUtil.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -79,6 +80,32 @@ public class DatabricksTypeUtil {
               ColumnInfoTypeName.TINYINT,
               ColumnInfoTypeName.BYTE,
               ColumnInfoTypeName.BIGINT));
+
+  /**
+   * Recovers {@link ColumnInfoTypeName#STRING} from a server type name/text when the enum type
+   * could not be resolved (i.e. {@code getTypeName()} is null). A collated string column is
+   * reported as {@code "STRING COLLATE UTF8_LCASE"}, which does not map to any {@link
+   * ColumnInfoTypeName}; without this the value read NPEs and the metadata reports {@code OTHER}.
+   *
+   * <p>Matches on a word boundary so {@code "STRING"} and {@code "STRING COLLATE ..."} are
+   * recovered but hypothetical future types such as {@code "STRINGVIEW"} are not. Case-insensitive
+   * via {@link Locale#ROOT} so both sites (value and metadata paths) agree regardless of the case
+   * the server emits.
+   *
+   * @param typeText the server type text (e.g. arrow metadata or {@code ColumnInfo.getTypeText()})
+   * @return {@link ColumnInfoTypeName#STRING} if the text denotes a (possibly collated) string,
+   *     otherwise {@code null}
+   */
+  public static ColumnInfoTypeName recoverStringType(String typeText) {
+    if (typeText == null) {
+      return null;
+    }
+    String upper = typeText.toUpperCase(Locale.ROOT);
+    if (upper.equals(STRING) || upper.startsWith(STRING + " ") || upper.startsWith(STRING + "(")) {
+      return ColumnInfoTypeName.STRING;
+    }
+    return null;
+  }
 
   /**
    * Maps a SQL type name (as returned by DESCRIBE QUERY or schema metadata) to the corresponding

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -147,6 +147,29 @@ public class DatabricksResultSetMetaDataTest {
   }
 
   @Test
+  public void testColumnsWithCollatedString() throws SQLException {
+    ResultManifest resultManifest = new ResultManifest();
+    resultManifest.setTotalRowCount(1L);
+    ResultSchema schema = new ResultSchema();
+    schema.setColumnCount(1L);
+
+    // A collated string column arrives with a null typeName (the collated type name does not map
+    // to a ColumnInfoTypeName) and a typeText carrying the collation.
+    ColumnInfo collatedColumnInfo = getColumn("name", null, "STRING COLLATE UTF8_LCASE");
+    schema.setColumns(List.of(collatedColumnInfo));
+    resultManifest.setSchema(schema);
+
+    DatabricksResultSetMetaData metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
+    assertEquals(1, metaData.getColumnCount());
+    assertEquals("name", metaData.getColumnName(1));
+    // The collated type text is preserved for getColumnTypeName(), but the java.sql type resolves
+    // to VARCHAR (instead of OTHER) so the column is usable as a string.
+    assertEquals("STRING COLLATE UTF8_LCASE", metaData.getColumnTypeName(1));
+    assertEquals(Types.VARCHAR, metaData.getColumnType(1));
+  }
+
+  @Test
   public void testColumnsWithTimestampNTZ_legacyTypeNameDisabled() throws SQLException {
     // With EnableTimestampNtzTypeName=0 the type name is normalized to TIMESTAMP to
     // match the legacy (v2.x.x) driver behavior. The java.sql type is unchanged.

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetMetaDataTest.java
@@ -170,6 +170,24 @@ public class DatabricksResultSetMetaDataTest {
   }
 
   @Test
+  public void testColumnsWithCollatedStringLowerCase() throws SQLException {
+    // Recovery must be case-insensitive so a lower/mixed-case collated type text resolves the same
+    // way (VARCHAR) as the upper-case form, matching the value path.
+    ResultManifest resultManifest = new ResultManifest();
+    resultManifest.setTotalRowCount(1L);
+    ResultSchema schema = new ResultSchema();
+    schema.setColumnCount(1L);
+
+    ColumnInfo collatedColumnInfo = getColumn("name", null, "string collate utf8_lcase");
+    schema.setColumns(List.of(collatedColumnInfo));
+    resultManifest.setSchema(schema);
+
+    DatabricksResultSetMetaData metaData =
+        new DatabricksResultSetMetaData(STATEMENT_ID, resultManifest, false, connectionContext);
+    assertEquals(Types.VARCHAR, metaData.getColumnType(1));
+  }
+
+  @Test
   public void testColumnsWithTimestampNTZ_legacyTypeNameDisabled() throws SQLException {
     // With EnableTimestampNtzTypeName=0 the type name is normalized to TIMESTAMP to
     // match the legacy (v2.x.x) driver behavior. The java.sql type is unchanged.

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
@@ -137,6 +137,22 @@ public class ArrowToJavaObjectConverterTest {
     enableArrowNullChecking();
   }
 
+  @Test
+  public void testCollatedStringWithNullRequiredType() throws Exception {
+    // A collated string column (e.g. STRING COLLATE UTF8_LCASE) is reported with a type_name that
+    // does not map to any ColumnInfoTypeName, so requiredType arrives as null. The type must be
+    // recovered from the metadata prefix and read as a string rather than throwing an NPE.
+    VarCharVector vector = new VarCharVector("collatedVector", this.bufferAllocator);
+    vector.allocateNew(1);
+    vector.set(0, "Hello".getBytes());
+    vector.setValueCount(1);
+
+    assertEquals(
+        "Hello", convert(vector, 0, null, "STRING COLLATE UTF8_LCASE", new ColumnInfo()));
+
+    vector.close();
+  }
+
   private void disableArrowNullChecking() {
     System.setProperty("arrow.enable_null_check_for_get", "false");
   }

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
@@ -141,7 +141,7 @@ public class ArrowToJavaObjectConverterTest {
   public void testCollatedStringWithNullRequiredType() throws Exception {
     // A collated string column (e.g. STRING COLLATE UTF8_LCASE) is reported with a type_name that
     // does not map to any ColumnInfoTypeName, so requiredType arrives as null. The type must be
-    // recovered from the metadata prefix and read as a string rather than throwing an NPE.
+    // recovered from the metadata and read as a string rather than throwing an NPE.
     VarCharVector vector = new VarCharVector("collatedVector", this.bufferAllocator);
     vector.allocateNew(1);
     vector.set(0, "Hello".getBytes());

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
@@ -147,8 +147,37 @@ public class ArrowToJavaObjectConverterTest {
     vector.set(0, "Hello".getBytes());
     vector.setValueCount(1);
 
-    assertEquals(
-        "Hello", convert(vector, 0, null, "STRING COLLATE UTF8_LCASE", new ColumnInfo()));
+    assertEquals("Hello", convert(vector, 0, null, "STRING COLLATE UTF8_LCASE", new ColumnInfo()));
+
+    vector.close();
+  }
+
+  @Test
+  public void testCollatedStringLowerCaseMetadata() throws Exception {
+    // The collated type text may arrive in lower/mixed case; recovery must be case-insensitive so
+    // the value path and the metadata path agree (both use DatabricksTypeUtil.recoverStringType).
+    VarCharVector vector = new VarCharVector("collatedVector", this.bufferAllocator);
+    vector.allocateNew(1);
+    vector.set(0, "Hello".getBytes());
+    vector.setValueCount(1);
+
+    assertEquals("Hello", convert(vector, 0, null, "string collate utf8_lcase", new ColumnInfo()));
+
+    vector.close();
+  }
+
+  @Test
+  public void testTypeStartingWithStringWordIsNotCoercedToString() throws Exception {
+    // A hypothetical future type whose name merely begins with the letters STRING (e.g. STRINGVIEW)
+    // must NOT be silently coerced to STRING; recovery matches on a word boundary only.
+    VarCharVector vector = new VarCharVector("stringViewVector", this.bufferAllocator);
+    vector.allocateNew(1);
+    vector.set(0, "Hello".getBytes());
+    vector.setValueCount(1);
+
+    assertThrows(
+        DatabricksValidationException.class,
+        () -> convert(vector, 0, null, "STRINGVIEW", new ColumnInfo()));
 
     vector.close();
   }

--- a/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/converters/ArrowToJavaObjectConverterTest.java
@@ -153,6 +153,22 @@ public class ArrowToJavaObjectConverterTest {
     vector.close();
   }
 
+  @Test
+  public void testUnresolvableTypeThrowsValidationException() throws Exception {
+    // A non-null value whose type cannot be resolved (null requiredType and metadata matching no
+    // known prefix) must throw a DatabricksValidationException rather than a NullPointerException.
+    VarCharVector vector = new VarCharVector("unknownVector", this.bufferAllocator);
+    vector.allocateNew(1);
+    vector.set(0, "value".getBytes());
+    vector.setValueCount(1);
+
+    assertThrows(
+        DatabricksValidationException.class,
+        () -> convert(vector, 0, null, "SOME_UNKNOWN_TYPE", new ColumnInfo()));
+
+    vector.close();
+  }
+
   private void disableArrowNullChecking() {
     System.setProperty("arrow.enable_null_check_for_get", "false");
   }

--- a/src/test/java/com/databricks/jdbc/common/util/DatabricksTypeUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/DatabricksTypeUtilTest.java
@@ -440,4 +440,25 @@ class DatabricksTypeUtilTest {
     assertEquals(
         "DECIMAL(8,8)", DatabricksTypeUtil.getDecimalTypeString(new BigDecimal("0.00000123")));
   }
+
+  @Test
+  public void testRecoverStringType() {
+    // Plain and collated string, any case -> STRING
+    assertEquals(ColumnInfoTypeName.STRING, DatabricksTypeUtil.recoverStringType("STRING"));
+    assertEquals(
+        ColumnInfoTypeName.STRING,
+        DatabricksTypeUtil.recoverStringType("STRING COLLATE UTF8_LCASE"));
+    assertEquals(
+        ColumnInfoTypeName.STRING,
+        DatabricksTypeUtil.recoverStringType("string collate utf8_lcase"));
+    assertEquals(ColumnInfoTypeName.STRING, DatabricksTypeUtil.recoverStringType("STRING(10)"));
+
+    // Word-boundary: a longer type merely starting with STRING is not coerced
+    assertNull(DatabricksTypeUtil.recoverStringType("STRINGVIEW"));
+    assertNull(DatabricksTypeUtil.recoverStringType("STRINGSET"));
+
+    // Non-string / null
+    assertNull(DatabricksTypeUtil.recoverStringType("INT"));
+    assertNull(DatabricksTypeUtil.recoverStringType(null));
+  }
 }


### PR DESCRIPTION
## Description

Fixes #1547.

A `STRING` column carrying a non-default collation (e.g. `STRING COLLATE UTF8_LCASE`) cannot be read when the warehouse reports its type via the Statement Execution API (SEA). Such a column arrives with a `type_name` that does not map to any `ColumnInfoTypeName`, so `ColumnInfo.getTypeName()` is `null`, and two things break:

1. **Value read** — `ArrowToJavaObjectConverter.convert` reaches `switch (requiredType)` with `requiredType == null` and throws a `NullPointerException`. This aborts every result set containing a collated string column, including a single-row result.
2. **Metadata** — `DatabricksResultSetMetaData` maps the null type name to `Types.OTHER`, so `getColumnType()` returns `OTHER` and the column is not usable as a string, even once the value read is fixed.

### Trigger

The defect is latent in the driver's type handling — the converter and metadata builder both rely on the `ColumnInfoTypeName` enum resolving, and neither tolerates a null. What surfaces it is which metadata path the warehouse answers with: the Thrift path maps the collated column to `STRING`, while the SEA path returns the collated type text verbatim (`STRING COLLATE UTF8_LCASE`, over Arrow `type_name = UNKNOWN_COLUMN_TYPE_NAME`), which yields a null `ColumnInfoTypeName`. The converter source is unchanged across recent versions; the trigger is the metadata routing, gated on the advertised driver version. (Verified: same driver + query, one warehouse answered Thrift and read fine, another answered SEA and NPE'd; the SDK 0.69→0.106 bump was ruled out.)

## Changes

- **`DatabricksTypeUtil.recoverStringType(typeText)`** (new): returns `ColumnInfoTypeName.STRING` when the given type text denotes a (possibly collated) string, else `null`. Case-insensitive (`Locale.ROOT`) and matches on a word boundary, so `STRING`, `STRING COLLATE ...` and `STRING(...)` are recovered but a hypothetical future `STRINGVIEW` is not.
- **`ArrowToJavaObjectConverter.convert`** (value path): when `requiredType` is null, recover it via `recoverStringType(arrowMetadata)`. The `switch` is also guarded with an explicit `DatabricksValidationException` (logging only the metadata, not the raw cell value) so any genuinely unmappable type produces a clear error instead of a raw NPE.
- **`DatabricksResultSetMetaData`** (SEA result manifest constructor, metadata path): when the column type name is null, recover it via `recoverStringType(columnInfo.getTypeText())` so `getColumnType()` resolves to `VARCHAR` instead of `OTHER`. The collated type text is preserved so `getColumnTypeName()` still reports the server type (mirroring the existing `TIMESTAMP_NTZ` null-recovery).

Both call sites share the same recovery rule but pass their own source (arrow field metadata for the value path, manifest `type_text` for the metadata path), since those channels legitimately differ.

## Testing

- `DatabricksTypeUtilTest#testRecoverStringType` — plain/collated string in any case → `STRING`; word-boundary rejection (`STRINGVIEW`/`STRINGSET`); non-string and null → `null`.
- `ArrowToJavaObjectConverterTest`: `testCollatedStringWithNullRequiredType` (upper), `testCollatedStringLowerCaseMetadata` (lower, covers case handling), `testTypeStartingWithStringWordIsNotCoercedToString` (word boundary → `DatabricksValidationException`), `testUnresolvableTypeThrowsValidationException` (null-guard).
- `DatabricksResultSetMetaDataTest`: `testColumnsWithCollatedString` and `testColumnsWithCollatedStringLowerCase` — `getColumnType()` is `VARCHAR`, `getColumnTypeName()` preserves the collated text.
- Affected suites pass (151 tests across the three classes).
- Validated end-to-end against a live SQL warehouse whose view exposes `rule_name COLLATE UTF8_LCASE` / `rule_description COLLATE UTF8_LCASE` over the SEA path: with this change, all columns read successfully and `getColumnType()` reports `VARCHAR`, where the unpatched driver throws the NPE.

## Additional Notes to the Reviewer

- This revision consolidates the earlier two inline prefix checks into the single `recoverStringType` helper, addressing the review: the two sites now share one case-insensitive, word-boundary rule (no case drift between value and metadata paths), and a future unmappable type fails with a clear exception rather than an NPE.
- Longer term, the more robust fix is to drive value conversion from the Arrow physical type and treat the server type name as a non-fatal string (as the databricks-sql-python and databricks-sql-go connectors do, which do not have this bug); that is a larger, hot-path change better owned by maintainers. This PR is the contained fix. See #1547 for the design discussion.
