### PR TITLE
ci: warm test deps for Engineer Bot's offline agent + bump timeout

### DIFF
--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -50,16 +50,23 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    # Budget = setup + warmup + author + teardown. Setup+warmup (checkout, JDK,
-    # build, test-compile of jdbc-core -am, plugin/surefire resolution, repo-id
-    # normalization) is the heaviest non-author cost — call it ~10 min. The
-    # author step is capped at 45 min (see its own timeout-minutes), leaving
-    # 60-45=15 min for everything else, which comfortably covers setup+warmup
-    # plus teardown (publish + outcome comment). With the test repo warmed
-    # offline the real work converges in ~15-20 min; the headroom absorbs a hard
-    # bug without letting a stuck run idle for an hour. Bounding the author step
-    # below the job wall means a runaway fails that step cleanly (the outcome
-    # comment still posts) instead of the whole job being force-cancelled.
+    # Budget = setup + warmup + author + teardown, and the invariant that keeps
+    # the always()-guarded outcome comment alive is:
+    #     max(setup+warmup) + author_cap + teardown  <=  job_cap
+    # The author cap is STEP-relative (it starts only after setup+warmup), so a
+    # long warmup could otherwise push author_start+45 to the 60-min wall and
+    # leave zero room for teardown — re-introducing the bare "job cancelled, no
+    # issue comment" this PR exists to prevent. We size for headroom instead of
+    # hoping warmup stays short:
+    #     author_cap = 40  (see Run author's timeout-minutes)
+    #     teardown   ~= 2   (publish + Comment outcome; observed <15s)
+    #     => allowed setup+warmup = 60 - 40 - 2 = 18 min
+    # Observed setup+warmup is ~4.5 min (checkout, JDK, build, test-compile of
+    # jdbc-core -am, plugin/surefire resolution, one JUnit-Platform test run,
+    # repo-id normalization), so there is ~13 min of slack before the invariant
+    # is even at risk. With the repo warmed offline the real author work
+    # converges in ~15-20 min; the 40-min cap absorbs a hard bug while still
+    # guaranteeing teardown headroom regardless of warmup variance.
     timeout-minutes: 60
     concurrency:
       # One author run per issue; a re-label while a run is in flight queues.
@@ -266,9 +273,11 @@ jobs:
         # killed here (this step fails) rather than at the job wall (the whole job
         # is force-cancelled). Failing the step lets the always()-guarded outcome
         # comment still run and report a real failure on the issue instead of a
-        # bare "job cancelled". 45 min leaves ~10 min of the 60-min job for setup
-        # + teardown.
-        timeout-minutes: 45
+        # bare "job cancelled". Capped at 40 (not 45) so the guarantee holds even
+        # if warmup runs long: 40 + ~2 teardown leaves 18 min for setup+warmup
+        # under the 60-min job wall, ~4x the observed ~4.5 min. See the job-level
+        # timeout-minutes comment for the full budget arithmetic.
+        timeout-minutes: 40
         # Run from RUNNER_TEMP so the engine-rendered prompt's context file
         # (issue_body.txt, resolved against cwd) is read from there and the checkout
         # stays clean — publish's leftover check fails on any untracked path in the

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -129,6 +129,18 @@ jobs:
           [ -n "$SUREFIRE_VERSION" ] || SUREFIRE_VERSION="3.1.2"
           mvn -B dependency:get \
             -Dartifact="org.apache.maven.surefire:surefire-junit-platform:${SUREFIRE_VERSION}" || true
+          # Finally, actually EXECUTE one fast unit test while creds are live.
+          # test-compile + the explicit get above resolve the test classpath and
+          # the provider jar, but anything Surefire resolves LAZILY at execution
+          # time (JUnit-Platform engine internals, provider transitives) only
+          # lands in ~/.m2 once a JUnit-Platform run really happens. This is what
+          # warmMavenCache.yml relies on — run the same fast test it uses so the
+          # offline `mvn test` inside Run author can't hit an execution-time
+          # resolution miss. `|| true`: warming the repo is the goal, not the
+          # test verdict (the agent runs its own tests later).
+          mvn -pl jdbc-core -B test \
+            -Dtest="DatabricksParameterMetaDataTest#testInitialization" \
+            -Ddependency-check.skip=true || true
 
       # Normalize the repo-id tracking markers BEFORE going offline. Artifacts
       # downloaded through the JFrog mirror record their source repo id

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -50,7 +50,12 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    timeout-minutes: 45
+    # Setup (~4 min) + the model-driven author step. With the test repo warmed
+    # offline (see warmup steps below) the real work converges in ~15-20 min;
+    # the headroom absorbs a hard bug without letting a stuck run idle for an
+    # hour. The agent itself is bounded tighter by its own step timeout so a
+    # runaway fails cleanly and still leaves time for the outcome comment.
+    timeout-minutes: 60
     concurrency:
       # One author run per issue; a re-label while a run is in flight queues.
       group: engineer-bot-issue-${{ github.event.issue.number || inputs.issue_number }}
