### PR TITLE
feat(learning): add daily engineer-bot retrospective flow + bump engine to 654a31d0

### DIFF
--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -86,6 +86,11 @@ author:
     issue_url: ISSUE_URL
   context_files:
     - issue_body.txt   # {{issue_body}}
+  # Close the loop: the author phase reads this log back so fixes benefit from
+  # what the retrospective has learned. MUST match `retrospective.log_path` below
+  # — the retrospective WRITES that path; the author only READS it if the two
+  # agree. (Set together, they connect learning → application.)
+  knowledge_log: .claude/knowledge/learning-log.md
 
 # Engine orchestration for the author phase. `bug-fix` runs the plan →
 # author_tests → fix pipeline (write a failing test → fix the code → re-run to
@@ -94,3 +99,18 @@ author:
 # testing specifics (commands, layout, live e2e requirement, spotless) live in
 # prompts/engineer/system.md, not here.
 flow: bug-fix
+
+# Daily learning extraction (retrospective flow). Run by engineer-bot-learning.yml
+# via `python -m databricks_bot_engine.engineer_bot.retrospective`: over an adaptive
+# look-back window it sweeps every merged PR (diff + review comments, which the
+# engine gathers ITSELF per PR) plus engineer-bot author runs, and if the model
+# finds a durable, reusable learning, opens/updates a single rolling PR appending a
+# dated section to log_path. Human-gated — never commits the canonical log directly.
+# Omitting this block makes the retrospective a no-op. The system prompt is the
+# engine's built-in base; prompts/retrospective_system.md (present in this repo) is
+# appended as additive guidance.
+retrospective:
+  system_prompt: prompts/retrospective_system.md
+  log_path: .claude/knowledge/learning-log.md   # MUST match author.knowledge_log above
+  branch_prefix: ai/learning-pr-
+  pr_label: engineer-bot-learning

--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -112,7 +112,8 @@ flow: bug-fix
 # prompts/retrospective_system.md, so the engine's built-in base prompt is used.
 # (A set-but-missing system_prompt file would be a hard error; an UNSET key uses
 # the base. Add the key later only if you write a repo-specific additive prompt.)
-# The learning log is created on first write — no seed file needed.
+# An initial learning log is seeded at log_path so the author.knowledge_log read
+# path is a real file from day one; the retrospective appends dated sections to it.
 retrospective:
   log_path: .claude/knowledge/learning-log.md   # MUST match author.knowledge_log above
   branch_prefix: ai/learning-pr-

--- a/.bot/config.yaml
+++ b/.bot/config.yaml
@@ -106,11 +106,14 @@ flow: bug-fix
 # engine gathers ITSELF per PR) plus engineer-bot author runs, and if the model
 # finds a durable, reusable learning, opens/updates a single rolling PR appending a
 # dated section to log_path. Human-gated — never commits the canonical log directly.
-# Omitting this block makes the retrospective a no-op. The system prompt is the
-# engine's built-in base; prompts/retrospective_system.md (present in this repo) is
-# appended as additive guidance.
+# Omitting this block makes the retrospective a no-op.
+#
+# `system_prompt` is intentionally OMITTED: this repo ships no
+# prompts/retrospective_system.md, so the engine's built-in base prompt is used.
+# (A set-but-missing system_prompt file would be a hard error; an UNSET key uses
+# the base. Add the key later only if you write a repo-specific additive prompt.)
+# The learning log is created on first write — no seed file needed.
 retrospective:
-  system_prompt: prompts/retrospective_system.md
   log_path: .claude/knowledge/learning-log.md   # MUST match author.knowledge_log above
   branch_prefix: ai/learning-pr-
   pr_label: engineer-bot-learning

