### PR TITLE
Enable release freeze

### DIFF
--- a/development/.release-freeze.json
+++ b/development/.release-freeze.json
@@ -1,3 +1,3 @@
 {
-  "freeze": false
+  "freeze": true
 }


### PR DESCRIPTION
Enables the release freeze by setting `"freeze": true` in `development/.release-freeze.json`. While active, PRs are blocked from merging; individual PRs can override with `OVERRIDE_FREEZE=true` in their description.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.