@@ -87,6 +92,46 @@ jobs:
         # agent's diff. dependency-check.skip: the OWASP check needs NVD network +
         # is slow and not needed for the agent's build.
         run: mvn -pl jdbc-core -am -B clean install -DskipTests -Ddependency-check.skip=true
+
+      # Warm the TEST-scoped repo while creds are still live. The agent's bug-fix
+      # flow runs `mvn test`, but the build above skips the test phase — so the
+      # test-compile classpath and the Surefire JUnit-Platform provider never land
+      # in ~/.m2. Once creds are scrubbed and Maven goes offline, the agent cannot
+      # fetch them and burns its whole budget fighting "surefire-junit-platform
+      # (absent)" / cache-miss errors (observed: ~25 min wasted, job timed out).
+      # Resolve everything the offline `mvn test` will need, HERE. Mirrors the
+      # dependency-warming in .github/workflows/warmMavenCache.yml.
+      - name: Warm test dependencies for the offline agent
+        run: |
+          set -euo pipefail
+          # Compile the test sources so all test-scoped deps are downloaded.
+          mvn -pl jdbc-core -am -B test-compile -Ddependency-check.skip=true
+          # Pull all plugins referenced by the build into ~/.m2.
+          mvn -pl jdbc-core -B dependency:resolve-plugins -Ddependency-check.skip=true || true
+          # The Surefire JUnit-Platform provider is resolved LAZILY by Surefire
+          # only when it actually executes JUnit-Platform tests — test-compile
+          # never triggers it, so fetch it explicitly at the repo's pinned version.
+          SUREFIRE_VERSION=$(mvn -pl jdbc-core -B help:evaluate \
+            -Dexpression=maven-surefire-plugin.version -q -DforceStdout 2>/dev/null \
+            | tail -n1)
+          mvn -B dependency:get \
+            -Dartifact="org.apache.maven.surefire:surefire-junit-platform:${SUREFIRE_VERSION}" || true
+
+      # Normalize the repo-id tracking markers BEFORE going offline. Artifacts
+      # downloaded through the JFrog mirror record their source repo id
+      # (`jfrog-central`) in each `_remote.repositories`. Under the agent's empty
+      # offline settings that id is absent from the resolution context, so Maven
+      # rejects the cached artifact as "present, but unavailable" and the agent
+      # thrashes on the `trackingFilename` workaround. Rewriting the id to
+      # `central` (the implicit default repo) makes the warmed repo resolve
+      # cleanly offline. Same technique warmMavenCache.yml uses before caching.
+      - name: Normalize _remote.repositories for offline resolution
+        run: |
+          set -euo pipefail
+          COUNT=$(find ~/.m2/repository -name '_remote.repositories' -print | wc -l)
+          find ~/.m2/repository -name '_remote.repositories' \
+            -exec sed -i 's/jfrog-central/central/g' {} \;
+          echo "Normalized ${COUNT} _remote.repositories markers (jfrog-central -> central)"
 
       # `mvn install` above ran spotless:apply (bound to the compile phase), which
       # may have reformatted tracked .java files that were already in the tree.
@@ -192,6 +237,13 @@ jobs:
 
       - name: Run author
         id: author
+        # Bound the model-driven step BELOW the job timeout so a stuck agent is
+        # killed here (this step fails) rather than at the job wall (the whole job
+        # is force-cancelled). Failing the step lets the always()-guarded outcome
+        # comment still run and report a real failure on the issue instead of a
+        # bare "job cancelled". 45 min leaves ~10 min of the 60-min job for setup
+        # + teardown.
+        timeout-minutes: 45
         # Run from RUNNER_TEMP so the engine-rendered prompt's context file
         # (issue_body.txt, resolved against cwd) is read from there and the checkout
         # stays clean — publish's leftover check fails on any untracked path in the

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -50,11 +50,16 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    # Setup (~4 min) + the model-driven author step. With the test repo warmed
-    # offline (see warmup steps below) the real work converges in ~15-20 min;
-    # the headroom absorbs a hard bug without letting a stuck run idle for an
-    # hour. The agent itself is bounded tighter by its own step timeout so a
-    # runaway fails cleanly and still leaves time for the outcome comment.
+    # Budget = setup + warmup + author + teardown. Setup+warmup (checkout, JDK,
+    # build, test-compile of jdbc-core -am, plugin/surefire resolution, repo-id
+    # normalization) is the heaviest non-author cost — call it ~10 min. The
+    # author step is capped at 45 min (see its own timeout-minutes), leaving
+    # 60-45=15 min for everything else, which comfortably covers setup+warmup
+    # plus teardown (publish + outcome comment). With the test repo warmed
+    # offline the real work converges in ~15-20 min; the headroom absorbs a hard
+    # bug without letting a stuck run idle for an hour. Bounding the author step
+    # below the job wall means a runaway fails that step cleanly (the outcome
+    # comment still posts) instead of the whole job being force-cancelled.
     timeout-minutes: 60
     concurrency:
       # One author run per issue; a re-label while a run is in flight queues.