--- a/.claude/knowledge/learning-log.md
+++ b/.claude/knowledge/learning-log.md
@@ -1,0 +1,12 @@
+# Engineer-bot learning log
+
+This file is the canonical, human-gated knowledge log shared by two consumers
+configured in `.bot/config.yaml`:
+
+- `retrospective.log_path` — the retrospective flow APPENDS a dated section here
+  when it extracts a durable, reusable learning (via a human-gated rolling PR).
+- `author.knowledge_log` — the author phase READS this file so fixes benefit from
+  what has been learned. Seeded here so the read path is never a missing file.
+
+No learnings have been recorded yet. Dated sections are appended below by the
+retrospective flow.

--- a/.github/actions/bot-prelude/action.yml
+++ b/.github/actions/bot-prelude/action.yml
@@ -30,7 +30,7 @@ inputs:
     # value to move every bot to a new engine commit; never @main.
     description: 'Engine commit SHA (full 40-char) to install.'
     required: false
-    default: 'd05dcb113332401b4aee8d6aa05c7107399ad44f'
+    default: '654a31d0d26d2b77bcb58e84f1e4abe018f9fd5a'
   engine-repo:
     description: 'owner/name of the engine repo.'
     required: false

--- a/.github/workflows/engineer-bot-learning.yml
+++ b/.github/workflows/engineer-bot-learning.yml
@@ -100,11 +100,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.prelude.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          # Only the `<workspace>/serving-endpoints/` prefix matters:
-          # sdk_agent.translate_endpoint rewrites this to `.../serving-endpoints/anthropic`
-          # and discards the model path segment. The effective model comes from
-          # .bot/config.yaml `retrospective.model` (or the engine default).
-          MODEL_ENDPOINT: https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/anthropic/invocations
+          # Use the concrete `.../serving-endpoints/<model>/invocations` form (same
+          # as reviewer-bot.yml / engineer-bot.yml). sdk_agent.translate_endpoint
+          # strips it to the `.../serving-endpoints/anthropic` base the CLI needs.
+          # Do NOT use `.../serving-endpoints/anthropic/invocations` here: that hits
+          # translate_endpoint's already-v2 early-return, which keeps the trailing
+          # `invocations`, so the CLI appends `/v1/messages` →
+          # `.../anthropic/invocations/v1/messages` → HTTP 400 (unsupported path).
+          # The effective model is set by the engine default (no retrospective.model).
+          MODEL_ENDPOINT: https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           RUNNER_TEMP: ${{ runner.temp }}
           SINCE: ${{ inputs.since }}

--- a/.github/workflows/engineer-bot-learning.yml
+++ b/.github/workflows/engineer-bot-learning.yml
@@ -7,6 +7,14 @@
 # (`ai/learning-pr`), appending a dated section per day until a human merges it.
 # Human-gated by design: it NEVER commits the canonical log directly.
 #
+# That stable branch is DERIVED from .bot/config.yaml `retrospective.branch_prefix`
+# (`ai/learning-pr-`, trailing separator): the engine's `stable_branch()` strips
+# the trailing `-/ ` so the prefix collapses to the single date-less branch
+# `ai/learning-pr`. It is intentionally date-LESS — at most one open learning PR
+# ever exists; there is no per-run suffix and no branch-per-run churn. The config
+# keeps the `-` suffix to match the reference (sql-python); the two are NOT in
+# conflict — prefix in config, derived branch here.
+#
 # Own job (NOT `uses: databricks/databricks-bot-engine/...`): an external repo
 # can't resolve the internal engine's reusable workflows ("not found"). It shares
 # the SAME prelude the other bots use — ./.github/actions/bot-prelude (tokens +

