### PR TITLE
Use SHOW COLUMNS IN ALL CATALOGS for getColumns with null catalog

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Updated
+- `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 
 ### Fixed
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/CommandConstants.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/CommandConstants.java
@@ -25,6 +25,8 @@ public class CommandConstants {
   public static final String SHOW_TABLES_SQL = "SHOW TABLES" + IN_CATALOG_SQL;
   public static final String SHOW_TABLES_IN_ALL_CATALOGS_SQL = "SHOW TABLES" + IN_ALL_CATALOGS_SQL;
   public static final String SHOW_COLUMNS_SQL = "SHOW COLUMNS" + IN_CATALOG_SQL;
+  public static final String SHOW_COLUMNS_IN_ALL_CATALOGS_SQL =
+      "SHOW COLUMNS" + IN_ALL_CATALOGS_SQL;
   public static final String SHOW_FUNCTIONS_SQL = "SHOW FUNCTIONS" + IN_CATALOG_SQL;
   public static final String SHOW_SCHEMAS_IN_ALL_CATALOGS_SQL =
       "SHOW SCHEMAS" + IN_ALL_CATALOGS_SQL;

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilder.java
@@ -124,8 +124,13 @@ public class CommandBuilder {
             "Building command for fetching columns. Catalog %s, SchemaPattern %s, TablePattern %s, ColumnPattern %s and session context : %s",
             catalogName, schemaPattern, tablePattern, columnPattern, sessionContext);
     LOGGER.debug(contextString);
-    throwErrorIfNull(Collections.singletonMap(CATALOG, catalogName), contextString);
-    String showColumnsSQL = String.format(SHOW_COLUMNS_SQL, escapeSqlIdentifier(catalogName));
+    String showColumnsSQL;
+    if (catalogName == null) {
+      // Per JDBC spec, null catalog means "do not narrow the search" — list across all catalogs
+      showColumnsSQL = SHOW_COLUMNS_IN_ALL_CATALOGS_SQL;
+    } else {
+      showColumnsSQL = String.format(SHOW_COLUMNS_SQL, escapeSqlIdentifier(catalogName));
+    }
 
     if (schemaPattern != null) {
       showColumnsSQL += String.format(SCHEMA_LIKE_SQL, schemaPattern);

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClient.java
@@ -200,13 +200,9 @@ public class DatabricksMetadataQueryClient implements IDatabricksMetadataClient 
 
     catalog = autoFillCatalog(catalog, currentCatalog);
 
-    // Fetch columns from all catalogs if catalog is null
-    if (catalog == null) {
-      LOGGER.debug("Catalog is null, fetching columns across all catalogs");
-      return fetchColumnsAcrossCatalogs(
-          session, schemaNamePattern, tableNamePattern, columnNamePattern);
-    }
-
+    // When catalog is null, CommandBuilder emits "SHOW COLUMNS IN ALL CATALOGS" so the server
+    // enumerates every catalog in a single call (mirroring listSchemas/listTables). Older DBR
+    // versions that don't support that syntax are handled by the parse-error fallback below.
     CommandBuilder commandBuilder =
         new CommandBuilder(catalog, session)
             .setSchemaPattern(schemaNamePattern)
@@ -218,7 +214,13 @@ public class DatabricksMetadataQueryClient implements IDatabricksMetadataClient 
       return metadataResultSetBuilder.getColumnsResult(
           getResultSet(SQL, session, MetadataOperationType.GET_COLUMNS));
     } catch (SQLException e) {
-      if (isObjectNotFoundException(e)
+      if (catalog == null && PARSE_SYNTAX_ERROR_SQL_STATE.equals(e.getSQLState())) {
+        // Fallback for older DBR versions that don't support "SHOW COLUMNS IN ALL CATALOGS":
+        // enumerate the catalogs and issue a per-catalog SHOW COLUMNS.
+        LOGGER.debug("SQL command failed with syntax error. Fetching columns across all catalogs.");
+        return fetchColumnsAcrossCatalogs(
+            session, schemaNamePattern, tableNamePattern, columnNamePattern);
+      } else if (isObjectNotFoundException(e)
           || isEmptyPatternError(schemaNamePattern, tableNamePattern, columnNamePattern)) {
         LOGGER.debug("Error for getColumns ({}), returning empty result set.", e.getSQLState());
         return metadataResultSetBuilder.getColumnsResult(new ArrayList<>());

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/CommandBuilderTest.java
@@ -273,6 +273,29 @@ class CommandBuilderTest {
   }
 
   @Test
+  @DisplayName("Should generate SHOW COLUMNS IN ALL CATALOGS when catalog is null")
+  void shouldGenerateCorrectSqlForColumnsFromAllCatalogs() throws SQLException {
+    CommandBuilder builder = new CommandBuilder(null, mockSession);
+
+    assertEquals(SHOW_COLUMNS_IN_ALL_CATALOGS_SQL, builder.getSQLString(CommandName.LIST_COLUMNS));
+  }
+
+  @Test
+  @DisplayName(
+      "Should append SCHEMA/TABLE/column LIKE clauses to SHOW COLUMNS IN ALL CATALOGS when catalog is null")
+  void shouldGenerateCorrectSqlForColumnsFromAllCatalogsWithPatterns() throws SQLException {
+    CommandBuilder builder =
+        new CommandBuilder(null, mockSession)
+            .setSchemaPattern("testSchema")
+            .setTablePattern("testTable")
+            .setColumnPattern("testColumn");
+
+    assertEquals(
+        "SHOW COLUMNS IN ALL CATALOGS SCHEMA LIKE 'testSchema' TABLE LIKE 'testTable' LIKE 'testColumn'",
+        builder.getSQLString(CommandName.LIST_COLUMNS));
+  }
+
+  @Test
   @DisplayName("Should throw exception for unsupported command")
   void shouldThrowExceptionForUnsupportedCommand() {
     CommandBuilder builder = new CommandBuilder(TEST_CATALOG, mockSession);

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksMetadataQueryClientTest.java
@@ -22,6 +22,7 @@ import com.databricks.jdbc.common.CommandName;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.MetadataOperationType;
 import com.databricks.jdbc.common.StatementType;
+import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
 import com.databricks.jdbc.dbclient.impl.common.CrossReferenceKeysDatabricksResultSetAdapter;
 import com.databricks.jdbc.dbclient.impl.common.ImportedKeysDatabricksResultSetAdapter;
 import com.databricks.jdbc.exception.DatabricksSQLException;
@@ -426,6 +427,95 @@ public class DatabricksMetadataQueryClientTest {
         assertEquals(actualMetaData.isNullable(i + 1), ResultSetMetaData.columnNullable);
       }
     }
+  }
+
+  private void stubColumnsMetaData() throws SQLException {
+    doReturn(13).when(mockedMetaData).getColumnCount();
+    doReturn(COL_NAME_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(1);
+    doReturn(CATALOG_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(2);
+    doReturn(SCHEMA_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(3);
+    doReturn(TABLE_NAME_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(4);
+    doReturn(COLUMN_TYPE_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(5);
+    doReturn(COLUMN_SIZE_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(6);
+    doReturn(DECIMAL_DIGITS_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(7);
+    doReturn(NUM_PREC_RADIX_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(8);
+    doReturn(NULLABLE_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(9);
+    doReturn(REMARKS_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(10);
+    doReturn(ORDINAL_POSITION_COLUMN.getResultSetColumnName())
+        .when(mockedMetaData)
+        .getColumnName(11);
+    doReturn(IS_AUTO_INCREMENT_COLUMN.getResultSetColumnName())
+        .when(mockedMetaData)
+        .getColumnName(12);
+    doReturn(IS_GENERATED_COLUMN.getResultSetColumnName()).when(mockedMetaData).getColumnName(13);
+    when(mockedResultSet.getMetaData()).thenReturn(mockedMetaData);
+  }
+
+  @Test
+  void testListColumnsAllCatalogs() throws SQLException {
+    when(session.getComputeResource()).thenReturn(mockedComputeResource);
+    DatabricksMetadataQueryClient metadataClient = new DatabricksMetadataQueryClient(mockClient);
+    when(mockClient.executeStatement(
+            eq("SHOW COLUMNS IN ALL CATALOGS SCHEMA LIKE 'testSchema' TABLE LIKE 'testTable'"),
+            eq(mockedComputeResource),
+            any(),
+            eq(StatementType.METADATA),
+            eq(session),
+            any(),
+            eq(MetadataOperationType.GET_COLUMNS)))
+        .thenReturn(mockedResultSet);
+    when(mockedResultSet.next()).thenReturn(true, false);
+    stubColumnsMetaData();
+
+    // Null catalog issues a single "SHOW COLUMNS IN ALL CATALOGS" instead of enumerating catalogs
+    DatabricksResultSet actualResult =
+        metadataClient.listColumns(session, null, TEST_SCHEMA, TEST_TABLE, null);
+
+    assertEquals(StatementState.SUCCEEDED, actualResult.getStatementStatus().getState());
+    assertEquals(METADATA_STATEMENT_ID, actualResult.getStatementId());
+    assertEquals(1, ((DatabricksResultSetMetaData) actualResult.getMetaData()).getTotalRows());
+    // Should NOT fall back to enumerating catalogs via SHOW CATALOGS
+    verify(mockClient, never())
+        .executeStatement(eq("SHOW CATALOGS"), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void testListColumnsAllCatalogs_fallsBackOnParseSyntaxError() throws SQLException {
+    when(session.getComputeResource()).thenReturn(mockedComputeResource);
+    DatabricksMetadataQueryClient metadataClient = new DatabricksMetadataQueryClient(mockClient);
+
+    // "SHOW COLUMNS IN ALL CATALOGS" is unsupported on older DBR versions — the server returns a
+    // parse syntax error, and the client falls back to enumerating catalogs (fetchColumnsAcross
+    // Catalogs), which drives the metadata client returned by the session.
+    DatabricksSQLException parseError =
+        new DatabricksSQLException(
+            "syntax error at or near \"ALL CATALOGS\"", PARSE_SYNTAX_ERROR_SQL_STATE);
+    when(mockClient.executeStatement(
+            eq("SHOW COLUMNS IN ALL CATALOGS"),
+            eq(mockedComputeResource),
+            any(),
+            eq(StatementType.METADATA),
+            eq(session),
+            any(),
+            eq(MetadataOperationType.GET_COLUMNS)))
+        .thenThrow(parseError);
+
+    // Fallback enumerates catalogs through the session's metadata client. Return no catalogs so
+    // the fallback yields an empty result set without needing the parallel per-catalog fan-out.
+    IDatabricksMetadataClient sessionMetadataClient = mock(IDatabricksMetadataClient.class);
+    when(session.getDatabricksMetadataClient()).thenReturn(sessionMetadataClient);
+    when(session.getConnectionContext()).thenReturn(mock(IDatabricksConnectionContext.class));
+    DatabricksResultSet emptyCatalogs = mock(DatabricksResultSet.class);
+    when(emptyCatalogs.next()).thenReturn(false);
+    when(sessionMetadataClient.listCatalogs(session)).thenReturn(emptyCatalogs);
+
+    DatabricksResultSet actualResult = metadataClient.listColumns(session, null, null, null, null);
+
+    assertEquals(StatementState.SUCCEEDED, actualResult.getStatementStatus().getState());
+    assertEquals(METADATA_STATEMENT_ID, actualResult.getStatementId());
+    assertEquals(0, ((DatabricksResultSetMetaData) actualResult.getMetaData()).getTotalRows());
+    // Verify the fallback path was taken: catalogs were enumerated via the session client
+    verify(sessionMetadataClient).listCatalogs(session);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary

`DatabaseMetaData.getColumns(catalog=null, ...)` previously enumerated **every** catalog with `SHOW CATALOGS` and then issued a separate `SHOW COLUMNS IN CATALOG \`<cat>\`` for each one, fanning the calls out across a metadata thread pool. This predates the server-side support for `SHOW ... IN ALL CATALOGS`, which `getSchemas` and `getTables` already use for the null-catalog case.

