### PR TITLE
Throw SQLException for wrong complex-type getter calls

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.
+
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
@@ -1598,7 +1598,16 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
     }
     checkIfClosed();
     Object obj = getObjectInternal(columnIndex);
-
+    if (obj != null && !(obj instanceof DatabricksArray)) {
+      throw new DatabricksSQLException(
+          "Column "
+              + columnIndex
+              + " is not an ARRAY; cannot use getArray() (actual type: "
+              + obj.getClass().getSimpleName()
+              + ")",
+          DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_ARRAY_CONVERSION_ERROR,
+          silenceNonTerminalExceptions);
+    }
     return (DatabricksArray) obj;
   }
 
@@ -1630,7 +1639,16 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
     }
     checkIfClosed();
     Object obj = getObjectInternal(columnIndex);
-
+    if (obj != null && !(obj instanceof DatabricksStruct)) {
+      throw new DatabricksSQLException(
+          "Column "
+              + columnIndex
+              + " is not a STRUCT; cannot use getStruct() (actual type: "
+              + obj.getClass().getSimpleName()
+              + ")",
+          DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_STRUCT_CONVERSION_ERROR,
+          silenceNonTerminalExceptions);
+    }
     return (DatabricksStruct) obj;
   }
 
@@ -1663,7 +1681,16 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
     }
     checkIfClosed();
     Object obj = getObjectInternal(columnIndex);
-
+    if (obj != null && !(obj instanceof DatabricksMap)) {
+      throw new DatabricksSQLException(
+          "Column "
+              + columnIndex
+              + " is not a MAP; cannot use getMap() (actual type: "
+              + obj.getClass().getSimpleName()
+              + ")",
+          DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_MAP_CONVERSION_ERROR,
+          silenceNonTerminalExceptions);
+    }
     return (Map<String, Object>) obj;
   }
 

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
@@ -586,14 +586,12 @@ public class DatabricksResultSetTest {
 
   @Test
   void testGetMap() throws SQLException {
-    // Define expected map entries
-    Object[] mapEntries = {"key1", 100, "key2", 200};
-
     // Mock DatabricksMap
-    DatabricksMap<String, Integer> mockMap = mock(DatabricksMap.class);
+    DatabricksMap<String, Integer> mockMap =
+        new DatabricksMap<>(Map.of("key1", 100, "key2", 200), "MAP<STRING, INT>");
 
     // Mock execution result
-    when(mockedExecutionResult.getObject(4)).thenReturn(Map.of("key1", 100, "key2", 200));
+    when(mockedExecutionResult.getObject(4)).thenReturn(mockMap);
     when(mockedResultSetMetadata.getColumnNameIndex("int_map")).thenReturn(5);
 
     // Instantiate result set
@@ -614,6 +612,57 @@ public class DatabricksResultSetTest {
     // Retrieve map by label
     Map<String, Integer> retrievedMapByLabel = resultSet.getMap("int_map");
     assertNotNull(retrievedMapByLabel, "Retrieved map by label should not be null");
+  }
+
+  @Test
+  void testComplexGetterWrongTypeThrowsDatabricksSQLException() throws SQLException {
+    DatabricksArray array = new DatabricksArray(List.of("a"), "ARRAY<STRING>");
+    DatabricksMap<String, Integer> map = new DatabricksMap<>(Map.of("k", 1), "MAP<STRING, INT>");
+    DatabricksStruct struct = new DatabricksStruct(Map.of("id", 1), "STRUCT<id: INT>");
+
+    when(mockedExecutionResult.getObject(0)).thenReturn(array);
+    when(mockedExecutionResult.getObject(1)).thenReturn(map);
+    when(mockedExecutionResult.getObject(2)).thenReturn(struct);
+    when(mockedExecutionResult.getObject(3)).thenReturn(null);
+
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.METADATA,
+            null,
+            mockedExecutionResult,
+            mockedResultSetMetadata,
+            true);
+
+    assertNotNull(resultSet.getArray(1));
+    assertNotNull(resultSet.getMap(2));
+    assertNotNull(resultSet.getStruct(3));
+    assertNull(resultSet.getArray(4));
+
+    DatabricksSQLException getMapOnArray =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getMap(1));
+    assertEquals(
+        DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_MAP_CONVERSION_ERROR.name(),
+        getMapOnArray.getSQLState());
+
+    DatabricksSQLException getArrayOnMap =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getArray(2));
+    assertEquals(
+        DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_ARRAY_CONVERSION_ERROR.name(),
+        getArrayOnMap.getSQLState());
+
+    DatabricksSQLException getStructOnArray =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getStruct(1));
+    assertEquals(
+        DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_STRUCT_CONVERSION_ERROR.name(),
+        getStructOnArray.getSQLState());
+
+    DatabricksSQLException getArrayOnStruct =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getArray(3));
+    assertEquals(
+        DatabricksDriverErrorCode.COMPLEX_DATA_TYPE_ARRAY_CONVERSION_ERROR.name(),
+        getArrayOnStruct.getSQLState());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add `instanceof` guards in `getArray`, `getStruct`, and `getMap` so a type mismatch throws `DatabricksSQLException` with the existing `COMPLEX_DATA_TYPE_*_CONVERSION_ERROR` SQLState instead of an unchecked `ClassCastException`.
- Preserve SQL `NULL` handling (still returns `null`) and existing disabled/inline-mode guards.
- Add unit regression coverage and fix `testGetMap` to mock `DatabricksMap` (the runtime type the driver returns).

## Test plan
- [x] `mvn test -pl jdbc-core -Dtest=DatabricksResultSetTest`
- [x] Live repro: wrong complex getters throw `DatabricksSQLException` with correct SQLState; NULL array column still returns `null`