### PR TITLE
Improve SEA connection-failure error messages

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Improved SEA connection-failure error messages.
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -841,7 +841,13 @@ public class DatabricksSdkClient implements IDatabricksClient {
       return buildSSLCertificatePathErrorMessage(e);
     }
 
-    return "Error while establishing a connection in databricks";
+    String detail = e.getMessage();
+    if (detail == null || detail.isEmpty()) {
+      return "Error while establishing a connection in databricks";
+    }
+    String message = "Error while establishing a connection in databricks: " + detail;
+    int status = e.getStatusCode();
+    return status > 0 ? message + " (HTTP " + status + ")" : message;
   }
 
   /** Builds the SSL certificate path error message with actionable steps. */

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
@@ -33,6 +33,7 @@ import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.jdbc.model.core.ResultSchema;
 import com.databricks.jdbc.model.core.StatementStatus;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksError;
 import com.databricks.sdk.core.http.Request;
@@ -895,8 +896,11 @@ public class DatabricksSdkClientTest {
             DatabricksSQLException.class,
             () -> databricksSdkClient.createSession(warehouse, null, null, null));
 
-    String errorMessage = exception.getMessage();
-    assertEquals("Error while establishing a connection in databricks", errorMessage);
+    assertEquals(
+        "Error while establishing a connection in databricks: Some other error (HTTP 500)",
+        exception.getMessage());
+    assertEquals(DatabricksDriverErrorCode.CONNECTION_ERROR.name(), exception.getSQLState());
+    assertSame(nonSSLError, exception.getCause());
   }
 
   private static ImmutableSqlParameter getSqlParam(


### PR DESCRIPTION
## Description

SEA connection failures (bad token, missing credential, non-existent warehouse, etc.) surfaced only a generic `Error while establishing a connection in databricks` in `getMessage()`. The SDK already provides actionable detail (`Invalid access token`, HTTP status, etc.) but `buildErrorMessage()` discarded it. Thrift already propagates server text into the message; this aligns SEA for HTTP API failures.

- Append `DatabricksError` message and `(HTTP status)` in `buildErrorMessage()` fallback
- SSL certificate-path branch unchanged; exception type, SQLState, and cause chain unchanged
- Unknown-host failures are unchanged (different `DatabricksException` path)

## Testing

- [x] `mvn test -pl jdbc-core -Dtest=DatabricksSdkClientTest#testCreateSessionWithNonSSLError,DatabricksSdkClientTest#testCreateSessionWithSSLCertificatePathError`
- [x] Live repro: bad token, blank token, non-existent warehouse — server detail now in `getMessage()`
- [x] `isaac review --uncommitted` — APPROVE (0 actionable findings)

## Additional Notes to the Reviewer

Scope is intentionally minimal: one fallback return in `buildErrorMessage()`. No change to unknown-host handling (`DatabricksException` bypasses this path).