This PR makes `getColumns` consistent with the other metadata calls: when the catalog is `null`, the driver now emits a single **`SHOW COLUMNS IN ALL CATALOGS`** statement (plus the usual `SCHEMA LIKE` / `TABLE LIKE` / column `LIKE` clauses) and lets the server enumerate catalogs in one round trip.

## Details

- `CommandConstants`: add `SHOW_COLUMNS_IN_ALL_CATALOGS_SQL`.
- `CommandBuilder.fetchColumnsSQL`: emit `SHOW COLUMNS IN ALL CATALOGS` when `catalogName == null` (mirrors `fetchTablesSQL` / `fetchSchemaSQL`); the LIKE-clause building is unchanged.
- `DatabricksMetadataQueryClient.listColumns`: drop the up-front "enumerate catalogs" branch. The null-catalog request now goes through the normal path; on a **parse syntax error** (older DBR versions that don't support the syntax) it transparently falls back to the previous enumerate-and-fan-out behavior (`fetchColumnsAcrossCatalogs`), exactly like the `listSchemas` fallback.

The `SHOW COLUMNS IN ALL CATALOGS` result schema is identical to per-catalog `SHOW COLUMNS` — the `catalogName` column is populated per row — so `COLUMN_COLUMNS` mapping (`TABLE_CAT` ← `catalogName`) needs no changes.

## Testing

- Verified `SHOW COLUMNS IN ALL CATALOGS SCHEMA LIKE '…' TABLE LIKE '…'` succeeds against a real SQL warehouse and returns the expected 13-column schema with `catalogName` populated per row.
- `CommandBuilderTest`: added null-catalog cases asserting `SHOW COLUMNS IN ALL CATALOGS` with and without LIKE clauses.
- `DatabricksMetadataQueryClientTest`: added `testListColumnsAllCatalogs` (single-statement path, no catalog enumeration) and `testListColumnsAllCatalogs_fallsBackOnParseSyntaxError` (fallback to enumerate-and-fan-out).
- Full metadata suites green: `DatabricksMetadataQueryClientTest`, `CommandBuilderTest`, `MetadataResultSetBuilderTest`, `DatabricksSdkClientTest`, `DatabricksDatabaseMetaDataTest`.

This pull request and its description were written by Isaac.
