### PR TITLE
Harden OSV security-scan gate (fail-closed) + drop SMTP email

### DIFF
--- a/.github/workflows/securityScan.yml
+++ b/.github/workflows/securityScan.yml
@@ -4,15 +4,16 @@ name: Security Scan
 # thresholds:
 #
 #   - pull_request to main: fail the job on any unsuppressed
-#     CVSS >= 7 finding (HIGH+). MEDIUM/LOW findings show in the step
-#     summary but don't block merges. Not yet required-to-merge in
-#     branch protection.
+#     CVSS >= 7 finding (HIGH+), or any unscored finding. MEDIUM/LOW
+#     findings show in the step summary but don't block merges. Not yet
+#     required-to-merge in branch protection.
 #
-#   - cron (weekly): report ALL findings regardless of severity. Sends
-#     an email with the full sorted list and fails the job on any
-#     finding. The intent is full situational awareness for the team --
-#     emerging MEDIUM risks should be visible before they cross the PR
-#     gate, and the weekly is read by humans, not enforced by code.
+#   - cron (weekly): report ALL findings regardless of severity, fail the
+#     job on any finding, and upload the raw scan output as an artifact.
+#     The intent is full situational awareness -- emerging MEDIUM risks
+#     should be visible before they cross the PR gate. A separate
+#     cross-repo action collates the uploaded artifacts across all driver
+#     repos and sends a single digest; this job does NOT email directly.
 #
 #   - workflow_dispatch: behaves like the cron run (full reporting).
 #
@@ -32,7 +33,8 @@ name: Security Scan
 #
 # Suppressions live in `osv-scanner.toml` as [[IgnoredVulns]] entries
 # (CVE-id global; OSV-Scanner v2.3.8 doesn't support per-package CVE
-# scoping). Each entry has a justification comment.
+# scoping). Each entry has a justification comment and an `ignoreUntil`
+# expiry so suppressions re-surface for re-review rather than lingering.
 
 on:
   pull_request:
@@ -105,9 +107,14 @@ jobs:
           /tmp/osv-scanner --version
 
       - name: Run OSV-Scanner
-        # Drop -e because osv-scanner exits 1 on ANY finding regardless of
-        # severity. The severity >= 7 filter below is our actual gate, so
-        # we explicitly tolerate osv-scanner's non-zero exit via `|| true`.
+        # osv-scanner's exit codes are meaningful and we must NOT blanket
+        # `|| true` them: exit 0 = no vulns, exit 1 = vulns found (expected
+        # -- our real gate is the CVSS>=7 filter below), any OTHER non-zero
+        # (126/127/128+, network error reaching OSV.dev, corrupt binary,
+        # partial DB load, "no extractor matched") = a scanner error that
+        # must fail the job CLOSED. A blanket `|| true` + zero-byte guard
+        # let an errored-but-non-empty output pass as "clean" (fail-open);
+        # capture and classify the code.
         run: |
           set -uo pipefail
 
@@ -116,56 +123,129 @@ jobs:
             exit 1
           fi
 
+          scan_rc=0
           /tmp/osv-scanner scan source \
             --recursive=false \
             --config=osv-scanner.toml \
             --format=json \
             --output-file=/tmp/osv-out.json \
