### PR TITLE
[connection] Guarantee resource cleanup during close

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Updated
 
 ### Fixed
-- Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if the server-side session termination fails for any reason.
+- Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -435,27 +435,42 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   @Override
   public void close() throws SQLException {
     LOGGER.debug("public void close()");
-    // Shutdown heartbeat FIRST — prevents RPCs on closing connections and
-    // ensures shutdown runs even if statement.close() throws
-    if (heartbeatManager != null) {
-      heartbeatManager.shutdown();
-    }
-    for (IDatabricksStatementInternal statement : statementSet) {
-      statement.close(false);
-      statementSet.remove(statement);
-    }
-    // Always run driver-side cleanup regardless of whether session.close() succeeds.
-    // Without this guard, a failure in session.close() (e.g. expired token → 401 on
-    // deleteSession) would skip closeConnection(), permanently leaking the
-    // IdleConnectionEvictor thread and other resources (GitHub issue #1221).
     try {
-      this.session.close();
+      try {
+        // Shutdown heartbeat first to prevent RPCs on a closing connection.
+        if (heartbeatManager != null) {
+          heartbeatManager.shutdown();
+        }
+      } finally {
+        try {
+          for (IDatabricksStatementInternal statement : statementSet) {
+            statement.close(false);
+            statementSet.remove(statement);
+          }
+        } finally {
+          this.session.close();
+        }
+      }
     } finally {
-      TelemetryClientFactory.getInstance().closeTelemetryClient(connectionContext);
-      DatabricksClientConfiguratorManager.getInstance().removeInstance(connectionContext);
-      DatabricksDriverFeatureFlagsContextFactory.removeInstance(connectionContext);
-      DatabricksHttpClientFactory.getInstance().closeConnection(connectionContext);
-      DatabricksThreadContextHolder.clearAllContext();
+      // Each cleanup step must run even if an earlier one fails. In particular,
+      // closeConnection() stops the IdleConnectionEvictor owned by this connection.
+      try {
+        TelemetryClientFactory.getInstance().closeTelemetryClient(connectionContext);
+      } finally {
+        try {
+          DatabricksClientConfiguratorManager.getInstance().removeInstance(connectionContext);
+        } finally {
+          try {
+            DatabricksDriverFeatureFlagsContextFactory.removeInstance(connectionContext);
+          } finally {
+            try {
+              DatabricksHttpClientFactory.getInstance().closeConnection(connectionContext);
+            } finally {
+              DatabricksThreadContextHolder.clearAllContext();
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,6 +90,11 @@ public class DatabricksConnectionTest {
         DatabricksConnectionContext.parse(CATALOG_SCHEMA_JDBC_URL, new Properties());
     transactionsEnabledContext =
         DatabricksConnectionContext.parse(TRANSACTIONS_ENABLED_JDBC_URL, new Properties());
+  }
+
+  @AfterEach
+  void clearThreadContext() {
+    DatabricksThreadContextHolder.clearAllContext();
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
@@ -10,20 +10,27 @@ import static org.mockito.Mockito.*;
 import com.databricks.jdbc.api.impl.volume.DatabricksVolumeClientFactory;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionInternal;
+import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
+import com.databricks.jdbc.common.HttpClientType;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.common.Warehouse;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
+import com.databricks.jdbc.dbclient.impl.http.ClosedConnectionHttpClient;
+import com.databricks.jdbc.dbclient.impl.http.DatabricksHttpClientFactory;
 import com.databricks.jdbc.dbclient.impl.sqlexec.DatabricksSdkClient;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksSQLFeatureNotImplementedException;
 import com.databricks.jdbc.exception.DatabricksSQLFeatureNotSupportedException;
 import com.databricks.jdbc.exception.DatabricksTransactionException;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import java.lang.reflect.Field;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -1314,5 +1321,106 @@ public class DatabricksConnectionTest {
 
     // Verify deleteSession was attempted
     verify(databricksClient).deleteSession(any());
+  }
+
+  @Test
+  public void testExpiredTokenCloseStopsActualIdleConnectionEvictor() throws Exception {
+    IDatabricksConnectionContext localContext =
+        DatabricksConnectionContext.parse(CATALOG_SCHEMA_JDBC_URL, new Properties());
+    DatabricksHttpClientFactory httpClientFactory = DatabricksHttpClientFactory.getInstance();
+    int baselineEvictors = countEvictorThreads();
+
+    try {
+      assertNotNull(httpClientFactory.getClient(localContext, HttpClientType.COMMON));
+      assertTrue(
+          waitUntil(() -> countEvictorThreads() > baselineEvictors, 2, TimeUnit.SECONDS),
+          "Creating a real HTTP client must start an IdleConnectionEvictor");
+
+      when(databricksClient.createSession(
+              new Warehouse(WAREHOUSE_ID), CATALOG, SCHEMA, new HashMap<>()))
+          .thenReturn(IMMUTABLE_SESSION_INFO);
+      DatabricksConnection localConnection =
+          new DatabricksConnection(localContext, databricksClient);
+      localConnection.open();
+      doThrow(new DatabricksSQLException("401 Unauthorized", "08000"))
+          .when(databricksClient)
+          .deleteSession(any());
+
+      assertDoesNotThrow(localConnection::close);
+
+      assertInstanceOf(
+          ClosedConnectionHttpClient.class,
+          httpClientFactory.getClient(localContext, HttpClientType.COMMON));
+      assertTrue(
+          waitUntil(() -> countEvictorThreads() == baselineEvictors, 2, TimeUnit.SECONDS),
+          "Connection evictor must terminate after close despite the expired token");
+    } finally {
+      httpClientFactory.reset();
+    }
+  }
+
+  @Test
+  public void testStatementCloseFailureStillStopsActualIdleConnectionEvictor() throws Exception {
+    IDatabricksConnectionContext localContext =
+        DatabricksConnectionContext.parse(CATALOG_SCHEMA_JDBC_URL, new Properties());
+    DatabricksHttpClientFactory httpClientFactory = DatabricksHttpClientFactory.getInstance();
+    int baselineEvictors = countEvictorThreads();
+
+    try {
+      httpClientFactory.getClient(localContext, HttpClientType.COMMON);
+      assertTrue(waitUntil(() -> countEvictorThreads() > baselineEvictors, 2, TimeUnit.SECONDS));
+
+      when(databricksClient.createSession(
+              new Warehouse(WAREHOUSE_ID), CATALOG, SCHEMA, new HashMap<>()))
+          .thenReturn(IMMUTABLE_SESSION_INFO);
+      DatabricksConnection localConnection =
+          new DatabricksConnection(localContext, databricksClient);
+      localConnection.open();
+
+      IDatabricksStatementInternal failingStatement = mock(IDatabricksStatementInternal.class);
+      doThrow(new DatabricksSQLException("statement close failed", "08000"))
+          .when(failingStatement)
+          .close(false);
+      getStatementSet(localConnection).add(failingStatement);
+
+      assertThrows(DatabricksSQLException.class, localConnection::close);
+
+      verify(databricksClient).deleteSession(any());
+      assertInstanceOf(
+          ClosedConnectionHttpClient.class,
+          httpClientFactory.getClient(localContext, HttpClientType.COMMON));
+      assertTrue(
+          waitUntil(() -> countEvictorThreads() == baselineEvictors, 2, TimeUnit.SECONDS),
+          "Connection evictor must terminate even when statement.close() fails");
+    } finally {
+      httpClientFactory.reset();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Set<IDatabricksStatementInternal> getStatementSet(
+      DatabricksConnection databricksConnection) throws ReflectiveOperationException {
+    Field field = DatabricksConnection.class.getDeclaredField("statementSet");
+    field.setAccessible(true);
+    return (Set<IDatabricksStatementInternal>) field.get(databricksConnection);
+  }
+
+  private static int countEvictorThreads() {
+    return (int)
+        Thread.getAllStackTraces().keySet().stream()
+            .filter(thread -> thread.isAlive() && thread.getName().contains("Connection evictor"))
+            .count();
+  }
+
+  private static boolean waitUntil(BooleanSupplier condition, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+    while (System.nanoTime() < deadlineNanos) {
+      if (condition.getAsBoolean()) {
+        return true;
+      }
+      Thread.sleep(10);
+    }
+    return condition.getAsBoolean();
   }
 }

--- a/src/test/java/com/databricks/jdbc/auth/AzureMSICredentialProviderTest.java
+++ b/src/test/java/com/databricks/jdbc/auth/AzureMSICredentialProviderTest.java
@@ -170,10 +170,9 @@ public class AzureMSICredentialProviderTest {
     AzureMSICredentialProvider provider = setupProvider();
 
     // Make the HTTP client throw an exception
-    when(mockHttpClient.execute(any(HttpGet.class)))
-        .thenThrow(
-            new DatabricksHttpException(
-                "Connection failed", DatabricksDriverErrorCode.INVALID_STATE));
+    DatabricksHttpException httpException =
+        new DatabricksHttpException("Connection failed", DatabricksDriverErrorCode.INVALID_STATE);
+    when(mockHttpClient.execute(any(HttpGet.class))).thenThrow(httpException);
     HeaderFactory headerFactory = provider.configure(config);
     Exception exception = assertThrows(DatabricksException.class, headerFactory::headers);
 

--- a/src/test/java/com/databricks/jdbc/auth/AzureMSICredentialsTest.java
+++ b/src/test/java/com/databricks/jdbc/auth/AzureMSICredentialsTest.java
@@ -183,9 +183,9 @@ public class AzureMSICredentialsTest {
   @Test
   void should_ThrowException_When_HttpClientThrowsException() throws Exception {
     // Setup mock to throw exception
-    when(mockHttpClient.execute(any(HttpGet.class)))
-        .thenThrow(
-            new DatabricksHttpException("Network error", DatabricksDriverErrorCode.INVALID_STATE));
+    DatabricksHttpException httpException =
+        new DatabricksHttpException("Network error", DatabricksDriverErrorCode.INVALID_STATE);
+    when(mockHttpClient.execute(any(HttpGet.class))).thenThrow(httpException);
 
     AzureMSICredentials credentials = new AzureMSICredentials(mockHttpClient, null);
 

--- a/src/test/java/com/databricks/jdbc/auth/DatabricksTokenFederationProviderTest.java
+++ b/src/test/java/com/databricks/jdbc/auth/DatabricksTokenFederationProviderTest.java
@@ -106,10 +106,9 @@ public class DatabricksTokenFederationProviderTest {
   @Test
   public void testRetrieveTokensFailure() throws Exception {
 
-    when(mockHttpClient.execute(any(HttpPost.class)))
-        .thenThrow(
-            new DatabricksHttpException(
-                "Connection error", DatabricksDriverErrorCode.CONNECTION_ERROR));
+    DatabricksHttpException httpException =
+        new DatabricksHttpException("Connection error", DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(mockHttpClient.execute(any(HttpPost.class))).thenThrow(httpException);
 
     assertThrows(
         DatabricksDriverException.class,

--- a/src/test/java/com/databricks/jdbc/auth/JwtPrivateKeyClientCredentialsTest.java
+++ b/src/test/java/com/databricks/jdbc/auth/JwtPrivateKeyClientCredentialsTest.java
@@ -86,9 +86,9 @@ public class JwtPrivateKeyClientCredentialsTest {
 
   @Test
   public void testRetrieveTokenExceptionHandling() throws DatabricksHttpException {
-    when(httpClient.execute(any()))
-        .thenThrow(
-            new DatabricksHttpException("Network error", DatabricksDriverErrorCode.INVALID_STATE));
+    DatabricksHttpException httpException =
+        new DatabricksHttpException("Network error", DatabricksDriverErrorCode.INVALID_STATE);
+    when(httpClient.execute(any())).thenThrow(httpException);
     Exception exception =
         assertThrows(
             DatabricksException.class,


### PR DESCRIPTION
## Description

Follow-up to #1559 and #1221. The expired-token fix guarantees cleanup when server-side session deletion fails, but cleanup could still stop early if statement closure or another driver cleanup component threw. This change makes each connection-close stage independent so the HTTP client and its IdleConnectionEvictor are always released.

- Close the session even when heartbeat or statement cleanup fails.
- Run every driver cleanup step even when an earlier cleanup step throws.
- Assert against a real IdleConnectionEvictor thread, not only connection state.
- Cover expired-token 401 and statement-close failure paths.

## Testing

- [x] A/B regression test against the commit before #1559: retained a live DatabricksHttpClient and failed.
- [x] Identical test against merged #1559: HTTP client was tombstoned and the evictor returned to baseline.
- [x] Full affected suites on JDK 11: 71 tests, 0 failures, 0 errors.
- [x] mvn spotless:apply
- [x] git diff --check

## Additional Notes to the Reviewer

Please focus on the nested try/finally structure in DatabricksConnection.close(). It intentionally preserves exception propagation while ensuring later cleanup cannot be skipped. Real PAT revocation remains an external E2E validation; the deterministic regression test creates the actual Apache HTTP client and evictor while mocking only the server-side 401.