### PR TITLE
[5/7] Implement native SEA parameter batching

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/BatchParameterSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/BatchParameterSet.java
@@ -3,7 +3,9 @@ package com.databricks.jdbc.api.impl;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -12,16 +14,21 @@ import java.util.stream.Collectors;
 /**
  * Immutable, position-ordered snapshot of one prepared-statement parameter set.
  *
- * <p>This model normalizes JDBC's one-based parameter indexes to zero-based wire ordinals. It does
- * not validate parameter completeness, index continuity, or consistency with other parameter sets;
- * those validations remain the backend's responsibility.
+ * <p>This model preserves JDBC's one-based parameter indexes. Transport adapters are responsible
+ * for converting them to protocol-specific wire ordinals. It does not validate parameter
+ * completeness, index continuity, or consistency with other parameter sets; those validations
+ * remain the backend's responsibility.
  */
 public final class BatchParameterSet {
 
   private final List<ImmutableSqlParameter> parameters;
+  private final Map<Integer, ImmutableSqlParameter> parameterBindings;
 
   private BatchParameterSet(List<ImmutableSqlParameter> parameters) {
     this.parameters = List.copyOf(parameters);
+    Map<Integer, ImmutableSqlParameter> bindings = new LinkedHashMap<>();
+    this.parameters.forEach(parameter -> bindings.put(parameter.cardinal(), parameter));
+    this.parameterBindings = Collections.unmodifiableMap(bindings);
   }
 
   public static BatchParameterSet from(Map<Integer, ImmutableSqlParameter> parameterBindings) {
@@ -38,6 +45,10 @@ public final class BatchParameterSet {
     return parameters;
   }
 
+  public Map<Integer, ImmutableSqlParameter> getParameterBindings() {
+    return parameterBindings;
+  }
+
   public int size() {
     return parameters.size();
   }
@@ -50,7 +61,7 @@ public final class BatchParameterSet {
       Map.Entry<Integer, ImmutableSqlParameter> entry) {
     ImmutableSqlParameter parameter = entry.getValue();
     return ImmutableSqlParameter.builder()
-        .cardinal(entry.getKey() - 1)
+        .cardinal(entry.getKey())
         .type(parameter.type())
         .value(snapshotValue(parameter.value()))
         .build();

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
@@ -121,7 +121,19 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
             connection,
             interpolateParameters,
             (sqlToExecute, params, statementType, closeStatement) ->
-                executeInternal(sqlToExecute, params, statementType, closeStatement));
+                executeInternal(sqlToExecute, params, statementType, closeStatement),
+            new PreparedStatementBatchExecutor.NativeBatchExecutor() {
+              @Override
+              public boolean isSupported() {
+                return supportsNativeParameterBatching();
+              }
+
+              @Override
+              public long[] execute(String sql, List<BatchParameterSet> parameterSets)
+                  throws SQLException {
+                return executeNativeBatchInternal(sql, parameterSets);
+              }
+            });
 
     long[] updateCounts = batchExecutor.executeBatch(batchParameterSets);
 

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
@@ -33,7 +33,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
       JdbcLoggerFactory.getLogger(DatabricksPreparedStatement.class);
   private final String sql;
   private DatabricksParameterMetaData databricksParameterMetaData;
-  private List<DatabricksParameterMetaData> databricksBatchParameterMetaData;
+  private List<BatchParameterSet> batchParameterSets;
   private final boolean interpolateParameters;
   private final int CHUNK_SIZE = 8192;
 
@@ -43,7 +43,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
     this.sql = sql;
     this.interpolateParameters = connection.getConnectionContext().supportManyParameters();
     this.databricksParameterMetaData = new DatabricksParameterMetaData(sql);
-    this.databricksBatchParameterMetaData = new ArrayList<>();
+    this.batchParameterSets = new ArrayList<>();
     // Cache whether this statement should return a ResultSet (based on SQL and config)
     this.shouldReturnResultSet = shouldReturnResultSetWithConfig(sql);
   }
@@ -58,7 +58,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
     this.sql = sql;
     this.interpolateParameters = interpolateParameters;
     this.databricksParameterMetaData = databricksParameterMetaData;
-    this.databricksBatchParameterMetaData = new ArrayList<>();
+    this.batchParameterSets = new ArrayList<>();
     // Cache whether this statement should return a ResultSet (based on SQL and config)
     this.shouldReturnResultSet = shouldReturnResultSetWithConfig(sql);
   }
@@ -110,7 +110,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   public long[] executeLargeBatch() throws DatabricksBatchUpdateException {
     LOGGER.debug("public long executeLargeBatch()");
 
-    if (databricksBatchParameterMetaData.isEmpty()) {
+    if (batchParameterSets.isEmpty()) {
       return new long[0];
     }
 
@@ -123,7 +123,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
             (sqlToExecute, params, statementType, closeStatement) ->
                 executeInternal(sqlToExecute, params, statementType, closeStatement));
 
-    long[] updateCounts = batchExecutor.executeBatch(databricksBatchParameterMetaData);
+    long[] updateCounts = batchExecutor.executeBatch(batchParameterSets);
 
     // Clear the batch after successful execution per JDBC spec
     try {
@@ -371,7 +371,8 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   @Override
   public void addBatch() {
     LOGGER.debug("public void addBatch()");
-    this.databricksBatchParameterMetaData.add(databricksParameterMetaData);
+    this.batchParameterSets.add(
+        BatchParameterSet.from(databricksParameterMetaData.getParameterBindings()));
     this.databricksParameterMetaData = new DatabricksParameterMetaData(sql);
   }
 
@@ -380,7 +381,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
     LOGGER.debug("public void clearBatch()");
     checkIfClosed();
     this.databricksParameterMetaData = new DatabricksParameterMetaData(sql);
-    this.databricksBatchParameterMetaData = new ArrayList<>();
+    this.batchParameterSets = new ArrayList<>();
   }
 
   @Override
@@ -755,7 +756,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   private void checkIfBatchOperation() throws DatabricksSQLException {
-    if (!this.databricksBatchParameterMetaData.isEmpty()) {
+    if (!this.batchParameterSets.isEmpty()) {
       String errorMessage =
           "Batch must either be executed with executeBatch() or cleared with clearBatch()";
       LOGGER.error(errorMessage);

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatement.java
@@ -94,7 +94,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public int[] executeBatch() throws DatabricksBatchUpdateException {
+  public int[] executeBatch() throws SQLException {
     LOGGER.debug("public int executeBatch()");
     long[] largeUpdateCount = executeLargeBatch();
     int[] updateCount = new int[largeUpdateCount.length];
@@ -107,7 +107,7 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
   }
 
   @Override
-  public long[] executeLargeBatch() throws DatabricksBatchUpdateException {
+  public long[] executeLargeBatch() throws SQLException {
     LOGGER.debug("public long executeLargeBatch()");
 
     if (batchParameterSets.isEmpty()) {
@@ -135,16 +135,27 @@ public class DatabricksPreparedStatement extends DatabricksStatement implements 
               }
             });
 
-    long[] updateCounts = batchExecutor.executeBatch(batchParameterSets);
+    long[] updateCounts;
+    try {
+      updateCounts = batchExecutor.executeBatch(batchParameterSets);
+    } catch (NativeBatchResultException e) {
+      // The backend already completed the batch. Clear it before propagating the count-read error
+      // so a caller retry cannot insert the same rows again.
+      clearBatchAfterExecution();
+      throw e;
+    }
 
     // Clear the batch after successful execution per JDBC spec
+    clearBatchAfterExecution();
+    return updateCounts;
+  }
+
+  private void clearBatchAfterExecution() {
     try {
       clearBatch();
     } catch (SQLException e) {
-      LOGGER.error("Failed to clear batch after successful execution", e);
+      LOGGER.error("Failed to clear batch after execution", e);
     }
-
-    return updateCounts;
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
@@ -62,6 +62,7 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(DatabricksResultSet.class);
   protected static final String AFFECTED_ROWS_COUNT = "num_affected_rows";
+  private static final String REPEAT_COUNT = "repeat";
   private final ExecutionStatus executionStatus;
   private final StatementId statementId;
   private final IExecutionResult executionResult;
@@ -2308,6 +2309,44 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
       updateCount = 0L;
     }
     return updateCount;
+  }
+
+  long[] getBatchUpdateCounts(int expectedCount) throws SQLException {
+    checkIfClosed();
+    if (resultSetMetaData.getColumnNameIndex(AFFECTED_ROWS_COUNT) < 1) {
+      throw new DatabricksSQLException(
+          "Native batch result is missing column " + AFFECTED_ROWS_COUNT,
+          DatabricksDriverErrorCode.RESULT_SET_ERROR);
+    }
+
+    long[] counts = new long[expectedCount];
+    int index = 0;
+    boolean hasRepeatCount = resultSetMetaData.getColumnNameIndex(REPEAT_COUNT) > 0;
+    countingUpdateRows = true;
+    try {
+      while (next()) {
+        long repeatCount = hasRepeatCount ? getLong(REPEAT_COUNT) : 1;
+        if (repeatCount < 1 || repeatCount > expectedCount - index) {
+          throw new DatabricksSQLException(
+              "Native batch returned an invalid repeat count: " + repeatCount,
+              DatabricksDriverErrorCode.RESULT_SET_ERROR);
+        }
+        long affectedRows = getLong(AFFECTED_ROWS_COUNT);
+        for (long repeated = 0; repeated < repeatCount; repeated++) {
+          counts[index++] = affectedRows;
+        }
+      }
+    } finally {
+      countingUpdateRows = false;
+    }
+
+    if (index != expectedCount) {
+      throw new DatabricksSQLException(
+          String.format(
+              "Native batch returned %d update counts for %d parameter sets", index, expectedCount),
+          DatabricksDriverErrorCode.RESULT_SET_ERROR);
+    }
+    return counts;
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -866,6 +866,15 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
     LOGGER.debug(stackTraceMessage);
     CompletableFuture<DatabricksResultSet> futureResultSet =
         getFutureResult(sql, params, statementType);
+    return waitForExecutionResult(sql, stackTraceMessage, futureResultSet, closeStatement);
+  }
+
+  private DatabricksResultSet waitForExecutionResult(
+      String sql,
+      String stackTraceMessage,
+      CompletableFuture<DatabricksResultSet> futureResultSet,
+      boolean closeStatement)
+      throws SQLException {
     try {
       resultSet =
           timeoutInSeconds == 0
@@ -938,6 +947,34 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
     return result;
   }
 
+  boolean supportsNativeParameterBatching() {
+    try {
+      IDatabricksClient client = connection.getSession().getDatabricksClient();
+      return client.supportsNativeParameterBatching(connection.getSession().getComputeResource());
+    } catch (DatabricksSQLException e) {
+      LOGGER.warn("Unable to determine native batch capability, using legacy execution", e);
+      return false;
+    }
+  }
+
+  long[] executeNativeBatchInternal(String sql, List<BatchParameterSet> parameterSets)
+      throws SQLException {
+    resetForNewExecution();
+    DatabricksThreadContextHolder.setStatementType(StatementType.UPDATE);
+    String stackTraceMessage =
+        format(
+            "DatabricksResultSet executeNativeBatchInternal(String sql = %s, parameterSetCount = %s)",
+            sql, parameterSets.size());
+    LOGGER.debug(stackTraceMessage);
+    DatabricksResultSet result =
+        waitForExecutionResult(
+            sql,
+            stackTraceMessage,
+            getFutureBatchResult(sql, parameterSets, StatementType.UPDATE),
+            true);
+    return result.getBatchUpdateCounts(parameterSets.size());
+  }
+
   CompletableFuture<DatabricksResultSet> getFutureResult(
       String sql, Map<Integer, ImmutableSqlParameter> params, StatementType statementType) {
     return CompletableFuture.supplyAsync(
@@ -947,6 +984,21 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
             // Remove empty ESCAPE clauses that cause syntax errors in Databricks
             SQLString = StringUtil.removeRedundantEscapeClause(SQLString);
             return getResultFromClient(SQLString, params, statementType);
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        executor);
+  }
+
+  private CompletableFuture<DatabricksResultSet> getFutureBatchResult(
+      String sql, List<BatchParameterSet> parameterSets, StatementType statementType) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            String sqlString = escapeProcessing ? StringUtil.convertJdbcEscapeSequences(sql) : sql;
+            sqlString = StringUtil.removeRedundantEscapeClause(sqlString);
+            return getBatchResultFromClient(sqlString, parameterSets, statementType);
           } catch (SQLException e) {
             throw new RuntimeException(e);
           }
@@ -966,6 +1018,19 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
         connection.getSession(),
         this,
         null /* metadataOperationType */);
+  }
+
+  private DatabricksResultSet getBatchResultFromClient(
+      String sql, List<BatchParameterSet> parameterSets, StatementType statementType)
+      throws SQLException {
+    IDatabricksClient client = connection.getSession().getDatabricksClient();
+    return client.executeStatementBatch(
+        sql,
+        connection.getSession().getComputeResource(),
+        parameterSets,
+        statementType,
+        connection.getSession(),
+        this);
   }
 
   void checkIfClosed() throws DatabricksSQLException {

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -972,7 +972,11 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
             stackTraceMessage,
             getFutureBatchResult(sql, parameterSets, StatementType.UPDATE),
             true);
-    return result.getBatchUpdateCounts(parameterSets.size());
+    try {
+      return result.getBatchUpdateCounts(parameterSets.size());
+    } catch (SQLException e) {
+      throw new NativeBatchResultException(e);
+    }
   }
 
   CompletableFuture<DatabricksResultSet> getFutureResult(

--- a/src/main/java/com/databricks/jdbc/api/impl/LegacyPreparedStatementBatchExecutor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/LegacyPreparedStatementBatchExecutor.java
@@ -56,6 +56,11 @@ class LegacyPreparedStatementBatchExecutor {
     }
   }
 
