### PR TITLE
Add telemetry error classification guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,3 @@
 # Require review for changes to GitHub Actions workflows and CI configuration
 .github/workflows/ @databricks/eng-oss-sql-driver
 .github/CODEOWNERS @databricks/eng-oss-sql-driver 
-
-# Telemetry error-code changes require driver-owner review because they also need
-# classification in the maintainers' dashboard and automation taxonomy.
-src/main/java/com/databricks/jdbc/model/telemetry/enums/DatabricksDriverErrorCode.java @databricks/eng-oss-sql-driver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # Require review for changes to GitHub Actions workflows and CI configuration
 .github/workflows/ @databricks/eng-oss-sql-driver
 .github/CODEOWNERS @databricks/eng-oss-sql-driver 
+
+# Telemetry error-code changes require driver-owner review because they also need
+# classification in the maintainers' dashboard and automation taxonomy.
+src/main/java/com/databricks/jdbc/model/telemetry/enums/DatabricksDriverErrorCode.java @databricks/eng-oss-sql-driver

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,17 @@
 ## Testing
 <!-- Describe how the changes have been tested-->
 
+## Telemetry Errors
+<!--
+If this PR adds or changes an error emitted by the JDBC driver, complete both
+"Applicable" items. Otherwise check "Not applicable" only.
+-->
+- [ ] Not applicable — this PR does not add or change a telemetry-visible error.
+- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any
+      new code is uniquely numbered and tested.
+- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is
+      requested because the author cannot access the classification.
+
 ## Additional Notes to the Reviewer
 <!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
 Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,19 @@
 - `src/test/java/com/databricks/jdbc/` — unit and integration tests
 - `development/.release-freeze.json` — controls release freeze state
 
+## Telemetry Error Changes
+
+When adding or changing an error emitted by the JDBC driver:
+
+- Use `DatabricksDriverErrorCode` wherever a driver-owned error code applies. Reuse an
+  existing code when its meaning matches; otherwise add a uniquely numbered enum value.
+- Add or update a test that verifies the emitted error name and numeric code.
+- Record whether the error is a driver, server, or user error in the maintainers' OSS JDBC
+  telemetry dashboard and automation taxonomy. Link that update in the PR, or explicitly
+  ask a maintainer to make it if you do not have access. Do not infer the classification
+  from the error name alone.
+- Complete the telemetry-error section of the pull-request template.
+
 ## PR Checks — Common Pitfalls
 
 ### 1. DCO Sign-off (required)


### PR DESCRIPTION
## Description

Telemetry-visible JDBC errors need two things to remain useful downstream: a stable `DatabricksDriverErrorCode` and an explicit driver/server/user classification. Missing either can leave the telemetry dashboard and automation taxonomy out of sync.

This PR adds lightweight repository guardrails for future error changes:

- `CLAUDE.md` tells contributors to reuse or add an enum-backed code, verify the emitted name and numeric code in tests, and record the classification.
- The pull-request template asks authors to confirm those steps or request maintainer help when they cannot access the classification system.

The classification source is maintainer-owned and is not available to public-repository CI. The checks therefore remain review-based instead of adding CI that could validate only a PR checkbox, not the underlying classification.

NO_CHANGELOG=true

## Testing

Documentation and review-routing changes only; this PR does not change driver build or runtime behavior.

- Verified the exact error-code enum path referenced by the guidance.
- Verified the pull-request checklist covers both error-code and classification updates.
- `git diff --check` passes.

## Telemetry Errors

- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is requested because the author cannot access the classification.

## Additional Notes to the Reviewer

This is intentionally a lightweight contributor and reviewer guardrail. It does not duplicate the maintainer-owned taxonomy in the public repository or automatically classify existing errors.