@@ -111,9 +116,17 @@ jobs:
           # The Surefire JUnit-Platform provider is resolved LAZILY by Surefire
           # only when it actually executes JUnit-Platform tests — test-compile
           # never triggers it, so fetch it explicitly at the repo's pinned version.
+          # Fall back to 3.1.2 (matching warmMavenCache.yml) if help:evaluate
+          # can't resolve the expression: under `set -euo pipefail` a failed/empty
+          # command substitution does NOT abort the assignment, so without an
+          # explicit default SUREFIRE_VERSION could go empty, producing a
+          # malformed coordinate that the trailing `|| true` would silently
+          # swallow — re-introducing the exact "surefire-junit-platform (absent)"
+          # dead-end this step exists to prevent.
           SUREFIRE_VERSION=$(mvn -pl jdbc-core -B help:evaluate \
             -Dexpression=maven-surefire-plugin.version -q -DforceStdout 2>/dev/null \
             | tail -n1)
+          [ -n "$SUREFIRE_VERSION" ] || SUREFIRE_VERSION="3.1.2"
           mvn -B dependency:get \
             -Dartifact="org.apache.maven.surefire:surefire-junit-platform:${SUREFIRE_VERSION}" || true
 


### PR DESCRIPTION
## Problem

The **Engineer Bot** author runs are timing out. Of the first 3 runs, 2 hit the 45-minute wall (`cancelled`) and 1 failed at 21.8m. In every run the `Run author` step consumes essentially the entire budget — setup is only ~4 min.

Investigating [run 30479109185](https://github.com/databricks/databricks-jdbc/actions/runs/30479109185/job/90668185628) (the "Thrift NPE" issue): the agent produced a **correct root-cause and fix at ~minute 14** (`CompressionCodec.getCompressionMapping` dereferences null metadata → return `NONE`). It then spent **turns 24→150 (~25 min)** stuck trying to *run its test*, never escaping, until the job was force-cancelled.

The blocker was the offline Maven setup, in two flavors visible in the log:

1. **`surefire-junit-platform:<version>` is genuinely absent** from `~/.m2`. The warmup build is `mvn ... install -DskipTests`, so the test phase — which is what lazily resolves the JUnit-Platform Surefire provider — never runs. After creds are scrubbed and Maven is forced offline (`MAVEN_ARGS=-o`), the agent's `mvn test` cannot fetch the provider. Dead end.
2. **`_remote.repositories` tracking-id mismatch** — cached plugins come back *"present, but unavailable"* because their tracking file records `jfrog-central`, a repo id absent from the agent's empty offline settings. The agent eventually found the `-Daether.enhancedLocalRepository.trackingFilename` workaround, but only after many wasted turns.

## Fix

Both problems are already solved for forked PRs in [`warmMavenCache.yml`](.github/workflows/warmMavenCache.yml); this PR applies the same techniques inline to the Engineer Bot, **while JFrog credentials are still live** (before the scrub step):

- **`Warm test dependencies for the offline agent`** — `test-compile` (downloads test-scoped deps), `dependency:resolve-plugins`, and an explicit `dependency:get` for `surefire-junit-platform` at the pom's pinned version.
- **`Normalize _remote.repositories for offline resolution`** — rewrites `jfrog-central` → `central` across `~/.m2` so the warmed repo resolves cleanly under the agent's offline settings.
- **Timeouts** — job `timeout-minutes` 45 → 60, plus a **45-min step timeout on `Run author`** so a genuinely stuck agent fails *the step* (the `always()`-guarded outcome comment then reports a real failure on the issue) instead of the whole job being force-cancelled with a bare "operation was canceled".

The test-compile churn is reverted by the existing "Revert spotless churn" step, which runs after these steps, keeping the tree clean for publish.

## Expected impact

Reclaims the ~25 min the agent wasted on dependency resolution — the real work in the sampled run converged in ~14-18 min. The timeout headroom absorbs a genuinely hard bug without letting a stuck run idle for an hour.

## Testing

Workflow-only change; validated YAML locally. Real validation is the next label-triggered (or `workflow_dispatch`) Engineer Bot run — the warmup steps should succeed with creds live, and the offline `mvn test` inside `Run author` should resolve without the surefire/tracking errors.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.