--- a/.github/workflows/engineer-bot-learning.yml
+++ b/.github/workflows/engineer-bot-learning.yml
@@ -1,0 +1,123 @@
+# Engineer Bot — learning (retrospective) extraction — DAILY CRON.
+#
+# Over an adaptive look-back window the engine gathers merged PRs (diff + review
+# comments) AND recent engineer-bot author-run console logs ITSELF via the GitHub
+# API — no in-workflow context gathering, no per-PR trigger — and if the model
+# finds durable, reusable learnings, opens ONE ROLLING PR on a stable branch
+# (`ai/learning-pr`), appending a dated section per day until a human merges it.
+# Human-gated by design: it NEVER commits the canonical log directly.
+#
+# Own job (NOT `uses: databricks/databricks-bot-engine/...`): an external repo
+# can't resolve the internal engine's reusable workflows ("not found"). It shares
+# the SAME prelude the other bots use — ./.github/actions/bot-prelude (tokens +
+# Node + pinned engine install) — so the engine pin stays single-sourced in
+# bot-prelude's `engine-ref` default (no second SHA to drift).
+#
+# Opt-in is purely via the `retrospective:` block in .bot/config.yaml + this
+# workflow; absent that block the engine phase is a clean no-op.
+name: Engineer Bot — Learning
+
+on:
+  schedule:
+    # 17:23 UTC daily — off-peak, off-:00 minute (GitHub delays/drops on-the-hour crons).
+    - cron: "23 17 * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'ISO lower bound to shorten the window and recover a wedged flow. Empty = adaptive cursor.'
+        type: string
+        default: ''
+      window-hours:
+        # STRING, not number: a `type: number` workflow_dispatch input fails the
+        # whole run at startup ("workflow file issue") when combined with the
+        # `schedule` trigger. argparse coerces it to int downstream.
+        description: 'Fallback look-back window (hours) used only when there is no prior successful run.'
+        type: string
+        default: '24'
+
+permissions:
+  contents: write        # push the learning branch / open the learning PR
+  pull-requests: write
+  actions: read          # Track B lists engineer-bot author runs + logs via the App token;
+                         # the engineer-bot App installation must ALSO carry actions:read
+                         # (a missing scope surfaces as a 403 that fails the whole run —
+                         # list_author_runs raises, no escape hatch).
+  id-token: write        # JFrog OIDC exchange for the engine/SDK/CLI install
+
+concurrency:
+  # One learning run at a time; a queued run waits rather than racing the rolling
+  # PR's branch. Not keyed on a PR number (this is a cron, no PR event).
+  group: engineer-bot-learning-cron
+  cancel-in-progress: false
+
+jobs:
+  learning:
+    environment: azure-prod   # DATABRICKS_HOST / DATABRICKS_TOKEN live here
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Checkout the default branch (the learning PR is cut from it) FIRST, so the
+      # local `./` composites below resolve. persist-credentials:false — the
+      # retrospective sets its own authenticated push remote (see the run step),
+      # so no token is left in .git/config.
+      - name: Checkout default branch (learning PR is cut from it)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # No separate `setup-jfrog` step. install-bot-engine (via bot-prelude) does
+      # its own keyless OIDC→JFrog mint and passes the credential through job-local
+      # files + per-command --index-url flags; it never reads PIP_INDEX_URL /
+      # JFROG_ACCESS_TOKEN from the environment. A preceding setup-jfrog would be
+      # redundant (the engine install is the only fetch — the learning flow runs no
+      # `mvn` build) AND harmful: setup-jfrog exports a token-bearing PIP_INDEX_URL
+      # to $GITHUB_ENV, exposing it to every later step including the model run.
+      # Mirrors the read-only sibling reviewer-bot.yml.
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+
+      # Shared prelude: mint the engineer-bot token (opens the learning PR) + the
+      # engine-scoped token, set up Node, install the pinned engine (PAT-free). The
+      # engine pin comes from bot-prelude's `engine-ref` default — the SINGLE source
+      # of truth for every bot; there is no second SHA in this file to drift.
+      - name: Bot prelude (tokens + Node + engine install)
+        id: prelude
+        uses: ./.github/actions/bot-prelude
+        with:
+          app-id: ${{ secrets.ENGINEER_BOT_APP_ID }}
+          private-key: ${{ secrets.ENGINEER_BOT_APP_PRIVATE_KEY }}
+
+      # NOTE: no git-identity step — the engine's retrospective configures the git
+      # user AND DCO sign-off itself from .bot/config.yaml `bot_login_prefix`.
+      # NOTE: no context-gather step — the daily-cron engine enumerates merged PRs
+      # + author runs itself over the adaptive window.
+      - name: Extract learnings + open rolling PR
+        env:
+          GH_TOKEN: ${{ steps.prelude.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Only the `<workspace>/serving-endpoints/` prefix matters:
+          # sdk_agent.translate_endpoint rewrites this to `.../serving-endpoints/anthropic`
+          # and discards the model path segment. The effective model comes from
+          # .bot/config.yaml `retrospective.model` (or the engine default).
+          MODEL_ENDPOINT: https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/anthropic/invocations
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          SINCE: ${{ inputs.since }}
+          WINDOW_HOURS: ${{ inputs.window-hours }}
+        # The retrospective pushes the learning branch with a plain `git push
+        # origin`, and the checkout ran persist-credentials:false — so set an
+        # authenticated push remote from the minted App token first, mirroring
+        # engineer-bot.yml's publish step. --since / --window-hours are passed only
+        # when provided via workflow_dispatch (the schedule trigger leaves them
+        # empty → the adaptive cursor drives the window).
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          args=(--repo-dir "$GITHUB_WORKSPACE")
+          [ -n "$SINCE" ] && args+=(--since "$SINCE")
+          [ -n "$WINDOW_HOURS" ] && args+=(--window-hours "$WINDOW_HOURS")
+          python -m databricks_bot_engine.engineer_bot.retrospective "${args[@]}"


### PR DESCRIPTION
## What

Turn on the engineer-bot **daily learning (retrospective)** loop for this repo, mirroring `databricks-sql-python` (the reference implementation). Three changes:

| File | Change |
|---|---|
| `.github/workflows/engineer-bot-learning.yml` *(new)* | Daily `schedule` (17:23 UTC) + `workflow_dispatch`. Own job on `./.github/actions/bot-prelude` (Python + pinned engine install, PAT-free). |
| `.bot/config.yaml` | Add the `retrospective:` block + close the loop with `author.knowledge_log`. |
| `.github/actions/bot-prelude/action.yml` | Bump `engine-ref` `d05dcb11` → `654a31d0`. |

## Why

The other bots (reviewer, engineer, followups) were onboarded earlier; the retrospective was deliberately deferred. This adds it. Over an adaptive look-back window the engine gathers merged PRs + engineer-bot author-run logs itself and, if it finds durable learnings, opens **one rolling PR** (`ai/learning-pr`) appending a dated section to `.claude/knowledge/learning-log.md` — human-gated, never committing the canonical log directly.

## Notes on the wiring

- **No `setup-jfrog` step** — this repo's `install-bot-engine` self-mints its pip credential via OIDC and never reads `PIP_INDEX_URL` from env, so a setup-jfrog step would be redundant (the engine install is the only fetch — the learning flow runs no `mvn` build) *and* would leak a token-bearing `PIP_INDEX_URL` to the job env. Mirrors the read-only reviewer-bot.yml.
- **`actions: read`** added for Track B (lists engineer-bot author runs + downloads their logs via the App token). The engineer-bot App installation must also carry `actions:read`, or the run 403s.
- **Close the loop:** `author.knowledge_log` == `retrospective.log_path` (`.claude/knowledge/learning-log.md`). — the retrospective writes it, the author reads it back. `system_prompt` is omitted (this repo ships no `prompts/retrospective_system.md`, so the engine's base prompt is used); the learning log is created on first write.
- **Pin bump** is SHA-only — SDK/CLI (`0.2.102` / `2.1.61`) unchanged at `654a31d0`. Brings the daily-cron retrospective + per-bot models.
- The learning flow runs no `mvn` build, so spotless does not apply to it.

## Validation

The `schedule` registers only once this lands on the default branch. Before the first cron, validate via a manual **workflow_dispatch** with a recent `since` — it should open/update the `ai/learning-pr` PR.

This pull request and its description were written by Isaac.



NO_CHANGELOG=true

