### PR TITLE
[connection] Retain the JDBC read-only hint

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Updated
+- `Connection.isReadOnly()` now reflects the hint most recently supplied to `Connection.setReadOnly()`.
 
 ### Fixed
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnection.java
@@ -37,6 +37,7 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   private final IDatabricksSession session;
   private final Set<IDatabricksStatementInternal> statementSet = ConcurrentHashMap.newKeySet();
   private SQLWarning warnings = null;
+  private boolean readOnly;
   private final IDatabricksConnectionContext connectionContext;
   private final ResultHeartbeatManager heartbeatManager;
 
@@ -490,19 +491,16 @@ public class DatabricksConnection implements IDatabricksConnection, IDatabricksC
   public void setReadOnly(boolean readOnly) throws SQLException {
     LOGGER.debug("public void setReadOnly(boolean readOnly = {})", readOnly);
     throwExceptionIfConnectionIsClosed();
-    // Per the JDBC spec, setReadOnly is a hint used to enable database optimizations. The
-    // Databricks
-    // backend does not enforce a connection-level read-only mode, so this is treated as a no-op
-    // rather than throwing. isReadOnly() continues to report false since the hint is not enforced.
-    // Throwing here breaks common clients (e.g. HikariCP, DBCP, Trino/Starburst) that call
-    // setReadOnly(true) during connection initialization.
+    // This is a JDBC hint only. Remember it for isReadOnly(), but do not enforce it or send it to
+    // the server.
+    this.readOnly = readOnly;
   }
 
   @Override
   public boolean isReadOnly() throws SQLException {
     LOGGER.debug("public boolean isReadOnly()");
     throwExceptionIfConnectionIsClosed();
-    return false;
+    return readOnly;
   }
 
   @Override

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionTest.java
@@ -638,10 +638,10 @@ public class DatabricksConnectionTest {
   void testReadOnlyAndAbort() throws SQLException {
     connection = new DatabricksConnection(connectionContext, databricksClient);
     connection.open();
-    // setReadOnly is a JDBC hint; the driver does not enforce read-only mode, so both values are
-    // accepted as no-ops (see JDBC spec). isReadOnly() continues to report false.
-    assertDoesNotThrow(() -> connection.setReadOnly(false));
+    assertFalse(connection.isReadOnly());
     assertDoesNotThrow(() -> connection.setReadOnly(true));
+    assertTrue(connection.isReadOnly());
+    assertDoesNotThrow(() -> connection.setReadOnly(false));
     assertFalse(connection.isReadOnly());
     ExecutorService executorService = Executors.newFixedThreadPool(1);
     assertDoesNotThrow(() -> connection.abort(executorService));


### PR DESCRIPTION
## Description

`Connection.setReadOnly(boolean)` accepts a JDBC hint, but the connection previously discarded it, so `isReadOnly()` always returned `false`. JDBC clients can reasonably expect the getter to reflect the most recently supplied hint even when the backend does not enforce a read-only mode.

This change stores the hint as connection-local state and returns it from `isReadOnly()`. The value defaults to `false` and can be toggled in either direction. It does not parse SQL, block write statements, modify execution requests, or send additional state to the server.

## Testing

- [x] JDK 11 focused tests: `DatabricksConnectionTest#testReadOnlyAndAbort,DatabricksConnectionTest#testCommonMethods` — 2 tests, 0 failures
- [x] JDK 21 full `DatabricksConnectionTest` — 46 tests, 0 failures
- [x] Spotless formatting and `git diff --check`

## Additional Notes to the Reviewer

The existing closed-connection validation remains unchanged. The read-only value is intentionally a hint only and is not an authorization or write-prevention mechanism.