+  long[] executeIndividually(List<BatchParameterSet> batchParameterSets)
+      throws DatabricksBatchUpdateException {
+    return executeIndividualStatements(batchParameterSets);
+  }
+
   private boolean canUseBatchedInsert() {
     // Check if batched inserts are enabled via connection property
     if (!connection.getConnectionContext().isBatchedInsertsEnabled()) {

--- a/src/main/java/com/databricks/jdbc/api/impl/LegacyPreparedStatementBatchExecutor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/LegacyPreparedStatementBatchExecutor.java
@@ -41,18 +41,18 @@ class LegacyPreparedStatementBatchExecutor {
     this.statementExecutor = statementExecutor;
   }
 
-  long[] executeBatch(List<DatabricksParameterMetaData> batchParameterMetaData)
+  long[] executeBatch(List<BatchParameterSet> batchParameterSets)
       throws DatabricksBatchUpdateException {
-    if (batchParameterMetaData.isEmpty()) {
+    if (batchParameterSets.isEmpty()) {
       return new long[0];
     }
 
     // Try to optimize INSERT statements with multi-row batching
     if (canUseBatchedInsert()) {
-      return executeBatchedInsert(batchParameterMetaData);
+      return executeBatchedInsert(batchParameterSets);
     } else {
       // Fall back to individual execution for non-INSERT or incompatible statements
-      return executeIndividualStatements(batchParameterMetaData);
+      return executeIndividualStatements(batchParameterSets);
     }
   }
 
@@ -76,9 +76,9 @@ class LegacyPreparedStatementBatchExecutor {
     }
   }
 
-  private long[] executeBatchedInsert(List<DatabricksParameterMetaData> batchParameterMetaData)
+  private long[] executeBatchedInsert(List<BatchParameterSet> batchParameterSets)
       throws DatabricksBatchUpdateException {
-    LOGGER.debug("Executing batched INSERT with {} rows", batchParameterMetaData.size());
+    LOGGER.debug("Executing batched INSERT with {} rows", batchParameterSets.size());
 
     try {
       InsertStatementParser.InsertInfo insertInfo = InsertStatementParser.parseInsertStrict(sql);
@@ -98,7 +98,7 @@ class LegacyPreparedStatementBatchExecutor {
               "BatchInsertSize must be at least 1, got: " + configuredBatchSize,
               DatabricksDriverErrorCode.INVALID_STATE);
         }
-        maxRowsPerChunk = Math.min(configuredBatchSize, batchParameterMetaData.size());
+        maxRowsPerChunk = Math.min(configuredBatchSize, batchParameterSets.size());
       } else {
         // When using parameterized queries, respect the 256 parameter limit from Databricks
         // backend
@@ -113,13 +113,13 @@ class LegacyPreparedStatementBatchExecutor {
         }
       }
 
-      long[] allUpdateCounts = new long[batchParameterMetaData.size()];
+      long[] allUpdateCounts = new long[batchParameterSets.size()];
 
       // Process batches in chunks
       for (int startIndex = 0;
-          startIndex < batchParameterMetaData.size();
+          startIndex < batchParameterSets.size();
           startIndex += maxRowsPerChunk) {
-        int endIndex = Math.min(startIndex + maxRowsPerChunk, batchParameterMetaData.size());
+        int endIndex = Math.min(startIndex + maxRowsPerChunk, batchParameterSets.size());
         int chunkSize = endIndex - startIndex;
 
         // Build multi-row INSERT for this chunk
@@ -128,7 +128,7 @@ class LegacyPreparedStatementBatchExecutor {
         int paramIndex = 1;
 
         for (int i = startIndex; i < endIndex; i++) {
-          DatabricksParameterMetaData batchParams = batchParameterMetaData.get(i);
+          BatchParameterSet batchParams = batchParameterSets.get(i);
           Map<Integer, ImmutableSqlParameter> rowParams = batchParams.getParameterBindings();
           for (int j = 1; j <= rowParams.size(); j++) {
             if (rowParams.containsKey(j)) {
@@ -161,7 +161,7 @@ class LegacyPreparedStatementBatchExecutor {
     } catch (Exception e) {
       // Unexpected exception - mark all as failed
       LOGGER.error("Unexpected error executing batched INSERT: {}", e.getMessage(), e);
-      long[] failedCounts = new long[batchParameterMetaData.size()];
+      long[] failedCounts = new long[batchParameterSets.size()];
       for (int i = 0; i < failedCounts.length; i++) {
         failedCounts[i] = Statement.EXECUTE_FAILED;
       }
@@ -170,22 +170,17 @@ class LegacyPreparedStatementBatchExecutor {
     }
   }
 
-  private long[] executeIndividualStatements(
-      List<DatabricksParameterMetaData> batchParameterMetaData)
+  private long[] executeIndividualStatements(List<BatchParameterSet> batchParameterSets)
       throws DatabricksBatchUpdateException {
-    LOGGER.debug("Executing batch individually with {} statements", batchParameterMetaData.size());
-    long[] largeUpdateCount = new long[batchParameterMetaData.size()];
+    LOGGER.debug("Executing batch individually with {} statements", batchParameterSets.size());
+    long[] largeUpdateCount = new long[batchParameterSets.size()];
 
-    for (int sqlQueryIndex = 0; sqlQueryIndex < batchParameterMetaData.size(); sqlQueryIndex++) {
-      DatabricksParameterMetaData databricksParameterMetaData =
-          batchParameterMetaData.get(sqlQueryIndex);
+    for (int sqlQueryIndex = 0; sqlQueryIndex < batchParameterSets.size(); sqlQueryIndex++) {
+      BatchParameterSet batchParameterSet = batchParameterSets.get(sqlQueryIndex);
       try {
         DatabricksResultSet resultSet =
             statementExecutor.execute(
-                sql,
-                databricksParameterMetaData.getParameterBindings(),
-                StatementType.UPDATE,
-                false);
+                sql, batchParameterSet.getParameterBindings(), StatementType.UPDATE, false);
         largeUpdateCount[sqlQueryIndex] = resultSet.getUpdateCount();
       } catch (Exception e) {
         LOGGER.error(

--- a/src/main/java/com/databricks/jdbc/api/impl/NativeBatchResultException.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/NativeBatchResultException.java
@@ -1,0 +1,22 @@
+package com.databricks.jdbc.api.impl;
+
+import com.databricks.jdbc.exception.DatabricksSQLException;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import java.sql.SQLException;
+
+/**
+ * Indicates that a native batch succeeded but its JDBC update counts could not be read.
+ *
+ * <p>This is intentionally not a {@code BatchUpdateException}: backend execution did not fail.
+ */
+class NativeBatchResultException extends DatabricksSQLException {
+
+  NativeBatchResultException(SQLException cause) {
+    super(
+        "Native batch execution succeeded, but JDBC update counts could not be read. "
+            + "Inserted rows may already be committed. Cause: "
+            + cause.getMessage(),
+        cause,
+        DatabricksDriverErrorCode.RESULT_SET_ERROR);
+  }
+}

--- a/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
@@ -67,8 +67,7 @@ class PreparedStatementBatchExecutor {
     this.nativeExecutor = nativeExecutor;
   }
 
-  long[] executeBatch(List<BatchParameterSet> batchParameterSets)
-      throws DatabricksBatchUpdateException {
+  long[] executeBatch(List<BatchParameterSet> batchParameterSets) throws SQLException {
     if (batchParameterSets.isEmpty()) {
       return new long[0];
     }
@@ -81,6 +80,8 @@ class PreparedStatementBatchExecutor {
     }
     try {
       return nativeExecutor.execute(sql, batchParameterSets);
+    } catch (NativeBatchResultException e) {
+      throw e;
     } catch (SQLException e) {
       if (isUnsupportedNativeBatching(e)) {
         return legacyExecutor.executeBatch(batchParameterSets);

--- a/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
@@ -1,6 +1,7 @@
 package com.databricks.jdbc.api.impl;
 
 import com.databricks.jdbc.common.StatementType;
+import com.databricks.jdbc.common.util.InsertStatementParser;
 import com.databricks.jdbc.exception.DatabricksBatchUpdateException;
 import java.sql.SQLException;
 import java.util.List;
@@ -8,7 +9,23 @@ import java.util.Map;
 
 class PreparedStatementBatchExecutor {
 
+  private static final NativeBatchExecutor UNSUPPORTED_NATIVE_EXECUTOR =
+      new NativeBatchExecutor() {
+        @Override
+        public boolean isSupported() {
+          return false;
+        }
+
+        @Override
+        public long[] execute(String sql, List<BatchParameterSet> parameterSets) {
+          throw new IllegalStateException("Native batch execution is not supported");
+        }
+      };
+
+  private final String sql;
+  private final DatabricksConnection connection;
   private final LegacyPreparedStatementBatchExecutor legacyExecutor;
+  private final NativeBatchExecutor nativeExecutor;
 
   @FunctionalInterface
   interface StatementExecutor {
@@ -20,18 +37,47 @@ class PreparedStatementBatchExecutor {
         throws SQLException;
   }
 
+  interface NativeBatchExecutor {
+    boolean isSupported();
+
+    long[] execute(String sql, List<BatchParameterSet> parameterSets)
+        throws DatabricksBatchUpdateException;
+  }
+
   PreparedStatementBatchExecutor(
       String sql,
       DatabricksConnection connection,
       boolean interpolateParameters,
       StatementExecutor statementExecutor) {
+    this(sql, connection, interpolateParameters, statementExecutor, UNSUPPORTED_NATIVE_EXECUTOR);
+  }
+
+  PreparedStatementBatchExecutor(
+      String sql,
+      DatabricksConnection connection,
+      boolean interpolateParameters,
+      StatementExecutor statementExecutor,
+      NativeBatchExecutor nativeExecutor) {
+    this.sql = sql;
+    this.connection = connection;
     this.legacyExecutor =
         new LegacyPreparedStatementBatchExecutor(
             sql, connection, interpolateParameters, statementExecutor);
+    this.nativeExecutor = nativeExecutor;
   }
 
-  long[] executeBatch(List<DatabricksParameterMetaData> batchParameterMetaData)
+  long[] executeBatch(List<BatchParameterSet> batchParameterSets)
       throws DatabricksBatchUpdateException {
-    return legacyExecutor.executeBatch(batchParameterMetaData);
+    if (canUseNativeBatching(batchParameterSets)) {
+      return nativeExecutor.execute(sql, batchParameterSets);
+    }
+    return legacyExecutor.executeBatch(batchParameterSets);
+  }
+
+  private boolean canUseNativeBatching(List<BatchParameterSet> batchParameterSets) {
+    return !batchParameterSets.isEmpty()
+        && connection.getConnectionContext().isNativeBatchingEnabled()
+        && InsertStatementParser.isParametrizedInsert(sql)
+        && nativeExecutor.isSupported();
   }
 }

--- a/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutor.java
@@ -4,6 +4,8 @@ import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.common.util.InsertStatementParser;
 import com.databricks.jdbc.exception.DatabricksBatchUpdateException;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -40,8 +42,7 @@ class PreparedStatementBatchExecutor {
   interface NativeBatchExecutor {
     boolean isSupported();
 
-    long[] execute(String sql, List<BatchParameterSet> parameterSets)
-        throws DatabricksBatchUpdateException;
+    long[] execute(String sql, List<BatchParameterSet> parameterSets) throws SQLException;
   }
 
   PreparedStatementBatchExecutor(
@@ -68,16 +69,32 @@ class PreparedStatementBatchExecutor {
 
   long[] executeBatch(List<BatchParameterSet> batchParameterSets)
       throws DatabricksBatchUpdateException {
-    if (canUseNativeBatching(batchParameterSets)) {
-      return nativeExecutor.execute(sql, batchParameterSets);
+    if (batchParameterSets.isEmpty()) {
+      return new long[0];
     }
-    return legacyExecutor.executeBatch(batchParameterSets);
+    if (!InsertStatementParser.isParametrizedInsert(sql)) {
+      return legacyExecutor.executeIndividually(batchParameterSets);
+    }
+    if (!connection.getConnectionContext().isNativeBatchingEnabled()
+        || !nativeExecutor.isSupported()) {
+      return legacyExecutor.executeBatch(batchParameterSets);
+    }
+    try {
+      return nativeExecutor.execute(sql, batchParameterSets);
+    } catch (SQLException e) {
+      if (isUnsupportedNativeBatching(e)) {
+        return legacyExecutor.executeBatch(batchParameterSets);
+      }
+      long[] failedCounts = new long[batchParameterSets.size()];
+      Arrays.fill(failedCounts, Statement.EXECUTE_FAILED);
+      throw new DatabricksBatchUpdateException(
+          e.getMessage(), e.getSQLState(), e.getErrorCode(), failedCounts, e);
+    }
   }
 
-  private boolean canUseNativeBatching(List<BatchParameterSet> batchParameterSets) {
-    return !batchParameterSets.isEmpty()
-        && connection.getConnectionContext().isNativeBatchingEnabled()
-        && InsertStatementParser.isParametrizedInsert(sql)
-        && nativeExecutor.isSupported();
+  private boolean isUnsupportedNativeBatching(SQLException exception) {
+    return "42P02".equals(exception.getSQLState())
+        && exception.getMessage() != null
+        && exception.getMessage().contains("[UNBOUND_SQL_PARAMETER]");
   }
 }

--- a/src/main/java/com/databricks/jdbc/common/util/ProtocolFeatureUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ProtocolFeatureUtil.java
@@ -141,6 +141,16 @@ public final class ProtocolFeatureUtil {
   }
 
   /**
+   * Checks if the given protocol version supports native parameter batches.
+   *
+   * @param protocolVersion The protocol version to check
+   * @return true if native parameter batches are supported, false otherwise
+   */
+  public static boolean supportsNativeParameterBatching(TProtocolVersion protocolVersion) {
+    return protocolVersion.compareTo(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V10) >= 0;
+  }
+
+  /**
    * Checks if the given protocol version indicates a non-Databricks compute.
    *
    * @param protocolVersion The protocol version to check

--- a/src/main/java/com/databricks/jdbc/dbclient/IDatabricksClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/IDatabricksClient.java
@@ -15,6 +15,8 @@ import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimed;
 import com.databricks.sdk.core.DatabricksConfig;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.List;
 import java.util.Map;
 
 /** Interface for Databricks client which abstracts the integration with Databricks server. */
@@ -70,6 +72,37 @@ public interface IDatabricksClient {
       IDatabricksStatementInternal parentStatement,
       MetadataOperationType metadataOperationType)
       throws SQLException;
+
+  /**
+   * Returns whether this client can execute a native parameter batch for the given compute.
+   *
+   * @param computeResource underlying SQL warehouse or all-purpose cluster
+   */
+  default boolean supportsNativeParameterBatching(IDatabricksComputeResource computeResource) {
+    return false;
+  }
+
+  /**
+   * Executes one statement with multiple ordered parameter sets in a single backend request.
+   *
+   * @param sql SQL statement that needs to be executed
+   * @param computeResource underlying SQL warehouse or all-purpose cluster
+   * @param parameterSets ordered parameter sets for the statement
+   * @param statementType type of statement
+   * @param session underlying session
+   * @param parentStatement statement instance
+   */
+  @DatabricksMetricsTimed
+  default DatabricksResultSet executeStatementBatch(
+      String sql,
+      IDatabricksComputeResource computeResource,
+      List<BatchParameterSet> parameterSets,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatementInternal parentStatement)
+      throws SQLException {
+    throw new SQLFeatureNotSupportedException("Native parameter batching is not supported");
+  }
 
   /**
    * Executes a statement in Databricks server asynchronously

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -191,6 +191,27 @@ public class DatabricksSdkClient implements IDatabricksClient {
       IDatabricksStatementInternal parentStatement,
       MetadataOperationType metadataOperationType)
       throws SQLException {
+    return executeStatement(
+        sql,
+        computeResource,
+        parameters,
+        statementType,
+        session,
+        parentStatement,
+        metadataOperationType,
+        null);
+  }
+
+  private DatabricksResultSet executeStatement(
+      String sql,
+      IDatabricksComputeResource computeResource,
+      Map<Integer, ImmutableSqlParameter> parameters,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatementInternal parentStatement,
+      MetadataOperationType metadataOperationType,
+      ExecuteStatementRequest suppliedRequest)
+      throws SQLException {
     LOGGER.debug(
         "public DatabricksResultSet executeStatement(String sql = {}, compute resource = {}, Map<Integer, ImmutableSqlParameter> parameters = {}, StatementType statementType = {}, IDatabricksSession session = {}, parentStatement = {}, metadataOperationType = {})",
         sql,
@@ -205,14 +226,16 @@ public class DatabricksSdkClient implements IDatabricksClient {
     long executionStartTime = Instant.now().toEpochMilli();
     DatabricksThreadContextHolder.setStatementType(statementType);
     ExecuteStatementRequest request =
-        getRequest(
-            statementType,
-            sql,
-            ((Warehouse) computeResource).getWarehouseId(),
-            session,
-            parameters,
-            parentStatement,
-            false);
+        suppliedRequest != null
+            ? suppliedRequest
+            : getRequest(
+                statementType,
+                sql,
+                ((Warehouse) computeResource).getWarehouseId(),
+                session,
+                parameters,
+                parentStatement,
+                false);
     ExecuteStatementResponse response;
     try {
       Request req = new Request(Request.POST, STATEMENT_PATH, apiClient.serialize(request));
@@ -353,6 +376,39 @@ public class DatabricksSdkClient implements IDatabricksClient {
     }
 
     return resultSet;
+  }
+
+  @Override
+  public boolean supportsNativeParameterBatching(IDatabricksComputeResource computeResource) {
+    return computeResource instanceof Warehouse;
+  }
+
+  @Override
+  public DatabricksResultSet executeStatementBatch(
+      String sql,
+      IDatabricksComputeResource computeResource,
+      List<BatchParameterSet> parameterSets,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatementInternal parentStatement)
+      throws SQLException {
+    ExecuteStatementRequest request =
+        getBatchRequest(
+            statementType,
+            sql,
+            ((Warehouse) computeResource).getWarehouseId(),
+            session,
+            parameterSets,
+            parentStatement);
+    return executeStatement(
+        sql,
+        computeResource,
+        Collections.emptyMap(),
+        statementType,
+        session,
+        parentStatement,
+        null,
+        request);
   }
 
   @Override
@@ -756,15 +812,52 @@ public class DatabricksSdkClient implements IDatabricksClient {
     return request;
   }
 
+  private ExecuteStatementRequest getBatchRequest(
+      StatementType statementType,
+      String sql,
+      String warehouseId,
+      IDatabricksSession session,
+      List<BatchParameterSet> parameterSets,
+      IDatabricksStatementInternal parentStatement)
+      throws SQLException {
+    ExecuteStatementRequest request =
+        getRequest(
+            statementType,
+            sql,
+            warehouseId,
+            session,
+            Collections.emptyMap(),
+            parentStatement,
+            false);
+    List<StatementParameterSet> seaParameterSets =
+        parameterSets.stream()
+            .map(
+                parameterSet ->
+                    new StatementParameterSet()
+                        .setParameters(
+                            parameterSet.getParameters().stream()
+                                .map(
+                                    parameter ->
+                                        mapToParameterListItem(parameter, parameter.cardinal() - 1))
+                                .collect(Collectors.toList())))
+            .collect(Collectors.toList());
+    return request.setParameterSets(seaParameterSets).unsetRowLimit();
+  }
+
   @VisibleForTesting
   StatementParameterListItem mapToParameterListItem(ImmutableSqlParameter parameter) {
+    return mapToParameterListItem(parameter, parameter.cardinal());
+  }
+
+  private StatementParameterListItem mapToParameterListItem(
+      ImmutableSqlParameter parameter, int ordinal) {
     Object value = parameter.value();
     String typeString = parameter.type().name();
     if (typeString.equals(DECIMAL) && value instanceof BigDecimal) {
       typeString = getDecimalTypeString((BigDecimal) value);
     }
     return new PositionalStatementParameterListItem()
-        .setOrdinal(parameter.cardinal())
+        .setOrdinal(ordinal)
         .setType(typeString)
         .setValue(value != null ? value.toString() : null);
   }

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClient.java
@@ -13,9 +13,11 @@ import com.databricks.jdbc.api.impl.*;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
+import com.databricks.jdbc.common.AllPurposeCluster;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.MetadataOperationType;
 import com.databricks.jdbc.common.StatementType;
+import com.databricks.jdbc.common.Warehouse;
 import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.common.util.DriverUtil;
 import com.databricks.jdbc.common.util.ProtocolFeatureUtil;
@@ -173,6 +175,33 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
   }
 
   @Override
+  public boolean supportsNativeParameterBatching(IDatabricksComputeResource computeResource) {
+    if (computeResource instanceof AllPurposeCluster) {
+      return ProtocolFeatureUtil.supportsNativeParameterBatching(serverProtocolVersion);
+    }
+    return computeResource instanceof Warehouse;
+  }
+
+  @Override
+  public DatabricksResultSet executeStatementBatch(
+      String sql,
+      IDatabricksComputeResource computeResource,
+      List<BatchParameterSet> parameterSets,
+      StatementType statementType,
+      IDatabricksSession session,
+      IDatabricksStatementInternal parentStatement)
+      throws SQLException {
+    LOGGER.debug(
+        "Executing native parameter batch with {} parameter sets on {}",
+        parameterSets.size(),
+        computeResource);
+    DatabricksThreadContextHolder.setStatementType(statementType);
+    TExecuteStatementReq request =
+        getBatchRequest(sql, parameterSets, session, parentStatement, statementType);
+    return thriftAccessor.execute(request, parentStatement, session, statementType);
+  }
+
+  @Override
   public DatabricksResultSet executeStatementAsync(
       String sql,
       IDatabricksComputeResource computeResource,
@@ -194,15 +223,45 @@ public class DatabricksThriftServiceClient implements IDatabricksClient, IDatabr
 
   @VisibleForTesting
   TSparkParameter mapToSparkParameterListItem(ImmutableSqlParameter parameter) {
+    return mapToSparkParameterListItem(parameter, parameter.cardinal());
+  }
+
+  private TSparkParameter mapToSparkParameterListItem(
+      ImmutableSqlParameter parameter, int ordinal) {
     Object value = parameter.value();
     String typeString = parameter.type().name();
     if (typeString.equals(DECIMAL) && value instanceof BigDecimal) {
       typeString = getDecimalTypeString((BigDecimal) value);
     }
     return new TSparkParameter()
-        .setOrdinal(parameter.cardinal())
+        .setOrdinal(ordinal)
         .setType(typeString)
         .setValue(value != null ? TSparkParameterValue.stringValue(value.toString()) : null);
+  }
+
+  private TExecuteStatementReq getBatchRequest(
+      String sql,
+      List<BatchParameterSet> parameterSets,
+      IDatabricksSession session,
+      IDatabricksStatementInternal parentStatement,
+      StatementType statementType)
+      throws SQLException {
+    TExecuteStatementReq request =
+        getRequest(sql, Collections.emptyMap(), session, parentStatement, false, statementType);
+    request.unsetParameters();
+    request.unsetResultRowLimit();
+    List<List<TSparkParameter>> batchParameters =
+        parameterSets.stream()
+            .map(
+                parameterSet ->
+                    parameterSet.getParameters().stream()
+                        .map(
+                            parameter ->
+                                mapToSparkParameterListItem(parameter, parameter.cardinal() - 1))
+                        .collect(Collectors.toList()))
+            .collect(Collectors.toList());
+    request.setBatchParameters(batchParameters);
+    return request;
   }
 
   private TExecuteStatementReq getRequest(

--- a/src/main/java/com/databricks/jdbc/model/client/sqlexec/ExecuteStatementRequest.java
+++ b/src/main/java/com/databricks/jdbc/model/client/sqlexec/ExecuteStatementRequest.java
@@ -43,6 +43,9 @@ public class ExecuteStatementRequest {
   @JsonProperty("parameters")
   private Collection<StatementParameterListItem> parameters;
 
+  @JsonProperty("parameter_sets")
+  private Collection<StatementParameterSet> parameterSets;
+
   @JsonProperty("result_compression")
   private CompressionCodec resultCompression;
 
@@ -82,6 +85,10 @@ public class ExecuteStatementRequest {
     return parameters;
   }
 
+  public Collection<StatementParameterSet> getParameterSets() {
+    return parameterSets;
+  }
+
   public CompressionCodec getResultCompression() {
     return resultCompression;
   }
@@ -104,6 +111,11 @@ public class ExecuteStatementRequest {
 
   public ExecuteStatementRequest setRowLimit(long rowLimit) {
     this.rowLimit = rowLimit;
+    return this;
+  }
+
+  public ExecuteStatementRequest unsetRowLimit() {
+    this.rowLimit = null;
     return this;
   }
 
@@ -135,6 +147,17 @@ public class ExecuteStatementRequest {
 
   public ExecuteStatementRequest setParameters(Collection<StatementParameterListItem> parameters) {
     this.parameters = parameters;
+    if (parameters != null) {
+      this.parameterSets = null;
+    }
+    return this;
+  }
+
+  public ExecuteStatementRequest setParameterSets(Collection<StatementParameterSet> parameterSets) {
+    this.parameterSets = parameterSets;
+    if (parameterSets != null) {
+      this.parameters = null;
+    }
     return this;
   }
 
@@ -145,6 +168,7 @@ public class ExecuteStatementRequest {
         .add("format", format)
         .add("onWaitTimeout", onWaitTimeout)
         .add("parameters", parameters)
+        .add("parameterSetCount", parameterSets == null ? 0 : parameterSets.size())
         .add("statement", statement)
         .add("sessionId", sessionId)
         .add("waitTimeout", waitTimeout)
@@ -160,6 +184,7 @@ public class ExecuteStatementRequest {
         format,
         onWaitTimeout,
         parameters,
+        parameterSets,
         rowLimit,
         statement,
         waitTimeout,
@@ -177,6 +202,7 @@ public class ExecuteStatementRequest {
         && Objects.equals(format, that.format)
         && Objects.equals(onWaitTimeout, that.onWaitTimeout)
         && Objects.equals(parameters, that.parameters)
+        && Objects.equals(parameterSets, that.parameterSets)
         && Objects.equals(rowLimit, that.rowLimit)
         && Objects.equals(statement, that.statement)
         && Objects.equals(waitTimeout, that.waitTimeout)

--- a/src/main/java/com/databricks/jdbc/model/client/sqlexec/StatementParameterSet.java
+++ b/src/main/java/com/databricks/jdbc/model/client/sqlexec/StatementParameterSet.java
@@ -1,0 +1,47 @@
+package com.databricks.jdbc.model.client.sqlexec;
+
+import com.databricks.sdk.service.sql.StatementParameterListItem;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/** Driver-owned SEA model for one ordered statement parameter set. */
+public class StatementParameterSet {
+
+  @JsonProperty("parameters")
+  private Collection<StatementParameterListItem> parameters;
+
+  public Collection<StatementParameterListItem> getParameters() {
+    return parameters;
+  }
+
+  public StatementParameterSet setParameters(Collection<StatementParameterListItem> parameters) {
+    this.parameters = parameters == null ? null : List.copyOf(parameters);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof StatementParameterSet)) {
+      return false;
+    }
+    StatementParameterSet that = (StatementParameterSet) other;
+    return Objects.equals(parameters, that.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(parameters);
+  }
+
+  @Override
+  public String toString() {
+    return "StatementParameterSet{parameterCount="
+        + (parameters == null ? 0 : parameters.size())
+        + '}';
+  }
+}

--- a/src/test/java/com/databricks/jdbc/api/impl/BatchParameterSetTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/BatchParameterSetTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class BatchParameterSetTest {
 
   @Test
-  void ordersParametersByJdbcIndexAndUsesZeroBasedOrdinals() {
+  void ordersParametersAndPreservesJdbcIndexes() {
     Map<Integer, ImmutableSqlParameter> bindings = new HashMap<>();
     bindings.put(3, parameter(99, "third", ColumnInfoTypeName.STRING));
     bindings.put(1, parameter(99, "first", ColumnInfoTypeName.STRING));
@@ -26,7 +26,8 @@ class BatchParameterSetTest {
     BatchParameterSet parameterSet = BatchParameterSet.from(bindings);
 
     assertEquals(List.of("first", "second", "third"), values(parameterSet));
-    assertEquals(List.of(0, 1, 2), ordinals(parameterSet));
+    assertEquals(List.of(1, 2, 3), indexes(parameterSet));
+    assertEquals(List.of(1, 2, 3), List.copyOf(parameterSet.getParameterBindings().keySet()));
   }
 
   @Test
@@ -38,7 +39,7 @@ class BatchParameterSetTest {
     BatchParameterSet parameterSet = BatchParameterSet.from(bindings);
 
     assertEquals(List.of("first", "third"), values(parameterSet));
-    assertEquals(List.of(0, 2), ordinals(parameterSet));
+    assertEquals(List.of(1, 3), indexes(parameterSet));
   }
 
   @Test
@@ -70,6 +71,12 @@ class BatchParameterSetTest {
     assertThrows(
         UnsupportedOperationException.class,
         () -> parameterSet.getParameters().add(parameter(3, "extra", ColumnInfoTypeName.STRING)));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            parameterSet
+                .getParameterBindings()
+                .put(3, parameter(3, "extra", ColumnInfoTypeName.STRING)));
   }
 
   @Test
@@ -80,7 +87,7 @@ class BatchParameterSetTest {
     ImmutableSqlParameter parameter = parameterSet.getParameters().get(0);
     assertNull(parameter.value());
     assertEquals(ColumnInfoTypeName.DECIMAL, parameter.type());
-    assertEquals(0, parameter.cardinal());
+    assertEquals(1, parameter.cardinal());
   }
 
   private ImmutableSqlParameter parameter(
@@ -98,7 +105,7 @@ class BatchParameterSetTest {
         .collect(java.util.stream.Collectors.toList());
   }
 
-  private List<Integer> ordinals(BatchParameterSet parameterSet) {
+  private List<Integer> indexes(BatchParameterSet parameterSet) {
     return parameterSet.getParameters().stream()
         .map(ImmutableSqlParameter::cardinal)
         .collect(java.util.stream.Collectors.toList());

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksCallableStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksCallableStatementTest.java
@@ -3,6 +3,7 @@ package com.databricks.jdbc.api.impl;
 import static com.databricks.jdbc.TestConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
@@ -304,7 +305,7 @@ public class DatabricksCallableStatementTest {
       when(client.executeStatement(
               eq(CALL_SQL_AS_EXECUTED),
               eq(new Warehouse(WAREHOUSE_ID)),
-              any(HashMap.class),
+              anyMap(),
               eq(StatementType.UPDATE),
               any(IDatabricksSession.class),
               eq(stmt),

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
@@ -4,6 +4,7 @@ import static com.databricks.jdbc.TestConstants.*;
 import static java.sql.JDBCType.DECIMAL;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.stream.Stream;
@@ -437,6 +439,40 @@ public class DatabricksPreparedStatementTest {
     for (int i = 0; i < 4; i++) {
       assertEquals(Statement.EXECUTE_FAILED, updateCounts[i]);
     }
+  }
+
+  @Test
+  public void testAddBatchSnapshotsMutableParameterValues() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, client);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, "INSERT INTO events (created_at) VALUES (?)");
+    Timestamp timestamp = Timestamp.valueOf("2026-08-10 12:34:56.123456789");
+    Timestamp expectedTimestamp = Timestamp.valueOf(timestamp.toString());
+
+    statement.setTimestamp(1, timestamp);
+    statement.addBatch();
+    timestamp.setTime(0);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<Integer, ImmutableSqlParameter>> parametersCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    when(client.executeStatement(
+            anyString(),
+            eq(new Warehouse(WAREHOUSE_ID)),
+            parametersCaptor.capture(),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement),
+            any()))
+        .thenReturn(resultSet);
+    when(resultSet.getUpdateCount()).thenReturn(1L);
+
+    assertArrayEquals(new int[] {1}, statement.executeBatch());
+    Object snapshottedValue = parametersCaptor.getValue().get(1).value();
+    assertEquals(expectedTimestamp, snapshottedValue);
+    assertNotSame(timestamp, snapshottedValue);
   }
 
   public static ImmutableSqlParameter getSqlParam(

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -473,6 +474,46 @@ public class DatabricksPreparedStatementTest {
     Object snapshottedValue = parametersCaptor.getValue().get(1).value();
     assertEquals(expectedTimestamp, snapshottedValue);
     assertNotSame(timestamp, snapshottedValue);
+  }
+
+  @Test
+  public void testExecuteBatchUsesSupportedNativeClient() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL + "EnableNativeBatching=1;", new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, thriftClient);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, "INSERT INTO target (id, name) VALUES (?, ?)");
+    statement.setInt(1, 1);
+    statement.setString(2, "first");
+    statement.addBatch();
+    statement.setInt(1, 2);
+    statement.setString(2, "second");
+    statement.addBatch();
+    when(thriftClient.supportsNativeParameterBatching(any())).thenReturn(true);
+    when(thriftClient.executeStatementBatch(
+            anyString(),
+            any(),
+            any(),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    when(resultSet.getBatchUpdateCounts(2)).thenReturn(new long[] {1, 1});
+
+    assertArrayEquals(new int[] {1, 1}, statement.executeBatch());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<BatchParameterSet>> parameterSetsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    verify(thriftClient)
+        .executeStatementBatch(
+            eq("INSERT INTO target (id, name) VALUES (?, ?)"),
+            any(),
+            parameterSetsCaptor.capture(),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement));
+    assertEquals(2, parameterSetsCaptor.getValue().size());
   }
 
   public static ImmutableSqlParameter getSqlParam(

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksPreparedStatementTest.java
@@ -516,6 +516,44 @@ public class DatabricksPreparedStatementTest {
     assertEquals(2, parameterSetsCaptor.getValue().size());
   }
 
+  @Test
+  public void testExecuteBatchThrowsResultErrorWhenNativeCountsCannotBeRead() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL + "EnableNativeBatching=1;", new Properties());
+    DatabricksConnection connection = new DatabricksConnection(connectionContext, thriftClient);
+    DatabricksPreparedStatement statement =
+        new DatabricksPreparedStatement(connection, "INSERT INTO target (id) VALUES (?)");
+    statement.setInt(1, 1);
+    statement.addBatch();
+    when(thriftClient.supportsNativeParameterBatching(any())).thenReturn(true);
+    when(thriftClient.executeStatementBatch(
+            anyString(),
+            any(),
+            any(),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement)))
+        .thenReturn(resultSet);
+    SQLException countError = new SQLException("Missing update-count column", "RESULT_SET_ERROR");
+    when(resultSet.getBatchUpdateCounts(1)).thenThrow(countError);
+
+    NativeBatchResultException exception =
+        assertThrows(NativeBatchResultException.class, statement::executeBatch);
+
+    assertEquals("RESULT_SET_ERROR", exception.getSQLState());
+    assertSame(countError, exception.getCause());
+    assertTrue(exception.getMessage().contains("Inserted rows may already be committed"));
+    assertArrayEquals(new int[0], statement.executeBatch());
+    verify(thriftClient, times(1))
+        .executeStatementBatch(
+            anyString(),
+            any(),
+            any(),
+            eq(StatementType.UPDATE),
+            any(IDatabricksSession.class),
+            eq(statement));
+  }
+
   public static ImmutableSqlParameter getSqlParam(
       int parameterIndex, Object x, String databricksType) {
     return ImmutableSqlParameter.builder()

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksResultSetTest.java
@@ -1232,6 +1232,86 @@ public class DatabricksResultSetTest {
   }
 
   @Test
+  void testGetBatchUpdateCountsPreservesOrder() throws SQLException {
+    when(mockedResultSetMetadata.getColumnType(1)).thenReturn(Types.BIGINT);
+    when(mockedResultSetMetadata.getColumnNameIndex(AFFECTED_ROWS_COUNT)).thenReturn(1);
+    when(mockedExecutionResult.next()).thenReturn(true, true, true, false);
+    when(mockedExecutionResult.getObject(0)).thenReturn(3L, 1L, 2L);
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.UPDATE,
+            null,
+            mockedExecutionResult,
+            mockedResultSetMetadata,
+            false);
+
+    assertArrayEquals(new long[] {3, 1, 2}, resultSet.getBatchUpdateCounts(3));
+  }
+
+  @Test
+  void testGetBatchUpdateCountsExpandsRepeatColumn() throws SQLException {
+    when(mockedResultSetMetadata.getColumnType(1)).thenReturn(Types.BIGINT);
+    when(mockedResultSetMetadata.getColumnType(2)).thenReturn(Types.BIGINT);
+    when(mockedResultSetMetadata.getColumnNameIndex(AFFECTED_ROWS_COUNT)).thenReturn(1);
+    when(mockedResultSetMetadata.getColumnNameIndex("repeat")).thenReturn(2);
+    when(mockedExecutionResult.next()).thenReturn(true, false);
+    when(mockedExecutionResult.getObject(0)).thenReturn(1L);
+    when(mockedExecutionResult.getObject(1)).thenReturn(3L);
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.UPDATE,
+            null,
+            mockedExecutionResult,
+            mockedResultSetMetadata,
+            false);
+
+    assertArrayEquals(new long[] {1, 1, 1}, resultSet.getBatchUpdateCounts(3));
+  }
+
+  @Test
+  void testGetBatchUpdateCountsRejectsWrongCardinality() throws SQLException {
+    when(mockedResultSetMetadata.getColumnType(1)).thenReturn(Types.BIGINT);
+    when(mockedResultSetMetadata.getColumnNameIndex(AFFECTED_ROWS_COUNT)).thenReturn(1);
+    when(mockedExecutionResult.next()).thenReturn(true, false);
+    when(mockedExecutionResult.getObject(0)).thenReturn(1L);
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.UPDATE,
+            null,
+            mockedExecutionResult,
+            mockedResultSetMetadata,
+            false);
+
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getBatchUpdateCounts(2));
+    assertTrue(exception.getMessage().contains("1 update counts for 2 parameter sets"));
+  }
+
+  @Test
+  void testGetBatchUpdateCountsRejectsMissingAffectedRowsColumn() throws SQLException {
+    when(mockedResultSetMetadata.getColumnNameIndex(AFFECTED_ROWS_COUNT)).thenReturn(-1);
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.UPDATE,
+            null,
+            mockedExecutionResult,
+            mockedResultSetMetadata,
+            false);
+
+    DatabricksSQLException exception =
+        assertThrows(DatabricksSQLException.class, () -> resultSet.getBatchUpdateCounts(1));
+    assertTrue(exception.getMessage().contains(AFFECTED_ROWS_COUNT));
+  }
+
+  @Test
   void testGetUpdateCountForClosedResultSet() throws SQLException {
     DatabricksResultSet resultSet = getResultSet(StatementState.SUCCEEDED, null);
     resultSet.close();
@@ -1633,5 +1713,32 @@ public class DatabricksResultSetTest {
 
     // getUpdateCount() must iterate all 5 rows despite maxRows=2
     assertEquals(5L, resultSet.getUpdateCount());
+  }
+
+  @Test
+  void testGetBatchUpdateCountsBypassesMaxRows() throws Exception {
+    InlineJsonResult mockExec = mock(InlineJsonResult.class);
+    when(mockExec.next()).thenReturn(true, false);
+    when(mockExec.getObject(0)).thenReturn(1L);
+    when(mockExec.getObject(1)).thenReturn(5L);
+
+    DatabricksResultSetMetaData mockMeta = mock(DatabricksResultSetMetaData.class);
+    when(mockMeta.getColumnType(1)).thenReturn(Types.BIGINT);
+    when(mockMeta.getColumnType(2)).thenReturn(Types.BIGINT);
+    when(mockMeta.getColumnNameIndex(AFFECTED_ROWS_COUNT)).thenReturn(1);
+    when(mockMeta.getColumnNameIndex("repeat")).thenReturn(2);
+    IDatabricksStatementInternal stmt = mock(IDatabricksStatementInternal.class);
+    when(stmt.getLargeMaxRows()).thenReturn(2L);
+    DatabricksResultSet resultSet =
+        new DatabricksResultSet(
+            new StatementStatus().setState(StatementState.SUCCEEDED),
+            STATEMENT_ID,
+            StatementType.UPDATE,
+            stmt,
+            mockExec,
+            mockMeta,
+            false);
+
+    assertArrayEquals(new long[] {1, 1, 1, 1, 1}, resultSet.getBatchUpdateCounts(5));
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -35,6 +36,7 @@ class PreparedStatementBatchExecutorTest {
   @Mock private DatabricksConnection connection;
   @Mock private IDatabricksConnectionContext connectionContext;
   @Mock private PreparedStatementBatchExecutor.StatementExecutor statementExecutor;
+  @Mock private PreparedStatementBatchExecutor.NativeBatchExecutor nativeBatchExecutor;
   @Mock private DatabricksResultSet firstResultSet;
   @Mock private DatabricksResultSet secondResultSet;
 
@@ -49,40 +51,76 @@ class PreparedStatementBatchExecutorTest {
   @Test
   void disabledBatchedInsertsExecuteEachParameterSetIndividually() throws Exception {
     setBatchedInsertsEnabled(false);
-    List<DatabricksParameterMetaData> batch = createBatch(2);
+    List<BatchParameterSet> batch = createBatch(2);
     when(statementExecutor.execute(eq(INSERT_SQL), anyMap(), eq(StatementType.UPDATE), eq(false)))
         .thenReturn(firstResultSet, secondResultSet);
     when(firstResultSet.getUpdateCount()).thenReturn(3L);
     when(secondResultSet.getUpdateCount()).thenReturn(5L);
 
-    long[] counts = newExecutor(INSERT_SQL, false).executeBatch(batch);
+    long[] counts = newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch);
 
     assertArrayEquals(new long[] {3, 5}, counts);
     verify(statementExecutor)
         .execute(INSERT_SQL, batch.get(0).getParameterBindings(), StatementType.UPDATE, false);
     verify(statementExecutor)
         .execute(INSERT_SQL, batch.get(1).getParameterBindings(), StatementType.UPDATE, false);
+    verify(nativeBatchExecutor, never()).isSupported();
   }
 
   @Test
   void ineligibleSqlFallsBackToIndividualExecution() throws Exception {
     setBatchedInsertsEnabled(true);
-    List<DatabricksParameterMetaData> batch = createBatch(1);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(1);
     when(statementExecutor.execute(eq(UPDATE_SQL), anyMap(), eq(StatementType.UPDATE), eq(false)))
         .thenReturn(firstResultSet);
     when(firstResultSet.getUpdateCount()).thenReturn(7L);
 
-    long[] counts = newExecutor(UPDATE_SQL, false).executeBatch(batch);
+    long[] counts = newExecutor(UPDATE_SQL, false, nativeBatchExecutor).executeBatch(batch);
 
     assertArrayEquals(new long[] {7}, counts);
     verify(statementExecutor)
         .execute(UPDATE_SQL, batch.get(0).getParameterBindings(), StatementType.UPDATE, false);
+    verify(nativeBatchExecutor, never()).isSupported();
+  }
+
+  @Test
+  void nativeBatchingHandsOrderedParameterSetsToNativeExecutor() throws Exception {
+    when(connection.getConnectionContext()).thenReturn(connectionContext);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(2);
+    when(nativeBatchExecutor.execute(INSERT_SQL, batch)).thenReturn(new long[] {2, 3});
+
+    long[] counts = newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch);
+
+    assertArrayEquals(new long[] {2, 3}, counts);
+    assertEquals(List.of(1, 2), indexes(batch.get(0)));
+    assertEquals(List.of(1, 2), indexes(batch.get(1)));
+    verify(nativeBatchExecutor).execute(INSERT_SQL, batch);
+    verifyNoInteractions(statementExecutor);
+  }
+
+  @Test
+  void unsupportedNativeExecutorFallsBackToLegacyExecution() throws Exception {
+    setBatchedInsertsEnabled(false);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(false);
+    List<BatchParameterSet> batch = createBatch(1);
+    when(statementExecutor.execute(eq(INSERT_SQL), anyMap(), eq(StatementType.UPDATE), eq(false)))
+        .thenReturn(firstResultSet);
+    when(firstResultSet.getUpdateCount()).thenReturn(6L);
+
+    long[] counts = newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch);
+
+    assertArrayEquals(new long[] {6}, counts);
+    verify(nativeBatchExecutor, never()).execute(anyString(), eq(batch));
   }
 
   @Test
   void eligibleInsertIsRewrittenWithFlattenedParameters() throws Exception {
     setBatchedInsertsEnabled(true);
-    List<DatabricksParameterMetaData> batch = createBatch(2);
+    List<BatchParameterSet> batch = createBatch(2);
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Map<Integer, ImmutableSqlParameter>> parametersCaptor =
@@ -180,18 +218,26 @@ class PreparedStatementBatchExecutorTest {
         sql, connection, interpolateParameters, statementExecutor);
   }
 
+  private PreparedStatementBatchExecutor newExecutor(
+      String sql,
+      boolean interpolateParameters,
+      PreparedStatementBatchExecutor.NativeBatchExecutor nativeExecutor) {
+    return new PreparedStatementBatchExecutor(
+        sql, connection, interpolateParameters, statementExecutor, nativeExecutor);
+  }
+
   private void setBatchedInsertsEnabled(boolean enabled) {
     when(connection.getConnectionContext()).thenReturn(connectionContext);
     when(connectionContext.isBatchedInsertsEnabled()).thenReturn(enabled);
   }
 
-  private List<DatabricksParameterMetaData> createBatch(int rowCount) {
-    List<DatabricksParameterMetaData> batch = new ArrayList<>();
+  private List<BatchParameterSet> createBatch(int rowCount) {
+    List<BatchParameterSet> batch = new ArrayList<>();
     for (int row = 1; row <= rowCount; row++) {
       DatabricksParameterMetaData parameterMetaData = new DatabricksParameterMetaData(INSERT_SQL);
       parameterMetaData.put(1, parameter(1, row, ColumnInfoTypeName.INT));
       parameterMetaData.put(2, parameter(2, "name-" + row, ColumnInfoTypeName.STRING));
-      batch.add(parameterMetaData);
+      batch.add(BatchParameterSet.from(parameterMetaData.getParameterBindings()));
     }
     return batch;
   }
@@ -208,5 +254,11 @@ class PreparedStatementBatchExecutorTest {
   private String multiRowInsert(int rows) {
     return "INSERT INTO target (`id`, `name`) VALUES "
         + String.join(", ", java.util.Collections.nCopies(rows, "(?, ?)"));
+  }
+
+  private List<Integer> indexes(BatchParameterSet parameterSet) {
+    return parameterSet.getParameters().stream()
+        .map(ImmutableSqlParameter::cardinal)
+        .collect(java.util.stream.Collectors.toList());
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
@@ -161,6 +161,27 @@ class PreparedStatementBatchExecutorTest {
   }
 
   @Test
+  void resultExtractionFailureThrowsDedicatedException() throws Exception {
+    when(connection.getConnectionContext()).thenReturn(connectionContext);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(2);
+    SQLException cause = new SQLException("Missing update-count column", "RESULT_SET_ERROR", 11);
+    when(nativeBatchExecutor.execute(INSERT_SQL, batch))
+        .thenThrow(new NativeBatchResultException(cause));
+
+    NativeBatchResultException exception =
+        assertThrows(
+            NativeBatchResultException.class,
+            () -> newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch));
+
+    assertEquals("RESULT_SET_ERROR", exception.getSQLState());
+    assertSame(cause, exception.getCause());
+    assertTrue(exception.getMessage().contains("Inserted rows may already be committed"));
+    verifyNoInteractions(statementExecutor);
+  }
+
+  @Test
   void unboundSqlStateWithoutCompatibilityMarkerDoesNotFallback() throws Exception {
     when(connection.getConnectionContext()).thenReturn(connectionContext);
     when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);

--- a/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/PreparedStatementBatchExecutorTest.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -69,8 +70,6 @@ class PreparedStatementBatchExecutorTest {
 
   @Test
   void ineligibleSqlFallsBackToIndividualExecution() throws Exception {
-    setBatchedInsertsEnabled(true);
-    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
     List<BatchParameterSet> batch = createBatch(1);
     when(statementExecutor.execute(eq(UPDATE_SQL), anyMap(), eq(StatementType.UPDATE), eq(false)))
         .thenReturn(firstResultSet);
@@ -115,6 +114,68 @@ class PreparedStatementBatchExecutorTest {
 
     assertArrayEquals(new long[] {6}, counts);
     verify(nativeBatchExecutor, never()).execute(anyString(), eq(batch));
+  }
+
+  @Test
+  void unboundParameterCompatibilityErrorFallsBackToLegacyExecution() throws Exception {
+    setBatchedInsertsEnabled(false);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(1);
+    when(nativeBatchExecutor.execute(INSERT_SQL, batch))
+        .thenThrow(
+            new SQLException("[UNBOUND_SQL_PARAMETER] Native batching is unsupported", "42P02", 0));
+    when(statementExecutor.execute(eq(INSERT_SQL), anyMap(), eq(StatementType.UPDATE), eq(false)))
+        .thenReturn(firstResultSet);
+    when(firstResultSet.getUpdateCount()).thenReturn(4L);
+
+    long[] counts = newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch);
+
+    assertArrayEquals(new long[] {4}, counts);
+    verify(statementExecutor)
+        .execute(INSERT_SQL, batch.get(0).getParameterBindings(), StatementType.UPDATE, false);
+  }
+
+  @Test
+  void nonCompatibilityNativeErrorDoesNotFallback() throws Exception {
+    when(connection.getConnectionContext()).thenReturn(connectionContext);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(2);
+    SQLException cause =
+        new SQLException("[PARAMETER_BATCH_ERROR] Too many parameters", "22023", 7);
+    when(nativeBatchExecutor.execute(INSERT_SQL, batch)).thenThrow(cause);
+
+    DatabricksBatchUpdateException exception =
+        assertThrows(
+            DatabricksBatchUpdateException.class,
+            () -> newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch));
+
+    assertEquals("22023", exception.getSQLState());
+    assertEquals(7, exception.getErrorCode());
+    assertSame(cause, exception.getCause());
+    assertArrayEquals(
+        new long[] {Statement.EXECUTE_FAILED, Statement.EXECUTE_FAILED},
+        exception.getLargeUpdateCounts());
+    verifyNoInteractions(statementExecutor);
+  }
+
+  @Test
+  void unboundSqlStateWithoutCompatibilityMarkerDoesNotFallback() throws Exception {
+    when(connection.getConnectionContext()).thenReturn(connectionContext);
+    when(connectionContext.isNativeBatchingEnabled()).thenReturn(true);
+    when(nativeBatchExecutor.isSupported()).thenReturn(true);
+    List<BatchParameterSet> batch = createBatch(1);
+    SQLException cause = new SQLException("A different unbound parameter error", "42P02", 3);
+    when(nativeBatchExecutor.execute(INSERT_SQL, batch)).thenThrow(cause);
+
+    DatabricksBatchUpdateException exception =
+        assertThrows(
+            DatabricksBatchUpdateException.class,
+            () -> newExecutor(INSERT_SQL, false, nativeBatchExecutor).executeBatch(batch));
+
+    assertSame(cause, exception.getCause());
+    verifyNoInteractions(statementExecutor);
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/common/util/ProtocolFeatureUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/ProtocolFeatureUtilTest.java
@@ -34,6 +34,8 @@ public class ProtocolFeatureUtilTest {
   private static final TProtocolVersion MIN_VERSION_PARAMETERIZED = SPARK_CLI_SERVICE_PROTOCOL_V8;
   private static final TProtocolVersion MIN_VERSION_ASYNC_OPERATIONS =
       SPARK_CLI_SERVICE_PROTOCOL_V9;
+  private static final TProtocolVersion MIN_VERSION_NATIVE_PARAMETER_BATCHING =
+      SPARK_CLI_SERVICE_PROTOCOL_V10;
 
   private static Stream<Arguments> protocolVersionProvider() {
     return Stream.of(
@@ -151,6 +153,14 @@ public class ProtocolFeatureUtilTest {
   public void testSupportsAsyncMetadataOperations(TProtocolVersion version) {
     boolean expected = version.compareTo(MIN_VERSION_ASYNC_OPERATIONS) >= 0;
     boolean actual = ProtocolFeatureUtil.supportsAsyncMetadataOperations(version);
+    assertEquals(expected, actual);
+  }
+
+  @ParameterizedTest
+  @MethodSource("protocolVersionProvider")
+  public void testSupportsNativeParameterBatching(TProtocolVersion version) {
+    boolean expected = version.compareTo(MIN_VERSION_NATIVE_PARAMETER_BATCHING) >= 0;
+    boolean actual = ProtocolFeatureUtil.supportsNativeParameterBatching(version);
     assertEquals(expected, actual);
   }
 

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
@@ -15,11 +15,13 @@ import static org.mockito.Mockito.when;
 
 import com.databricks.jdbc.api.impl.*;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.AllPurposeCluster;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.common.MetadataOperationType;
 import com.databricks.jdbc.common.StatementType;
 import com.databricks.jdbc.common.Warehouse;
 import com.databricks.jdbc.common.util.DatabricksTypeUtil;
+import com.databricks.jdbc.common.util.JsonUtil;
 import com.databricks.jdbc.dbclient.impl.common.ConfiguratorUtilsTest;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.exception.DatabricksSQLException;
@@ -38,6 +40,7 @@ import com.databricks.sdk.core.ApiClient;
 import com.databricks.sdk.core.DatabricksError;
 import com.databricks.sdk.core.http.Request;
 import com.databricks.sdk.service.sql.*;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -228,6 +231,73 @@ public class DatabricksSdkClientTest {
   }
 
   @Test
+  public void testNativeBatchCapabilityIsWarehouseOnly() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+
+    assertTrue(databricksSdkClient.supportsNativeParameterBatching(warehouse));
+    assertFalse(
+        databricksSdkClient.supportsNativeParameterBatching(
+            new AllPurposeCluster("org", "cluster")));
+  }
+
+  @Test
+  public void testExecuteStatementBatchBuildsSeaParameterSets() throws Exception {
+    setupClientMocks(true, false);
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+    DatabricksConnection connection =
+        new DatabricksConnection(connectionContext, databricksSdkClient);
+    connection.open();
+    DatabricksStatement statement = new DatabricksStatement(connection);
+    statement.setMaxRows(100);
+    List<BatchParameterSet> parameterSets =
+        List.of(
+            BatchParameterSet.from(
+                Map.of(
+                    1,
+                    getSqlParam(1, 1, DatabricksTypeUtil.INT),
+                    2,
+                    getSqlParam(2, "first", DatabricksTypeUtil.STRING))),
+            BatchParameterSet.from(
+                Map.of(
+                    1,
+                    getSqlParam(1, 2, DatabricksTypeUtil.INT),
+                    2,
+                    getSqlParam(2, "second", DatabricksTypeUtil.STRING))));
+
+    databricksSdkClient.executeStatementBatch(
+        "INSERT INTO target VALUES (?, ?)",
+        warehouse,
+        parameterSets,
+        StatementType.UPDATE,
+        connection.getSession(),
+        statement);
+
+    ArgumentCaptor<ExecuteStatementRequest> captor =
+        ArgumentCaptor.forClass(ExecuteStatementRequest.class);
+    verify(apiClient, atLeastOnce()).serialize(captor.capture());
+    ExecuteStatementRequest request = captor.getValue();
+    assertNull(request.getParameters());
+    assertNull(request.getRowLimit());
+    assertEquals(2, request.getParameterSets().size());
+    List<StatementParameterSet> capturedSets = new ArrayList<>(request.getParameterSets());
+    List<StatementParameterListItem> firstSet =
+        new ArrayList<>(capturedSets.get(0).getParameters());
+    assertEquals(0, ((PositionalStatementParameterListItem) firstSet.get(0)).getOrdinal());
+    assertEquals(1, ((PositionalStatementParameterListItem) firstSet.get(1)).getOrdinal());
+    assertEquals("first", firstSet.get(1).getValue());
+    JsonNode requestJson = JsonUtil.getMapper().valueToTree(request);
+    assertTrue(requestJson.has("parameter_sets"));
+    assertTrue(requestJson.get("parameters").isNull());
+    assertTrue(requestJson.get("row_limit").isNull());
+  }
+
+  @Test
   public void testExecuteStatementAsync() throws Exception {
     setupClientMocks(false, true);
     IDatabricksConnectionContext connectionContext =
@@ -338,6 +408,36 @@ public class DatabricksSdkClientTest {
 
     assertNotEquals("HY008", exception.getSQLState());
     assertTrue(exception.getMessage().contains("execution failed"));
+  }
+
+  @Test
+  public void testHandleFailedExecutionPreservesUnboundParameterFallbackSignal() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+    StatementStatus failedStatus =
+        new StatementStatus()
+            .setState(StatementState.FAILED)
+            .setSqlState("42P02")
+            .setError(
+                new ServiceError()
+                    .setMessage("[UNBOUND_SQL_PARAMETER] Found an unbound parameter")
+                    .setErrorCode(ServiceErrorCode.BAD_REQUEST));
+    ExecuteStatementResponse response =
+        new ExecuteStatementResponse()
+            .setStatementId(STATEMENT_ID.toSQLExecStatementId())
+            .setStatus(failedStatus);
+
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () ->
+                databricksSdkClient.handleFailedExecution(
+                    response, STATEMENT_ID.toSQLExecStatementId(), STATEMENT));
+
+    assertEquals("42P02", exception.getSQLState());
+    assertTrue(exception.getMessage().contains("[UNBOUND_SQL_PARAMETER]"));
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/thrift/DatabricksThriftServiceClientTest.java
@@ -158,6 +158,85 @@ public class DatabricksThriftServiceClientTest {
     assertDoesNotThrow(() -> client.deleteSession(SESSION_INFO));
   }
 
+  @Test
+  void testNativeBatchCapabilityUsesProtocolOnlyForAllPurposeClusters() {
+    DatabricksThriftServiceClient client =
+        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
+
+    client.setServerProtocolVersion(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9);
+    assertFalse(client.supportsNativeParameterBatching(CLUSTER_COMPUTE));
+    assertTrue(client.supportsNativeParameterBatching(WAREHOUSE_COMPUTE));
+
+    client.setServerProtocolVersion(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V10);
+    assertTrue(client.supportsNativeParameterBatching(CLUSTER_COMPUTE));
+    assertTrue(client.supportsNativeParameterBatching(WAREHOUSE_COMPUTE));
+  }
+
+  @Test
+  void testExecuteStatementBatchBuildsNativeThriftRequest() throws SQLException {
+    when(connectionContext.shouldEnableArrow()).thenReturn(true);
+    lenient().when(connectionContext.isCloudFetchEnabled()).thenReturn(true);
+    when(session.getSessionInfo()).thenReturn(SESSION_INFO);
+    when(parentStatement.getStatement()).thenReturn(statement);
+    when(parentStatement.getMaxRows()).thenReturn(10);
+    when(statement.getQueryTimeout()).thenReturn(15);
+    DatabricksThriftServiceClient client =
+        new DatabricksThriftServiceClient(thriftAccessor, connectionContext);
+    client.setServerProtocolVersion(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9);
+    List<BatchParameterSet> parameterSets =
+        List.of(
+            BatchParameterSet.from(
+                Map.of(
+                    1,
+                    ImmutableSqlParameter.builder().cardinal(1).type(INT).value(1).build(),
+                    2,
+                    ImmutableSqlParameter.builder()
+                        .cardinal(2)
+                        .type(STRING)
+                        .value("first")
+                        .build())),
+            BatchParameterSet.from(
+                Map.of(
+                    1,
+                    ImmutableSqlParameter.builder().cardinal(1).type(INT).value(2).build(),
+                    2,
+                    ImmutableSqlParameter.builder()
+                        .cardinal(2)
+                        .type(STRING)
+                        .value("second")
+                        .build())));
+    when(thriftAccessor.execute(
+            any(TExecuteStatementReq.class),
+            eq(parentStatement),
+            eq(session),
+            eq(StatementType.UPDATE)))
+        .thenReturn(resultSet);
+
+    DatabricksResultSet actual =
+        client.executeStatementBatch(
+            "INSERT INTO target VALUES (?, ?)",
+            WAREHOUSE_COMPUTE,
+            parameterSets,
+            StatementType.UPDATE,
+            session,
+            parentStatement);
+
+    assertSame(resultSet, actual);
+    ArgumentCaptor<TExecuteStatementReq> requestCaptor =
+        ArgumentCaptor.forClass(TExecuteStatementReq.class);
+    verify(thriftAccessor)
+        .execute(
+            requestCaptor.capture(), eq(parentStatement), eq(session), eq(StatementType.UPDATE));
+    TExecuteStatementReq request = requestCaptor.getValue();
+    assertFalse(request.isSetParameters());
+    assertFalse(request.isSetResultRowLimit());
+    assertEquals(2, request.getBatchParametersSize());
+    assertEquals(0, request.getBatchParameters().get(0).get(0).getOrdinal());
+    assertEquals(1, request.getBatchParameters().get(0).get(1).getOrdinal());
+    assertEquals("first", request.getBatchParameters().get(0).get(1).getValue().getStringValue());
+    assertEquals("second", request.getBatchParameters().get(1).get(1).getValue().getStringValue());
+  }
+
   private static Stream<Arguments> protocolVersionProvider() {
     return Stream.of(
         Arguments.of(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V1),


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-jdbc/pull/1632/files/b88cd288f12efdd3126506dc37a443dfea7c1842..07f31353e7ff8c94a644c74a4ace3d970dd63bac) to review incremental changes.
- [stack/native-batch-legacy-seam](https://github.com/databricks/databricks-jdbc/pull/1620) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1620/files)] [MERGED]
  - [stack/native-batch-foundation](https://github.com/databricks/databricks-jdbc/pull/1621) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1621/files)] [MERGED]
    - [stack/native-batch-routing](https://github.com/databricks/databricks-jdbc/pull/1623) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1623/files)]
      - [stack/native-batch-thrift](https://github.com/databricks/databricks-jdbc/pull/1625) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1625/files/597237e946403890862ba875b54121b489cfec12..b88cd288f12efdd3126506dc37a443dfea7c1842)]
        - [**stack/native-batch-sea**](https://github.com/databricks/databricks-jdbc/pull/1632) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1632/files/b88cd288f12efdd3126506dc37a443dfea7c1842..07f31353e7ff8c94a644c74a4ace3d970dd63bac)] ← _this PR_
          - [stack/native-batch-integration-tests](https://github.com/databricks/databricks-jdbc/pull/1633) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1633/files/07f31353e7ff8c94a644c74a4ace3d970dd63bac..2d0f4da302b183f15de9804af1c12346b5531bf4)]
            - [stack/native-batch-activation](https://github.com/databricks/databricks-jdbc/pull/1634) [[Files changed](https://github.com/databricks/databricks-jdbc/pull/1634/files/2d0f4da302b183f15de9804af1c12346b5531bf4..f4e3ff24e5d54451eec9603e429fce7549f291b8)]

---------
## Description

Add opt-in native `PreparedStatement` batch execution through the Statement Execution API.

- Add the driver-owned `StatementParameterSet` request model.
- Serialize ordered parameter sets as `parameter_sets` with zero-based ordinals.
- Ensure singular `parameters` and batch `parameter_sets` are mutually exclusive.
- Omit `row_limit` so update-count results are not truncated.
- Reuse the existing SEA submission, polling, timeout, cancellation, and result lifecycle.
- Reuse shared native routing, `42P02` fallback, repeat-count expansion, and result-error handling.

Native batching remains disabled by default through `EnableNativeBatching=0`.

## Testing

- Full `DatabricksSdkClientTest`: 49 passed.
- Targeted SEA request, capability, and fallback tests passed.
- Live serverless SEA native insertion passed with update-count and table-row verification.
- Live DBR 18.1 SEA compatibility fallback passed; verified one native attempt followed by three individual legacy executions.
- Temporary test tables were removed.
- Isaac review completed; the sole ordinal concern was invalidated by the zero-based backend contract and successful live native execution.

## Additional Notes to the Reviewer

The existing singular SEA path retains its current behavior. Zero-based ordinal conversion is applied only while constructing native `parameter_sets`.

NO_CHANGELOG=true