-            target/bom.json || true
+            target/bom.json \
+            || scan_rc=$?
+
+          # Tolerate only 0 (clean) and 1 (findings present). Anything else
+          # is a scanner failure -> fail closed rather than reporting zero.
+          if [ "$scan_rc" -ne 0 ] && [ "$scan_rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner exited $scan_rc (scanner error, not a findings result). Failing closed."
+            exit 1
+          fi
 
           if [ ! -s /tmp/osv-out.json ]; then
             echo "::error::OSV-Scanner did not produce an output file."
             exit 1
           fi
 
+          # Validate the output is well-formed JSON with a results array
+          # before any downstream parsing. A truncated/partial write is
+          # non-empty (defeats the -s guard) but unparseable -- catch it
+          # here so it fails closed instead of parsing to zero findings.
+          if ! jq -e 'has("results") and (.results | type == "array")' /tmp/osv-out.json >/dev/null 2>&1; then
+            echo "::error::OSV-Scanner output is not valid JSON with a .results array (partial/corrupt scan). Failing closed."
+            exit 1
+          fi
+
       # Parse OSV's JSON into job outputs. The terminal steps below
-      # (PR-fail and email) consume these outputs.
+      # (PR-fail and scheduled-fail) consume these outputs.
       #
       # Two thresholds: PR gating uses CVSS >= 7 (high_count) so we don't
-      # block merges on MEDIUM/LOW noise; the weekly email reports
-      # everything (total_findings) so the team has full situational
-      # awareness of emerging risk before it crosses the gate.
+      # block merges on MEDIUM/LOW noise; the weekly reports everything
+      # (total_findings) so the team has full situational awareness of
+      # emerging risk before it crosses the gate.
       - name: Collect findings
         id: findings
         run: |
           set -uo pipefail
 
-          # All findings (sorted by severity desc). Anything missing a
-          # CVSS score sorts to 0 -- visible in the report but not silent.
-          ALL_FINDINGS=$(jq -c '[
-            .results[].packages[]? |
-            .package as $pkg |
-            .groups[]? |
-            {pkg: ($pkg.name + "@" + $pkg.version), ids: .ids, severity: (.max_severity // "0")}
-          ] | sort_by(- (.severity | tonumber? // 0))' /tmp/osv-out.json)
+          # All findings (sorted by severity desc).
+          #
+          # Severity resolution is defense-in-depth against fail-open:
+          # OSV's group-level `.max_severity` is EMPTY ("") for advisory
+          # groups that lack a CVSS vector (common for GHSA-only advisories).
+          # jq's `//` only coalesces null/false -- an empty string is truthy
+          # and would pass through, then `"" | tonumber? // 0` scores it 0,
+          # silently sailing a real HIGH past the CVSS>=7 gate. So we do NOT
+          # trust max_severity alone:
+          #   1. Try group `.max_severity` (numeric only; empty/"" -> null).
+          #   2. Fall back to the max CVSS score across the group's own
+          #      vulnerabilities' `.severities[].score` (parsed from the
+          #      CVSS vector's numeric base score when present).
+          #   3. If still unresolved, emit the sentinel "UNKNOWN" (a
+          #      non-numeric string), never scored 0.
+          #
+          # BLOCKING RULE: Maven/GHSA advisories reliably carry a CVSS score.
+          # A scoreless UNKNOWN here means a GHSA-only advisory on a package
+          # we depend on -- always BLOCKING (fail closed).
+          #
+          # NOTE ON jq NUMBER PARSING: use `try (x|tonumber) catch null`,
+          # NOT `x|tonumber?`. On a non-numeric string, `tonumber?` yields
+          # EMPTY (not null); inside an `... as $var` binding that makes the
+          # entire finding row vanish -- silently dropping a scoreless HIGH.
+          # try/catch normalizes non-numeric to null so the row survives and
+          # the fallback logic runs.
+          ALL_FINDINGS=$(jq -c '
+            def cvss_num($sev):
+              # OSV severity entries: {type:"CVSS_V3", score:"9.8"} (numeric)
+              # or a full vector string. Take numeric scores only; vectors
+              # without a bare numeric score contribute nothing (null).
+              ($sev // []) | map(try (.score | tonumber) catch null)
+                           | map(select(. != null)) | (max // null);
+            [
+              .results[].packages[]? |
+              .package as $pkg |
+              (.vulnerabilities // []) as $vulns |
+              .groups[]? |
+              .ids as $gids |
+              # max CVSS across the vulnerabilities referenced by this group
+              ([ $vulns[] | select(.id as $id | ($gids | index($id)) != null) | cvss_num(.severities) ]
+                 | map(select(. != null)) | (max // null)) as $vuln_score |
+              (try (.max_severity | tonumber) catch null) as $grp_score |
+              ($grp_score // $vuln_score) as $resolved |
+              {
+                pkg: ($pkg.name + "@" + $pkg.version),
+                ids: .ids,
+                severity: (if $resolved == null then "UNKNOWN" else ($resolved | tostring) end)
+              }
+            ] | sort_by(if (try (.severity | tonumber) catch null) == null then -1 else - (.severity | tonumber) end)
+          ' /tmp/osv-out.json)
           TOTAL_FINDINGS=$(echo "$ALL_FINDINGS" | jq 'length')
 
-          # High findings (CVSS >= 7). Both counters are logged so a
-          # mismatch (e.g. 50 total / 0 high) is visible -- protects
-          # against silent fail-open if OSV ever changes its severity
-          # format (e.g. emits "HIGH" instead of a number, which
-          # `tonumber? // 0` would mask).
-          HIGH_FINDINGS=$(echo "$ALL_FINDINGS" | jq -c '[.[] | select((.severity | tonumber? // 0) >= 7)]')
+          # Scoreless (UNKNOWN) findings -- all blocking (see note above).
+          UNKNOWN_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity == "UNKNOWN")] | length')
+
+          # Blocking findings = CVSS >= 7 (any package) OR scoreless UNKNOWN.
+          HIGH_FINDINGS=$(echo "$ALL_FINDINGS" | jq -c '[.[] | select(((.severity | tonumber? // 0) >= 7) or (.severity == "UNKNOWN"))]')
           HIGH_COUNT=$(echo "$HIGH_FINDINGS" | jq 'length')
+
+          # Guard against empty counts propagating to the numeric gates
+          # below. If any jq above failed, the var would be "" and
+          # `[ "$X" -gt 0 ]` errors / `'' != '0'` reads true. Default to 0
+          # and, since a failed parse should never be silently "clean",
+          # fail closed if the counts didn't resolve to integers.
+          TOTAL_FINDINGS=${TOTAL_FINDINGS:-}
+          HIGH_COUNT=${HIGH_COUNT:-}
+          UNKNOWN_COUNT=${UNKNOWN_COUNT:-}
+          if ! [[ "$TOTAL_FINDINGS" =~ ^[0-9]+$ ]] || ! [[ "$HIGH_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not compute finding counts from OSV output (parse failure). Failing closed."
+            exit 1
+          fi
 
           # Persist the full findings list to a file rather than a job
           # output -- GitHub Actions outputs are size-capped at 1 MB and
-          # the formatted email body can be larger than that for big
-          # finding lists.
+          # the formatted finding list can be larger than that.
           echo "$ALL_FINDINGS" > /tmp/all-findings.json
 
           echo "total_findings=$TOTAL_FINDINGS" >> "$GITHUB_OUTPUT"
           echo "high_count=$HIGH_COUNT" >> "$GITHUB_OUTPUT"
+          echo "unknown_count=$UNKNOWN_COUNT" >> "$GITHUB_OUTPUT"
 
           # Step summary so findings are visible in the GH Actions UI
           # without downloading artifacts.
@@ -173,7 +253,8 @@ jobs:
             echo "## OSV-Scanner Findings"
             echo ""
             echo "- Total findings (any severity): \`$TOTAL_FINDINGS\`"
-            echo "- High findings (CVSS >= 7, PR-blocking): \`$HIGH_COUNT\`"
+            echo "- Blocking findings (CVSS >= 7, or unscored; PR-blocking): \`$HIGH_COUNT\`"
+            echo "- Unscored/UNKNOWN findings: \`$UNKNOWN_COUNT\` (all blocking)"
             if [ "$TOTAL_FINDINGS" -gt 0 ]; then
               echo ""
               echo "All findings (sorted by severity desc):"
@@ -186,7 +267,7 @@ jobs:
 
           # Also dump the findings to the job log so they're visible in
           # the default "Logs" view, not just the step summary panel.
-          echo "OSV: $TOTAL_FINDINGS total findings, $HIGH_COUNT at CVSS>=7"
+          echo "OSV: $TOTAL_FINDINGS total findings, $HIGH_COUNT blocking (CVSS>=7 or unscored)"
           if [ "$TOTAL_FINDINGS" -gt 0 ]; then
             echo ""
             echo "All findings (sorted by severity desc):"
@@ -195,18 +276,18 @@ jobs:
 
       # --- Terminal: PR event ---
       # Fail the job so the PR's check goes red. No email.
-      # PR gate is CVSS >= 7 only; MEDIUM/LOW findings show up in the
-      # step summary but don't block merges.
+      # PR gate is CVSS >= 7 (or unscored) only; MEDIUM/LOW findings show
+      # up in the step summary but don't block merges.
       - name: Fail on findings (PR)
         if: github.event_name == 'pull_request' && steps.findings.outputs.high_count != '0'
         run: |
           set -uo pipefail
-          # List the actual HIGH findings inline so the author sees what
+          # List the actual blocking findings inline so the author sees what
           # needs fixing without clicking through to the step summary
           # panel or downloading artifacts.
-          HIGH_FINDINGS=$(jq -c '[.[] | select((.severity | tonumber? // 0) >= 7)]' /tmp/all-findings.json)
+          HIGH_FINDINGS=$(jq -c '[.[] | select(((.severity | tonumber? // 0) >= 7) or (.severity == "UNKNOWN"))]' /tmp/all-findings.json)
 
-          echo "::error::${{ steps.findings.outputs.high_count }} unsuppressed CVSS>=7 finding(s) in this PR:"
+          echo "::error::${{ steps.findings.outputs.high_count }} unsuppressed blocking finding(s) (CVSS>=7, or unscored) in this PR:"
           echo ""
           echo "$HIGH_FINDINGS" | jq -r '.[] | "  [\(.severity)] \(.pkg)  \(.ids | join(", "))"'
           echo ""
@@ -219,60 +300,26 @@ jobs:
           exit 1
 
       # --- Terminal: scheduled/manual event ---
-      # Weekly reports ALL findings (not just CVSS >= 7) so the team sees
-      # emerging risk before it crosses the PR gate. PR-time is narrower
-      # to avoid blocking on MEDIUM/LOW noise; weekly is broader because
-      # it's read by humans, not enforced.
-      - name: Compose email body
-        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.findings.outputs.total_findings != '0'
-        run: |
-          set -uo pipefail
-          {
-            echo "<!DOCTYPE html><html><head><title>JDBC Driver Security Scan Results</title>"
-            echo "<style>"
-            echo "  body { font-family: -apple-system, sans-serif; }"
-            echo "  table { border-collapse: collapse; margin-top: 1em; }"
-            echo "  th, td { border: 1px solid #ddd; padding: 6px 12px; text-align: left; }"
-            echo "  th { background: #f5f5f5; }"
-            echo "  tr.high { background: #ffe5e5; }"
-            echo "  tr.medium { background: #fff5e5; }"
-            echo "</style></head><body>"
-            echo "<h1>Security Vulnerabilities Found</h1>"
-            echo "<p><b>${{ steps.findings.outputs.total_findings }}</b> total finding(s) on main; <b>${{ steps.findings.outputs.high_count }}</b> are CVSS &gt;= 7 (PR-blocking).</p>"
-            echo "<p>Full reports are attached to the GitHub Actions run as artifacts: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Artifacts</a></p>"
-            echo "<table><tr><th>Severity</th><th>Package</th><th>IDs</th></tr>"
-            jq -r '.[] |
-              (if (.severity | tonumber? // 0) >= 7 then "high"
-               elif (.severity | tonumber? // 0) >= 4 then "medium"
-               else "" end) as $cls |
-              "<tr class=\"\($cls)\"><td>\(.severity)</td><td>\(.pkg)</td><td>\(.ids | join(", "))</td></tr>"
-            ' /tmp/all-findings.json
-            echo "</table>"
-            echo "</body></html>"
-          } > security-scan-report.html
-
-      - name: Send Email
-        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.findings.outputs.total_findings != '0'
-        uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.SMTP_USERNAME }}
-          password: ${{ secrets.SMTP_PASSWORD }}
-          subject: OSS JDBC Driver Security Scan - 🚨 Vulnerabilities Found
-          html_body: file://security-scan-report.html
-          to: ${{ secrets.EMAIL_RECIPIENTS }}
-          from: JDBC Security Scanner
-          content_type: text/html
-
+      # Weekly reports ALL findings (not just CVSS >= 7) so emerging risk is
+      # visible before it crosses the PR gate. PR-time is narrower to avoid
+      # blocking on MEDIUM/LOW noise; weekly is broader for situational
+      # awareness.
+      #
+      # Notification is intentionally NOT done here: a separate cross-repo
+      # action collates findings from all driver repos and sends a single
+      # digest. This job's job is to (a) fail so the scheduled run is red
+      # when anything is found, and (b) upload the raw osv-out.json artifact
+      # for the collator to consume.
       - name: Fail on findings (scheduled/manual)
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.findings.outputs.total_findings != '0'
         run: |
-          echo "::error::${{ steps.findings.outputs.total_findings }} OSV finding(s) on main (${{ steps.findings.outputs.high_count }} at CVSS>=7). Email sent."
+          echo "::error::${{ steps.findings.outputs.total_findings }} OSV finding(s) on main (${{ steps.findings.outputs.high_count }} blocking at CVSS>=7 or unscored). See the security-scan-reports artifact."
           exit 1
 
-      # Always upload artifacts so triagers can pull the full reports
-      # without having to rerun anything.
+      # Always upload the raw scan output so triagers -- and the planned
+      # cross-repo collation/notification action -- can pull findings
+      # without rerunning. This is the machine-readable source of truth now
+      # that per-repo email has been removed.
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -280,6 +327,6 @@ jobs:
           name: security-scan-reports
           path: |
             /tmp/osv-out.json
+            /tmp/all-findings.json
             target/bom.json
-            security-scan-report.html
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Ports the fail-closed hardening already applied to the Go ([databricks/databricks-sql-go#362](https://github.com/databricks/databricks-sql-go/pull/362)) and Node ([databricks/databricks-sql-nodejs#388](https://github.com/databricks/databricks-sql-nodejs/pull/388)) OSV gates to this repo's `securityScan.yml`, closing three fail-open paths in the Maven OSV scan:

- **Capture the scanner exit code** — tolerate only 0 (clean) / 1 (findings) and fail closed on any other code (network error, corrupt binary, "no extractor matched") instead of masking it with `|| true`.
- **Validate the output JSON** has a `.results` array before parsing, so a truncated/partial scan fails closed rather than parsing to zero findings.
- **Resolve empty `max_severity`** via a `cvss_num` fallback to an `UNKNOWN` sentinel (using `try (x|tonumber) catch null`, not `tonumber?`), so a scoreless GHSA-only finding can never sort to 0 and sail past the CVSS>=7 gate. `UNKNOWN` always blocks.
- **Integer-count guards** fail closed on parse failure.

Also **drops the per-repo SMTP email** in favor of artifact upload, for the planned cross-repo findings collator (parity with Go/Node/Python). The scheduled run still fails red on any finding and uploads `osv-out.json` + `all-findings.json` for the collator to consume.

No change to the scan surface (still `target/bom.json`) or the CVSS>=7 PR-gate threshold — only the fail-open handling and the notification path change.

## Test plan

- [x] YAML validated.
- [x] Fail-closed logic verified against synthetic OSV JSON (scanner-error exit, partial/corrupt JSON, empty-severity, scoreless-UNKNOWN all fail closed).
- [x] Ported verbatim from the already-merged Go/Node gates.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.
