### PR TITLE
Add FAST session version exchange to SEA client

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added FAST explicit-session mode and session-version exchange for SQL Exec API connections.
 
 ### Updated
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksResultSet.java
@@ -429,6 +429,8 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
       // connection is GC'd without close(), heartbeat RPCs will fail and self-stop after
       // maxConsecutiveFailures (10 ticks, ~10 min at 60s interval). Acceptable tradeoff.
       final IDatabricksClient client = conn.getSession().getDatabricksClient();
+      final IDatabricksSession capturedSession =
+          parentStatement.shouldTrackSessionVersion() ? conn.getSession() : null;
       final StatementId capturedStatementId = this.statementId;
       final int maxConsecutiveFailures = 10;
       final java.util.concurrent.atomic.AtomicInteger consecutiveFailures =
@@ -449,7 +451,7 @@ public class DatabricksResultSet implements IDatabricksResultSet, IDatabricksRes
               return; // client/session may be closed, skip RPC
             }
             try {
-              boolean alive = client.checkStatementAlive(capturedStatementId);
+              boolean alive = client.checkStatementAlive(capturedStatementId, capturedSession);
               consecutiveFailures.set(0); // reset on success
               if (!alive) {
                 LOGGER.info(

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
@@ -21,6 +21,7 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksTemporaryRedirectException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.jdbc.telemetry.TelemetryHelper;
 import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimedProcessor;
@@ -29,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -43,6 +45,7 @@ public class DatabricksSession implements IDatabricksSession {
   private final IDatabricksComputeResource computeResource;
   private boolean isSessionOpen;
   private ImmutableSessionInfo sessionInfo;
+  private final AtomicReference<Long> sessionVersion = new AtomicReference<>();
 
   /** For context based commands */
   private String catalog;
@@ -109,6 +112,37 @@ public class DatabricksSession implements IDatabricksSession {
   public ImmutableSessionInfo getSessionInfo() {
     LOGGER.debug("public String getSessionInfo()");
     return sessionInfo;
+  }
+
+  @Nullable
+  @Override
+  public SessionVersion getSessionVersion() {
+    Long versionId = sessionVersion.get();
+    return versionId == null ? null : new SessionVersion().setVersionId(versionId);
+  }
+
+  @Override
+  public void updateSessionVersion(
+      @Nullable String expectedSessionId, @Nullable SessionVersion newSessionVersion) {
+    if (expectedSessionId == null
+        || newSessionVersion == null
+        || newSessionVersion.getVersionId() == null) {
+      return;
+    }
+    synchronized (this) {
+      if (!isSessionOpen
+          || sessionInfo == null
+          || !expectedSessionId.equals(sessionInfo.sessionId())) {
+        return;
+      }
+      Long newVersionId = newSessionVersion.getVersionId();
+      sessionVersion.accumulateAndGet(
+          newVersionId,
+          (currentVersion, candidateVersion) ->
+              currentVersion == null || candidateVersion > currentVersion
+                  ? candidateVersion
+                  : currentVersion);
+    }
   }
 
   @Override
@@ -217,6 +251,7 @@ public class DatabricksSession implements IDatabricksSession {
             throw e;
           }
         }
+        this.sessionVersion.set(sessionInfo == null ? null : sessionInfo.sessionVersion());
         this.isSessionOpen = true;
       }
     }
@@ -240,6 +275,7 @@ public class DatabricksSession implements IDatabricksSession {
         } finally {
           // Always clean up local state
           this.sessionInfo = null;
+          this.sessionVersion.set(null);
           this.isSessionOpen = false;
         }
       }
@@ -406,6 +442,7 @@ public class DatabricksSession implements IDatabricksSession {
     } catch (SQLException e) {
       LOGGER.error("Error closing session resources, but marking the session as closed.");
     } finally {
+      this.sessionVersion.set(null);
       this.isSessionOpen = false;
     }
   }

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksStatement.java
@@ -44,6 +44,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
   protected final DatabricksConnection connection;
   DatabricksResultSet resultSet;
   private volatile StatementId statementId; // volatile: cancel() reads from a different thread
+  private boolean trackSessionVersion;
   private boolean isClosed;
   private boolean closeOnCompletion;
   private SQLWarning warnings = null;
@@ -69,6 +70,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
     this.connection = connection;
     this.resultSet = null;
     this.statementId = null;
+    this.trackSessionVersion = true;
     this.isClosed = false;
     this.timeoutInSeconds = DEFAULT_STATEMENT_TIMEOUT_SECONDS;
     this.databricksBatchExecutor =
@@ -79,6 +81,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
       throws DatabricksValidationException {
     this.connection = connection;
     this.statementId = statementId;
+    this.trackSessionVersion = false;
     this.resultSet = null;
     this.isClosed = false;
     this.timeoutInSeconds = DEFAULT_STATEMENT_TIMEOUT_SECONDS;
@@ -646,6 +649,7 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
   public void setStatementId(StatementId statementId) {
     LOGGER.debug("void setStatementId(Statement statementId = {})", statementId);
     this.statementId = statementId;
+    this.trackSessionVersion = true;
   }
 
   @Override
@@ -656,6 +660,11 @@ public class DatabricksStatement implements IDatabricksStatement, IDatabricksSta
   @Override
   public Statement getStatement() {
     return this;
+  }
+
+  @Override
+  public boolean shouldTrackSessionVersion() {
+    return trackSessionVersion;
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/SessionInfo.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/SessionInfo.java
@@ -13,5 +13,8 @@ public interface SessionInfo {
   IDatabricksComputeResource computeResource();
 
   @Nullable
+  Long sessionVersion();
+
+  @Nullable
   TSessionHandle sessionHandle(); // This field is set only for all-purpose cluster compute
 }

--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksSession.java
@@ -6,6 +6,7 @@ import com.databricks.jdbc.common.IDatabricksComputeResource;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
 import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
 import com.databricks.jdbc.exception.DatabricksSQLException;
+import com.databricks.jdbc.model.core.SessionVersion;
 import java.sql.SQLException;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -23,6 +24,12 @@ public interface IDatabricksSession {
 
   @Nullable
   ImmutableSessionInfo getSessionInfo();
+
+  @Nullable
+  SessionVersion getSessionVersion();
+
+  void updateSessionVersion(
+      @Nullable String expectedSessionId, @Nullable SessionVersion sessionVersion);
 
   /**
    * Get the warehouse associated with the session.

--- a/src/main/java/com/databricks/jdbc/api/internal/IDatabricksStatementInternal.java
+++ b/src/main/java/com/databricks/jdbc/api/internal/IDatabricksStatementInternal.java
@@ -23,6 +23,10 @@ public interface IDatabricksStatementInternal {
 
   Statement getStatement();
 
+  default boolean shouldTrackSessionVersion() {
+    return true;
+  }
+
   void allowInputStreamForVolumeOperation(boolean allowedInputStream) throws DatabricksSQLException;
 
   boolean isAllowedInputStreamForVolumeOperation() throws DatabricksSQLException;

--- a/src/main/java/com/databricks/jdbc/dbclient/IDatabricksClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/IDatabricksClient.java
@@ -120,6 +120,11 @@ public interface IDatabricksClient {
     throw new java.sql.SQLFeatureNotSupportedException("Heartbeat not supported by this client");
   }
 
+  default boolean checkStatementAlive(StatementId statementId, IDatabricksSession session)
+      throws SQLException {
+    return checkStatementAlive(statementId);
+  }
+
   /**
    * Fetches result for underlying statement-Id
    *

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClient.java
@@ -37,6 +37,8 @@ import com.databricks.jdbc.model.core.Disposition;
 import com.databricks.jdbc.model.core.ExternalLink;
 import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
+import com.databricks.jdbc.model.core.SessionExecutionMode;
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.databricks.jdbc.model.core.StatementStatus;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.sdk.WorkspaceClient;
@@ -116,7 +118,9 @@ public class DatabricksSdkClient implements IDatabricksClient {
         schema,
         sessionConf);
     CreateSessionRequest request =
-        new CreateSessionRequest().setWarehouseId(((Warehouse) warehouse).getWarehouseId());
+        new CreateSessionRequest()
+            .setWarehouseId(((Warehouse) warehouse).getWarehouseId())
+            .setExecutionMode(SessionExecutionMode.FAST);
     if (catalog != null) {
       request.setCatalog(catalog);
     }
@@ -153,10 +157,32 @@ public class DatabricksSdkClient implements IDatabricksClient {
       LOGGER.error(errorMessage, e);
       throw new DatabricksSQLException(errorMessage, e, DatabricksDriverErrorCode.SDK_CLIENT_ERROR);
     }
-    DatabricksThreadContextHolder.setSessionId(createSessionResponse.getSessionId());
+    String sessionId = createSessionResponse == null ? null : createSessionResponse.getSessionId();
+    if (sessionId == null || sessionId.isEmpty()) {
+      throw new DatabricksSQLException(
+          "FAST session response did not include session_id",
+          DatabricksDriverErrorCode.CONNECTION_ERROR);
+    }
+    if (createSessionResponse.getSessionVersion() == null
+        || createSessionResponse.getSessionVersion().getVersionId() == null) {
+      DatabricksSQLException validationError =
+          new DatabricksSQLException(
+              "FAST session response did not include session_version.version_id",
+              DatabricksDriverErrorCode.CONNECTION_ERROR);
+      try {
+        deleteSession(
+            ImmutableSessionInfo.builder().computeResource(warehouse).sessionId(sessionId).build());
+      } catch (Exception cleanupError) {
+        validationError.addSuppressed(cleanupError);
+        LOGGER.warn("Failed to delete invalid FAST session {}", sessionId, cleanupError);
+      }
+      throw validationError;
+    }
+    DatabricksThreadContextHolder.setSessionId(sessionId);
     return ImmutableSessionInfo.builder()
         .computeResource(warehouse)
-        .sessionId(createSessionResponse.getSessionId())
+        .sessionId(sessionId)
+        .sessionVersion(createSessionResponse.getSessionVersion().getVersionId())
         .build();
   }
 
@@ -200,7 +226,8 @@ public class DatabricksSdkClient implements IDatabricksClient {
         session,
         parentStatement,
         metadataOperationType);
-    DatabricksThreadContextHolder.setSessionId(session.getSessionId());
+    String requestSessionId = session.getSessionId();
+    DatabricksThreadContextHolder.setSessionId(requestSessionId);
     long pollCount = 0;
     long executionStartTime = Instant.now().toEpochMilli();
     DatabricksThreadContextHolder.setStatementType(statementType);
@@ -210,6 +237,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
             sql,
             ((Warehouse) computeResource).getWarehouseId(),
             session,
+            requestSessionId,
             parameters,
             parentStatement,
             false);
@@ -223,6 +251,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
       }
       req.withHeaders(getHeaders("executeStatement", statementType, false, additionalHeaders));
       response = apiClient.execute(req, ExecuteStatementResponse.class);
+      updateSessionVersion(session, requestSessionId, response.getStatus());
     } catch (IOException e) {
       String errorMessage = "Error while processing the execute statement request";
       LOGGER.error(errorMessage, e);
@@ -289,6 +318,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
         Request req = new Request(Request.GET, getStatusPath, apiClient.serialize(request));
         req.withHeaders(getHeaders("getStatement"));
         response = wrapGetStatementResponse(apiClient.execute(req, GetStatementResponse.class));
+        updateSessionVersion(session, requestSessionId, response.getStatus());
       } catch (IOException e) {
         String errorMessage = "Error while processing the get statement response";
         LOGGER.error(errorMessage, e);
@@ -369,7 +399,8 @@ public class DatabricksSdkClient implements IDatabricksClient {
         computeResource.toString(),
         session,
         parentStatement);
-    DatabricksThreadContextHolder.setSessionId(session.getSessionId());
+    String requestSessionId = session.getSessionId();
+    DatabricksThreadContextHolder.setSessionId(requestSessionId);
     StatementType statementType = StatementType.SQL;
     ExecuteStatementRequest request =
         getRequest(
@@ -377,6 +408,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
             sql,
             ((Warehouse) computeResource).getWarehouseId(),
             session,
+            requestSessionId,
             parameters,
             parentStatement,
             true);
@@ -385,6 +417,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
       Request req = new Request(Request.POST, STATEMENT_PATH, apiClient.serialize(request));
       req.withHeaders(getHeaders("executeStatement", statementType, true));
       response = apiClient.execute(req, ExecuteStatementResponse.class);
+      updateSessionVersion(session, requestSessionId, response.getStatus());
     } catch (IOException e) {
       String errorMessage = "Error while processing the execute statement async request";
       LOGGER.error(errorMessage, e);
@@ -417,13 +450,21 @@ public class DatabricksSdkClient implements IDatabricksClient {
 
   @Override
   public boolean checkStatementAlive(StatementId typedStatementId) throws SQLException {
+    return checkStatementAlive(typedStatementId, null);
+  }
+
+  @Override
+  public boolean checkStatementAlive(StatementId typedStatementId, IDatabricksSession session)
+      throws SQLException {
     String statementId = typedStatementId.toSQLExecStatementId();
+    String requestSessionId = session == null ? null : session.getSessionId();
     // Use lightweight /status endpoint (~100 bytes) instead of full GetStatement (~21KB)
     String statusPath = String.format(STATEMENT_STATUS_PATH_WITH_ID, statementId);
     try {
       Request req = new Request(Request.GET, statusPath, (String) null);
       req.withHeaders(getHeaders("getStatementStatus"));
       StatementStatus status = apiClient.execute(req, StatementStatus.class);
+      updateSessionVersion(session, requestSessionId, status);
       StatementState state = status.getState();
       // Terminal states mean the operation is no longer alive
       return state != StatementState.CANCELED
@@ -445,7 +486,8 @@ public class DatabricksSdkClient implements IDatabricksClient {
       IDatabricksStatementInternal parentStatement)
       throws SQLException {
     DatabricksThreadContextHolder.setStatementId(typedStatementId);
-    DatabricksThreadContextHolder.setSessionId(session.getSessionId());
+    String requestSessionId = session.getSessionId();
+    DatabricksThreadContextHolder.setSessionId(requestSessionId);
     String statementId = typedStatementId.toSQLExecStatementId();
     GetStatementRequest request = new GetStatementRequest().setStatementId(statementId);
     String getStatusPath = String.format(STATEMENT_PATH_WITH_ID, statementId);
@@ -454,6 +496,9 @@ public class DatabricksSdkClient implements IDatabricksClient {
       Request req = new Request(Request.GET, getStatusPath, apiClient.serialize(request));
       req.withHeaders(getHeaders("getStatement"));
       response = apiClient.execute(req, GetStatementResponse.class);
+      if (parentStatement == null || parentStatement.shouldTrackSessionVersion()) {
+        updateSessionVersion(session, requestSessionId, response.getStatus());
+      }
     } catch (IOException e) {
       String errorMessage = "Error while processing the get statement result request";
       LOGGER.error(errorMessage, e);
@@ -712,6 +757,7 @@ public class DatabricksSdkClient implements IDatabricksClient {
       String sql,
       String warehouseId,
       IDatabricksSession session,
+      String requestSessionId,
       Map<Integer, ImmutableSqlParameter> parameters,
       IDatabricksStatementInternal parentStatement,
       boolean executeAsync)
@@ -734,13 +780,17 @@ public class DatabricksSdkClient implements IDatabricksClient {
         parameters.values().stream().map(this::mapToParameterListItem).collect(Collectors.toList());
     ExecuteStatementRequest request =
         new ExecuteStatementRequest()
-            .setSessionId(session.getSessionId())
+            .setSessionId(requestSessionId)
             .setStatement(sql)
             .setWarehouseId(warehouseId)
             .setDisposition(disposition)
             .setFormat(format)
             .setResultCompression(compressionCodec)
             .setParameters(parameterListItems);
+    SessionVersion sessionVersion = session.getSessionVersion();
+    if (sessionVersion != null) {
+      request.setSessionVersion(sessionVersion);
+    }
     if (executeAsync) {
       request.setWaitTimeout(ASYNC_TIMEOUT_VALUE);
     } else {
@@ -821,6 +871,13 @@ public class DatabricksSdkClient implements IDatabricksClient {
         .setStatus(getStatementResponse.getStatus())
         .setManifest(getStatementResponse.getManifest())
         .setResult(getStatementResponse.getResult());
+  }
+
+  private void updateSessionVersion(
+      IDatabricksSession session, String requestSessionId, StatementStatus status) {
+    if (session != null && status != null) {
+      session.updateSessionVersion(requestSessionId, status.getSessionVersion());
+    }
   }
 
   /**

--- a/src/main/java/com/databricks/jdbc/model/client/sqlexec/CreateSessionRequest.java
+++ b/src/main/java/com/databricks/jdbc/model/client/sqlexec/CreateSessionRequest.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.client.sqlexec;
 
+import com.databricks.jdbc.model.core.SessionExecutionMode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
@@ -18,6 +19,9 @@ public class CreateSessionRequest {
 
   @JsonProperty("session_confs")
   private Map<String, String> sessionConfigs;
+
+  @JsonProperty("execution_mode")
+  private SessionExecutionMode executionMode;
 
   public CreateSessionRequest setWarehouseId(String warehouseId) {
     this.warehouseId = warehouseId;
@@ -53,5 +57,14 @@ public class CreateSessionRequest {
 
   public Map<String, String> getSessionConfigs() {
     return sessionConfigs;
+  }
+
+  public CreateSessionRequest setExecutionMode(SessionExecutionMode executionMode) {
+    this.executionMode = executionMode;
+    return this;
+  }
+
+  public SessionExecutionMode getExecutionMode() {
+    return executionMode;
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/client/sqlexec/CreateSessionResponse.java
+++ b/src/main/java/com/databricks/jdbc/model/client/sqlexec/CreateSessionResponse.java
@@ -1,5 +1,6 @@
 package com.databricks.jdbc.model.client.sqlexec;
 
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -13,6 +14,9 @@ public class CreateSessionResponse {
   @JsonProperty("session_id")
   private String sessionId;
 
+  @JsonProperty("session_version")
+  private SessionVersion sessionVersion;
+
   public CreateSessionResponse setSessionId(String sessionId) {
     this.sessionId = sessionId;
     return this;
@@ -20,5 +24,14 @@ public class CreateSessionResponse {
 
   public String getSessionId() {
     return sessionId;
+  }
+
+  public CreateSessionResponse setSessionVersion(SessionVersion sessionVersion) {
+    this.sessionVersion = sessionVersion;
+    return this;
+  }
+
+  public SessionVersion getSessionVersion() {
+    return sessionVersion;
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/client/sqlexec/ExecuteStatementRequest.java
+++ b/src/main/java/com/databricks/jdbc/model/client/sqlexec/ExecuteStatementRequest.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.model.client.sqlexec;
 
 import com.databricks.jdbc.common.CompressionCodec;
 import com.databricks.jdbc.model.core.Disposition;
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.databricks.sdk.service.sql.ExecuteStatementRequestOnWaitTimeout;
 import com.databricks.sdk.service.sql.Format;
 import com.databricks.sdk.service.sql.StatementParameterListItem;
@@ -46,6 +47,9 @@ public class ExecuteStatementRequest {
   @JsonProperty("result_compression")
   private CompressionCodec resultCompression;
 
+  @JsonProperty("session_version")
+  private SessionVersion sessionVersion;
+
   public String getStatement() {
     return statement;
   }
@@ -84,6 +88,10 @@ public class ExecuteStatementRequest {
 
   public CompressionCodec getResultCompression() {
     return resultCompression;
+  }
+
+  public SessionVersion getSessionVersion() {
+    return sessionVersion;
   }
 
   // Setters
@@ -138,6 +146,11 @@ public class ExecuteStatementRequest {
     return this;
   }
 
+  public ExecuteStatementRequest setSessionVersion(SessionVersion sessionVersion) {
+    this.sessionVersion = sessionVersion;
+    return this;
+  }
+
   @Override
   public String toString() {
     return new ToStringer(ExecuteStatementRequest.class)
@@ -147,6 +160,7 @@ public class ExecuteStatementRequest {
         .add("parameters", parameters)
         .add("statement", statement)
         .add("sessionId", sessionId)
+        .add("sessionVersion", sessionVersion)
         .add("waitTimeout", waitTimeout)
         .add("warehouseId", warehouseId)
         .add("rowLimit", rowLimit)
@@ -161,6 +175,8 @@ public class ExecuteStatementRequest {
         onWaitTimeout,
         parameters,
         rowLimit,
+        sessionId,
+        sessionVersion,
         statement,
         waitTimeout,
         warehouseId);
@@ -181,6 +197,7 @@ public class ExecuteStatementRequest {
         && Objects.equals(statement, that.statement)
         && Objects.equals(waitTimeout, that.waitTimeout)
         && Objects.equals(sessionId, that.sessionId)
+        && Objects.equals(sessionVersion, that.sessionVersion)
         && Objects.equals(warehouseId, that.warehouseId);
   }
 }

--- a/src/main/java/com/databricks/jdbc/model/core/SessionExecutionMode.java
+++ b/src/main/java/com/databricks/jdbc/model/core/SessionExecutionMode.java
@@ -1,0 +1,7 @@
+package com.databricks.jdbc.model.core;
+
+public enum SessionExecutionMode {
+  SESSION_EXECUTION_MODE_UNSPECIFIED,
+  DEFAULT,
+  FAST
+}

--- a/src/main/java/com/databricks/jdbc/model/core/SessionVersion.java
+++ b/src/main/java/com/databricks/jdbc/model/core/SessionVersion.java
@@ -1,0 +1,37 @@
+package com.databricks.jdbc.model.core;
+
+import com.databricks.sdk.support.ToStringer;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class SessionVersion {
+  @JsonProperty("version_id")
+  private Long versionId;
+
+  public Long getVersionId() {
+    return versionId;
+  }
+
+  public SessionVersion setVersionId(Long versionId) {
+    this.versionId = versionId;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SessionVersion that = (SessionVersion) o;
+    return Objects.equals(versionId, that.versionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(versionId);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringer(SessionVersion.class).add("versionId", versionId).toString();
+  }
+}

--- a/src/main/java/com/databricks/jdbc/model/core/StatementStatus.java
+++ b/src/main/java/com/databricks/jdbc/model/core/StatementStatus.java
@@ -16,6 +16,9 @@ public class StatementStatus {
   @JsonProperty("sql_state")
   private String sqlState;
 
+  @JsonProperty("session_version")
+  private SessionVersion sessionVersion;
+
   public StatementStatus() {}
 
   public StatementStatus setError(ServiceError error) {
@@ -45,6 +48,15 @@ public class StatementStatus {
     return this.sqlState;
   }
 
+  public StatementStatus setSessionVersion(SessionVersion sessionVersion) {
+    this.sessionVersion = sessionVersion;
+    return this;
+  }
+
+  public SessionVersion getSessionVersion() {
+    return sessionVersion;
+  }
+
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -52,14 +64,15 @@ public class StatementStatus {
       StatementStatus that = (StatementStatus) o;
       return Objects.equals(this.error, that.error)
           && Objects.equals(this.state, that.state)
-          && Objects.equals(this.sqlState, that.sqlState);
+          && Objects.equals(this.sqlState, that.sqlState)
+          && Objects.equals(this.sessionVersion, that.sessionVersion);
     } else {
       return false;
     }
   }
 
   public int hashCode() {
-    return Objects.hash(new Object[] {this.error, this.state, this.sqlState});
+    return Objects.hash(new Object[] {this.error, this.state, this.sqlState, this.sessionVersion});
   }
 
   public String toString() {
@@ -67,6 +80,7 @@ public class StatementStatus {
         .add("error", this.error)
         .add("state", this.state)
         .add("sqlState", this.sqlState)
+        .add("sessionVersion", this.sessionVersion)
         .toString();
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksSessionTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksSessionTest.java
@@ -21,11 +21,13 @@ import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksTemporaryRedirectException;
 import com.databricks.jdbc.model.client.thrift.generated.TSessionHandle;
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimedProcessor;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -89,6 +91,66 @@ public class DatabricksSessionTest {
     session.close();
     assertFalse(session.isOpen());
     assertNull(session.getSessionId());
+  }
+
+  @Test
+  public void testSessionVersionTracksConcurrentMaximumAndClearsOnClose() throws SQLException {
+    setupWarehouse(false /* useThrift */);
+    ImmutableSessionInfo sessionInfo =
+        ImmutableSessionInfo.builder()
+            .sessionId(SESSION_ID)
+            .sessionVersion(10L)
+            .computeResource(WAREHOUSE_COMPUTE)
+            .build();
+    when(sdkClient.createSession(any(), any(), any(), any())).thenReturn(sessionInfo);
+    DatabricksSession session = new DatabricksSession(connectionContext, sdkClient);
+    session.open();
+
+    LongStream.rangeClosed(1, 1000)
+        .parallel()
+        .forEach(
+            version ->
+                session.updateSessionVersion(
+                    SESSION_ID, new SessionVersion().setVersionId(version)));
+    session.updateSessionVersion(SESSION_ID, new SessionVersion().setVersionId(500L));
+    session.updateSessionVersion(SESSION_ID, new SessionVersion());
+    session.updateSessionVersion(SESSION_ID, null);
+
+    assertEquals(1000L, session.getSessionVersion().getVersionId());
+    session.close();
+    assertNull(session.getSessionVersion());
+  }
+
+  @Test
+  public void testSessionVersionRejectsLateUpdatesAfterCloseAndReopen() throws SQLException {
+    setupWarehouse(false /* useThrift */);
+    String replacementSessionId = "replacement_session_id";
+    when(sdkClient.createSession(any(), any(), any(), any()))
+        .thenReturn(
+            ImmutableSessionInfo.builder()
+                .sessionId(SESSION_ID)
+                .sessionVersion(10L)
+                .computeResource(WAREHOUSE_COMPUTE)
+                .build())
+        .thenReturn(
+            ImmutableSessionInfo.builder()
+                .sessionId(replacementSessionId)
+                .sessionVersion(20L)
+                .computeResource(WAREHOUSE_COMPUTE)
+                .build());
+    DatabricksSession session = new DatabricksSession(connectionContext, sdkClient);
+    session.open();
+    session.close();
+
+    session.updateSessionVersion(SESSION_ID, new SessionVersion().setVersionId(99L));
+    assertNull(session.getSessionVersion());
+
+    session.open();
+    session.updateSessionVersion(SESSION_ID, new SessionVersion().setVersionId(99L));
+    assertEquals(20L, session.getSessionVersion().getVersionId());
+
+    session.updateSessionVersion(replacementSessionId, new SessionVersion().setVersionId(21L));
+    assertEquals(21L, session.getSessionVersion().getVersionId());
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/sqlexec/DatabricksSdkClientTest.java
@@ -32,6 +32,8 @@ import com.databricks.jdbc.model.core.Disposition;
 import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.jdbc.model.core.ResultSchema;
+import com.databricks.jdbc.model.core.SessionExecutionMode;
+import com.databricks.jdbc.model.core.SessionVersion;
 import com.databricks.jdbc.model.core.StatementStatus;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.sdk.core.ApiClient;
@@ -59,6 +61,8 @@ public class DatabricksSdkClientTest {
   // Reference to MetadataOperationType to ensure import is not removed
   private static final MetadataOperationType SAMPLE_OP_TYPE = MetadataOperationType.GET_CATALOGS;
   private static final String SESSION_ID = "session_id";
+  private static final long INITIAL_SESSION_VERSION = 10L;
+  private static final long UPDATED_SESSION_VERSION = 12L;
   private static final StatementId STATEMENT_ID = new StatementId("statementId");
   private static final String STATEMENT =
       "SELECT * FROM orders WHERE user_id = ? AND shard = ? AND region_code = ? AND namespace = ?";
@@ -76,8 +80,18 @@ public class DatabricksSdkClientTest {
         }
       };
 
+  private static SessionVersion sessionVersion(long versionId) {
+    return new SessionVersion().setVersionId(versionId);
+  }
+
+  private static CreateSessionResponse createSessionResponse() {
+    return new CreateSessionResponse()
+        .setSessionId(SESSION_ID)
+        .setSessionVersion(sessionVersion(INITIAL_SESSION_VERSION));
+  }
+
   private void setupSessionMocks() throws IOException {
-    CreateSessionResponse response = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse response = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(response);
   }
@@ -93,7 +107,10 @@ public class DatabricksSdkClientTest {
           }
         };
 
-    StatementStatus statementStatus = new StatementStatus().setState(StatementState.SUCCEEDED);
+    StatementStatus statementStatus =
+        new StatementStatus()
+            .setState(StatementState.SUCCEEDED)
+            .setSessionVersion(sessionVersion(UPDATED_SESSION_VERSION));
     ExecuteStatementRequest executeStatementRequest =
         new ExecuteStatementRequest()
             .setSessionId(SESSION_ID)
@@ -102,6 +119,7 @@ public class DatabricksSdkClientTest {
             .setDisposition(Disposition.INLINE_OR_EXTERNAL_LINKS)
             .setFormat(Format.ARROW_STREAM)
             .setRowLimit(100L)
+            .setSessionVersion(sessionVersion(INITIAL_SESSION_VERSION))
             .setParameters(params);
     if (async) {
       executeStatementRequest.setWaitTimeout("0s");
@@ -131,7 +149,7 @@ public class DatabricksSdkClientTest {
               if (req.getUrl().equals(STATEMENT_PATH)) {
                 return response;
               } else if (req.getUrl().equals(SESSION_PATH)) {
-                return new CreateSessionResponse().setSessionId(SESSION_ID);
+                return createSessionResponse();
               }
               return null;
             });
@@ -148,6 +166,79 @@ public class DatabricksSdkClientTest {
         databricksSdkClient.createSession(warehouse, null, null, null);
     assertEquals(sessionInfo.sessionId(), SESSION_ID);
     assertEquals(sessionInfo.computeResource(), warehouse);
+    assertEquals(INITIAL_SESSION_VERSION, sessionInfo.sessionVersion());
+    verify(apiClient)
+        .serialize(
+            argThat(
+                request ->
+                    request instanceof CreateSessionRequest
+                        && ((CreateSessionRequest) request).getExecutionMode()
+                            == SessionExecutionMode.FAST));
+  }
+
+  @Test
+  public void testCreateSessionFailsWithoutInitialSessionVersion() throws Exception {
+    when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
+        .thenReturn(new CreateSessionResponse().setSessionId(SESSION_ID));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> databricksSdkClient.createSession(warehouse, null, null, null));
+
+    assertTrue(exception.getMessage().contains("session_version.version_id"));
+    verify(apiClient)
+        .execute(
+            argThat(
+                request ->
+                    Request.DELETE.equals(request.getMethod())
+                        && String.format(SESSION_PATH_WITH_ID, SESSION_ID)
+                            .equals(request.getUrl())),
+            eq(Void.class));
+  }
+
+  @Test
+  public void testCreateSessionFailsWithoutSessionId() throws Exception {
+    when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
+        .thenReturn(
+            new CreateSessionResponse().setSessionVersion(sessionVersion(INITIAL_SESSION_VERSION)));
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> databricksSdkClient.createSession(warehouse, null, null, null));
+
+    assertTrue(exception.getMessage().contains("session_id"));
+    verify(apiClient, never()).execute(any(Request.class), eq(Void.class));
+  }
+
+  @Test
+  public void testCreateSessionPreservesCleanupFailure() throws Exception {
+    when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
+        .thenReturn(new CreateSessionResponse().setSessionId(SESSION_ID));
+    IOException cleanupError = new IOException("cleanup failed");
+    when(apiClient.execute(any(Request.class), eq(Void.class))).thenThrow(cleanupError);
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> databricksSdkClient.createSession(warehouse, null, null, null));
+
+    assertTrue(exception.getMessage().contains("session_version.version_id"));
+    assertEquals(1, exception.getSuppressed().length);
+    assertSame(cleanupError, exception.getSuppressed()[0].getCause());
   }
 
   @Test
@@ -217,9 +308,17 @@ public class DatabricksSdkClientTest {
             null);
     assertEquals(STATEMENT_ID, statement.getStatementId());
     assertNotNull(resultSet.getMetaData());
+    assertEquals(
+        UPDATED_SESSION_VERSION, connection.getSession().getSessionVersion().getVersionId());
 
     // Verify a Request with POST method is created and executed
-    verify(apiClient, atLeastOnce()).serialize(any(ExecuteStatementRequest.class));
+    verify(apiClient, atLeastOnce())
+        .serialize(
+            argThat(
+                request ->
+                    request instanceof ExecuteStatementRequest
+                        && sessionVersion(INITIAL_SESSION_VERSION)
+                            .equals(((ExecuteStatementRequest) request).getSessionVersion())));
     verify(apiClient, atLeastOnce())
         .execute(
             argThat(
@@ -401,6 +500,66 @@ public class DatabricksSdkClientTest {
   }
 
   @Test
+  public void testGetStatementResultUpdatesSessionVersion() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+    DatabricksConnection connection =
+        new DatabricksConnection(connectionContext, databricksSdkClient);
+    when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
+        .thenReturn(createSessionResponse());
+    connection.open();
+
+    GetStatementResponse response =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID.toSQLExecStatementId())
+            .setStatus(
+                new StatementStatus()
+                    .setState(StatementState.SUCCEEDED)
+                    .setSessionVersion(sessionVersion(UPDATED_SESSION_VERSION)));
+    when(apiClient.execute(any(Request.class), eq(GetStatementResponse.class)))
+        .thenReturn(response);
+
+    databricksSdkClient.getStatementResult(STATEMENT_ID, connection.getSession(), null);
+
+    assertEquals(
+        UPDATED_SESSION_VERSION, connection.getSession().getSessionVersion().getVersionId());
+  }
+
+  @Test
+  public void testGetStatementResultDoesNotUpdateSessionVersionForDetachedStatement()
+      throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+    DatabricksConnection connection =
+        new DatabricksConnection(connectionContext, databricksSdkClient);
+    when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
+        .thenReturn(createSessionResponse());
+    connection.open();
+
+    GetStatementResponse response =
+        new GetStatementResponse()
+            .setStatementId(STATEMENT_ID.toSQLExecStatementId())
+            .setStatus(
+                new StatementStatus()
+                    .setState(StatementState.SUCCEEDED)
+                    .setSessionVersion(sessionVersion(UPDATED_SESSION_VERSION)));
+    when(apiClient.execute(any(Request.class), eq(GetStatementResponse.class)))
+        .thenReturn(response);
+    DatabricksStatement detachedStatement =
+        (DatabricksStatement) connection.getStatement(STATEMENT_ID.toString());
+
+    databricksSdkClient.getStatementResult(
+        STATEMENT_ID, connection.getSession(), detachedStatement);
+
+    assertEquals(
+        INITIAL_SESSION_VERSION, connection.getSession().getSessionVersion().getVersionId());
+  }
+
+  @Test
   public void testDisposition_arrowAndCloudFetchEnabled_usesExternalLinks() throws Exception {
     setupClientMocks(true, false);
     // Default JDBC_URL has arrow enabled and cloud fetch enabled
@@ -467,7 +626,7 @@ public class DatabricksSdkClientTest {
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
     // Mock session creation
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -487,7 +646,10 @@ public class DatabricksSdkClientTest {
             .setStatus(new StatementStatus().setState(StatementState.RUNNING));
     GetStatementResponse successStatementResponse =
         new GetStatementResponse()
-            .setStatus(new StatementStatus().setState(StatementState.SUCCEEDED));
+            .setStatus(
+                new StatementStatus()
+                    .setState(StatementState.SUCCEEDED)
+                    .setSessionVersion(sessionVersion(UPDATED_SESSION_VERSION)));
 
     // Set up response sequence for execute() calls
     when(apiClient.execute(
@@ -515,6 +677,8 @@ public class DatabricksSdkClientTest {
                 connection.getSession(),
                 statement,
                 null));
+    assertEquals(
+        UPDATED_SESSION_VERSION, connection.getSession().getSessionVersion().getVersionId());
 
     // Verify no cancellation occurred due to timeout
     verify(apiClient, atLeastOnce())
@@ -542,7 +706,7 @@ public class DatabricksSdkClientTest {
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
     // Mock session creation
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -620,7 +784,7 @@ public class DatabricksSdkClientTest {
     DatabricksConnection connection =
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -681,7 +845,7 @@ public class DatabricksSdkClientTest {
     DatabricksConnection connection =
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -721,7 +885,7 @@ public class DatabricksSdkClientTest {
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
     // Mock session creation
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -1175,7 +1339,7 @@ public class DatabricksSdkClientTest {
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
     // Mock session creation
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -1233,7 +1397,7 @@ public class DatabricksSdkClientTest {
         new DatabricksConnection(connectionContext, databricksSdkClient);
 
     // Mock session creation
-    CreateSessionResponse sessionResponse = new CreateSessionResponse().setSessionId(SESSION_ID);
+    CreateSessionResponse sessionResponse = createSessionResponse();
     when(apiClient.execute(any(Request.class), eq(CreateSessionResponse.class)))
         .thenReturn(sessionResponse);
     connection.open();
@@ -1332,6 +1496,24 @@ public class DatabricksSdkClientTest {
     when(apiClient.execute(any(Request.class), eq(StatementStatus.class))).thenReturn(status);
 
     assertTrue(databricksSdkClient.checkStatementAlive(STATEMENT_ID));
+  }
+
+  @Test
+  public void testCheckStatementAliveUpdatesSessionVersion() throws Exception {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(JDBC_URL, new Properties());
+    DatabricksSdkClient databricksSdkClient =
+        new DatabricksSdkClient(connectionContext, statementExecutionService, apiClient);
+    DatabricksSession session = mock(DatabricksSession.class);
+    when(session.getSessionId()).thenReturn(SESSION_ID);
+    SessionVersion updatedVersion = sessionVersion(UPDATED_SESSION_VERSION);
+    StatementStatus status =
+        new StatementStatus().setState(StatementState.SUCCEEDED).setSessionVersion(updatedVersion);
+    when(apiClient.execute(any(Request.class), eq(StatementStatus.class))).thenReturn(status);
+
+    assertTrue(databricksSdkClient.checkStatementAlive(STATEMENT_ID, session));
+
+    verify(session).updateSessionVersion(SESSION_ID, updatedVersion);
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/model/core/SessionVersionSerializationTest.java
+++ b/src/test/java/com/databricks/jdbc/model/core/SessionVersionSerializationTest.java
@@ -1,0 +1,45 @@
+package com.databricks.jdbc.model.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.databricks.jdbc.model.client.sqlexec.CreateSessionRequest;
+import com.databricks.jdbc.model.client.sqlexec.CreateSessionResponse;
+import com.databricks.jdbc.model.client.sqlexec.ExecuteStatementRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class SessionVersionSerializationTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testFastSessionRequestAndVersionUseProtoJsonFieldNames() throws Exception {
+    JsonNode createRequest =
+        objectMapper.valueToTree(
+            new CreateSessionRequest()
+                .setWarehouseId("warehouse")
+                .setExecutionMode(SessionExecutionMode.FAST));
+    JsonNode executeRequest =
+        objectMapper.valueToTree(
+            new ExecuteStatementRequest()
+                .setSessionVersion(new SessionVersion().setVersionId(42L)));
+
+    assertEquals("FAST", createRequest.get("execution_mode").asText());
+    assertEquals(42L, executeRequest.get("session_version").get("version_id").asLong());
+  }
+
+  @Test
+  public void testSessionVersionsDeserializeFromCreateAndStatusResponses() throws Exception {
+    CreateSessionResponse createResponse =
+        objectMapper.readValue(
+            "{\"session_id\":\"session\",\"session_version\":{\"version_id\":7}}",
+            CreateSessionResponse.class);
+    StatementStatus status =
+        objectMapper.readValue(
+            "{\"state\":\"SUCCEEDED\",\"session_version\":{\"version_id\":9}}",
+            StatementStatus.class);
+
+    assertEquals(7L, createResponse.getSessionVersion().getVersionId());
+    assertEquals(9L, status.getSessionVersion().getVersionId());
+  }
+}

--- a/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapiemptyresult/mappings/api_2.0_sql_sessions-57a7880f-1054-4cca-bcb2-ce82bc65204a.json
+++ b/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapiemptyresult/mappings/api_2.0_sql_sessions-57a7880f-1054-4cca-bcb2-ce82bc65204a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f1711a-a795-125e-a06e-d49671a410d5\"}",
+    "body" : "{\"session_id\":\"01f1711a-a795-125e-a06e-d49671a410d5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "cb1048d9-0fa0-4f7c-8fb3-fba99c290c64",
       "date" : "Fri, 26 Jun 2026 04:51:12 GMT",

--- a/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapimultichunkquery/mappings/api_2.0_sql_sessions-1f3a5637-e090-4a12-9df5-2988270b5de9.json
+++ b/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapimultichunkquery/mappings/api_2.0_sql_sessions-1f3a5637-e090-4a12-9df5-2988270b5de9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f1711a-ae50-1729-8840-92709bad352f\"}",
+    "body" : "{\"session_id\":\"01f1711a-ae50-1729-8840-92709bad352f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "0f484b63-5785-4252-a699-a07c861655a1",
       "date" : "Fri, 26 Jun 2026 04:51:23 GMT",

--- a/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapisinglechunkquery/mappings/api_2.0_sql_sessions-569946b8-dbec-46c5-b1ad-507e6c24b1c8.json
+++ b/src/test/resources/sqlexecapi/boundedseaapicloudfetchintegrationtests/testboundedseaapisinglechunkquery/mappings/api_2.0_sql_sessions-569946b8-dbec-46c5-b1ad-507e6c24b1c8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f1711a-aad5-1c78-a296-61e968534b4e\"}",
+    "body" : "{\"session_id\":\"01f1711a-aad5-1c78-a296-61e968534b4e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "f1ef4b6b-45f2-4a9f-bbdd-5205c491db4b",
       "date" : "Fri, 26 Jun 2026 04:51:17 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testautocommit_defaultistrue/mappings/api_2.0_sql_sessions-ab9c636d-35f0-48f6-81d1-d84137567790.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testautocommit_defaultistrue/mappings/api_2.0_sql_sessions-ab9c636d-35f0-48f6-81d1-d84137567790.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c17-14cd-19d1-9015-088882648a0e\"}",
+    "body" : "{\"session_id\":\"01f10c17-14cd-19d1-9015-088882648a0e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bc5178fe-463a-4581-8e13-adc5e0b049c2",
       "date" : "Tue, 17 Feb 2026 15:41:09 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetcatalog_returnsnonnull/mappings/api_2.0_sql_sessions-b3b7ace9-bad3-4232-98c9-4d78132dda52.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetcatalog_returnsnonnull/mappings/api_2.0_sql_sessions-b3b7ace9-bad3-4232-98c9-4d78132dda52.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-bb17-1796-a884-13dab608b261\"}",
+    "body" : "{\"session_id\":\"01f10beb-bb17-1796-a884-13dab608b261\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6ca8d941-1c3f-4537-97f0-9a1857c50592",
       "date" : "Tue, 17 Feb 2026 10:30:50 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetcatalog_returnsnonnull/mappings/api_2.0_sql_sessions-de62a3aa-23be-425f-8737-313671a0d8cd.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetcatalog_returnsnonnull/mappings/api_2.0_sql_sessions-de62a3aa-23be-425f-8737-313671a0d8cd.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-9aa8-14b0-b540-8dc5f7a6cbe8\"}",
+    "body" : "{\"session_id\":\"01f10bde-9aa8-14b0-b540-8dc5f7a6cbe8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e29e9ab6-721c-4474-8c08-da4b0f87e103",
       "date" : "Tue, 17 Feb 2026 08:56:53 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetclientinfo_returnsproperties/mappings/api_2.0_sql_sessions-5c67abf8-d6eb-4811-83ee-e484b6871727.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetclientinfo_returnsproperties/mappings/api_2.0_sql_sessions-5c67abf8-d6eb-4811-83ee-e484b6871727.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-c108-14bd-bc03-b1d3ab8c08c3\"}",
+    "body" : "{\"session_id\":\"01f10beb-c108-14bd-bc03-b1d3ab8c08c3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e40afd28-4f31-426f-a31c-e026548ce42a",
       "date" : "Tue, 17 Feb 2026 10:31:00 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetmetadata_returnsnonnull/mappings/api_2.0_sql_sessions-c322339d-fd0c-4c4f-ac86-f3c16c35ce7c.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetmetadata_returnsnonnull/mappings/api_2.0_sql_sessions-c322339d-fd0c-4c4f-ac86-f3c16c35ce7c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-bd0a-121a-b9a7-733a929c7efd\"}",
+    "body" : "{\"session_id\":\"01f10beb-bd0a-121a-b9a7-733a929c7efd\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b7df32f2-b86d-401d-b3cc-0aa7e80965d9",
       "date" : "Tue, 17 Feb 2026 10:30:54 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetschema_returnsnonnull/mappings/api_2.0_sql_sessions-51400b43-d922-46bf-a8f5-9a7847a90d14.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetschema_returnsnonnull/mappings/api_2.0_sql_sessions-51400b43-d922-46bf-a8f5-9a7847a90d14.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-969f-12c4-b492-495d4e87e582\"}",
+    "body" : "{\"session_id\":\"01f10bde-969f-12c4-b492-495d4e87e582\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b1cfedb2-736a-450d-b571-cf495b4cdbf3",
       "date" : "Tue, 17 Feb 2026 08:56:46 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetschema_returnsnonnull/mappings/api_2.0_sql_sessions-c111ad58-ce2c-4c3b-b482-6a2d6d57f27f.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetschema_returnsnonnull/mappings/api_2.0_sql_sessions-c111ad58-ce2c-4c3b-b482-6a2d6d57f27f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-b717-1a00-8f56-7c2be128b69b\"}",
+    "body" : "{\"session_id\":\"01f10beb-b717-1a00-8f56-7c2be128b69b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8e5939dc-b2f3-43c3-80f0-19eb17ed0922",
       "date" : "Tue, 17 Feb 2026 10:30:44 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgettransactionisolation/mappings/api_2.0_sql_sessions-5e778b40-37b0-456e-8bb2-7dc852fe91a7.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgettransactionisolation/mappings/api_2.0_sql_sessions-5e778b40-37b0-456e-8bb2-7dc852fe91a7.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c17-1f62-1e3e-9d60-7303bbe1b21c\"}",
+    "body" : "{\"session_id\":\"01f10c17-1f62-1e3e-9d60-7303bbe1b21c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "27ab67f6-5d35-4f53-b074-f7f5f90229d7",
       "date" : "Tue, 17 Feb 2026 15:41:27 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testgetwarnings_andclearwarnings/mappings/api_2.0_sql_sessions-1f6a9042-493c-4269-bc64-20910a14de89.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testgetwarnings_andclearwarnings/mappings/api_2.0_sql_sessions-1f6a9042-493c-4269-bc64-20910a14de89.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-c301-128a-88b1-62cd9c5c6f8c\"}",
+    "body" : "{\"session_id\":\"01f10beb-c301-128a-88b1-62cd9c5c6f8c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3a46c65b-2400-43fd-a3a3-5a70e7691a0b",
       "date" : "Tue, 17 Feb 2026 10:31:04 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testisclosed_newconnection/mappings/api_2.0_sql_sessions-12a047da-6ede-4007-9a86-111d02810f39.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testisclosed_newconnection/mappings/api_2.0_sql_sessions-12a047da-6ede-4007-9a86-111d02810f39.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-98af-1cb0-aaee-36da5cdeeeac\"}",
+    "body" : "{\"session_id\":\"01f10bde-98af-1cb0-aaee-36da5cdeeeac\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e2817350-4965-4b76-98f3-de54b72275ca",
       "date" : "Tue, 17 Feb 2026 08:56:49 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testisclosed_newconnection/mappings/api_2.0_sql_sessions-e97e50c8-398d-44d4-9fef-d4453228a798.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testisclosed_newconnection/mappings/api_2.0_sql_sessions-e97e50c8-398d-44d4-9fef-d4453228a798.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-b92a-102c-96e6-cb51bf812e16\"}",
+    "body" : "{\"session_id\":\"01f10beb-b92a-102c-96e6-cb51bf812e16\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "957848a5-9d20-4281-97a5-e5ed1ece965c",
       "date" : "Tue, 17 Feb 2026 10:30:47 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testisreadonly_default/mappings/api_2.0_sql_sessions-7e74f265-0fff-4bb6-9816-30d8732a5e99.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testisreadonly_default/mappings/api_2.0_sql_sessions-7e74f265-0fff-4bb6-9816-30d8732a5e99.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c17-0a3c-1ed2-8728-b613efcf09b1\"}",
+    "body" : "{\"session_id\":\"01f10c17-0a3c-1ed2-8728-b613efcf09b1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3164ce9a-e228-42a6-ae6f-eede5d6fccf4",
       "date" : "Tue, 17 Feb 2026 15:40:52 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testisvalid_activeconnection/mappings/api_2.0_sql_sessions-55743e5d-a478-4017-abbf-40692f483191.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testisvalid_activeconnection/mappings/api_2.0_sql_sessions-55743e5d-a478-4017-abbf-40692f483191.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-9c98-1ea6-b610-2bd7bba0d3ab\"}",
+    "body" : "{\"session_id\":\"01f10bde-9c98-1ea6-b610-2bd7bba0d3ab\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "32ac8835-1523-4e2d-815f-00a7a04844ad",
       "date" : "Tue, 17 Feb 2026 08:56:56 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testisvalid_activeconnection/mappings/api_2.0_sql_sessions-bd4e8291-de30-42f8-aa83-7bba09f03dd4.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testisvalid_activeconnection/mappings/api_2.0_sql_sessions-bd4e8291-de30-42f8-aa83-7bba09f03dd4.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-bf17-158d-8362-a063de6aff30\"}",
+    "body" : "{\"session_id\":\"01f10beb-bf17-158d-8362-a063de6aff30\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6137b0f0-d35f-419d-9a3a-3be19a631303",
       "date" : "Tue, 17 Feb 2026 10:30:57 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testpatinoauthtokenpassthrough/mappings/api_2.0_sql_sessions-12677348-4d51-4e17-b43b-d70e546b9a28.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testpatinoauthtokenpassthrough/mappings/api_2.0_sql_sessions-12677348-4d51-4e17-b43b-d70e546b9a28.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-cc99-1997-be50-513a774b395e\"}",
+    "body" : "{\"session_id\":\"01f099d9-cc99-1997-be50-513a774b395e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ea3c9738-12d0-46e1-bbef-1f90ccb90354",
       "date" : "Thu, 25 Sep 2025 06:35:16 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetcatalog/mappings/api_2.0_sql_sessions-8d825154-d56b-42cf-9f33-37a362a771fa.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetcatalog/mappings/api_2.0_sql_sessions-8d825154-d56b-42cf-9f33-37a362a771fa.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-5820-1d62-8f57-a48400252796\"}",
+    "body" : "{\"session_id\":\"01f10c86-5820-1d62-8f57-a48400252796\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8f5485d5-7cb5-4a78-9321-03364179cb7a",
       "date" : "Wed, 18 Feb 2026 04:57:36 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetclientinfo/mappings/api_2.0_sql_sessions-8284ad41-5a3b-4f51-8d0a-a97718c9bea6.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetclientinfo/mappings/api_2.0_sql_sessions-8284ad41-5a3b-4f51-8d0a-a97718c9bea6.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-5612-1612-b82f-83bc1bc76d0f\"}",
+    "body" : "{\"session_id\":\"01f10c86-5612-1612-b82f-83bc1bc76d0f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "518f06ac-a20c-4d39-ad4d-a315b8e1d282",
       "date" : "Wed, 18 Feb 2026 04:57:33 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetschema/mappings/api_2.0_sql_sessions-6fe03c33-b901-4a66-9fcd-ab0ad9e05370.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testsetandgetschema/mappings/api_2.0_sql_sessions-6fe03c33-b901-4a66-9fcd-ab0ad9e05370.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-50d9-169f-a964-78360fd5275b\"}",
+    "body" : "{\"session_id\":\"01f10c86-50d9-169f-a964-78360fd5275b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ef6a3f37-7367-4004-9cb4-092b0763cf69",
       "date" : "Wed, 18 Feb 2026 04:57:24 GMT",

--- a/src/test/resources/sqlexecapi/connectionintegrationtests/testsuccessfulconnection/mappings/api_2.0_sql_sessions-2999c7fa-a513-47e0-aee5-bd6889fdd539.json
+++ b/src/test/resources/sqlexecapi/connectionintegrationtests/testsuccessfulconnection/mappings/api_2.0_sql_sessions-2999c7fa-a513-47e0-aee5-bd6889fdd539.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-d162-1343-be12-ac8174541dfb\"}",
+    "body" : "{\"session_id\":\"01f099d9-d162-1343-be12-ac8174541dfb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d38d2cec-151b-4621-bc04-5e2e6f07628c",
       "date" : "Thu, 25 Sep 2025 06:35:24 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testgeospatialtypes/mappings/api_2.0_sql_sessions-26c29504-a4b8-440b-bbd1-d7b1d3576eb7.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testgeospatialtypes/mappings/api_2.0_sql_sessions-26c29504-a4b8-440b-bbd1-d7b1d3576eb7.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0a5bc-7472-14b8-bc16-71f68ce36d0c\"}",
+    "body" : "{\"session_id\":\"01f0a5bc-7472-14b8-bc16-71f68ce36d0c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b03130c4-9753-4a1d-93f1-b8d4fe7d021f",
       "date" : "Fri, 10 Oct 2025 09:35:27 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testgeospatialtypes/mappings/api_2.0_sql_sessions-53ba8b00-9e82-4ffe-a90a-aa18dfea3f89.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testgeospatialtypes/mappings/api_2.0_sql_sessions-53ba8b00-9e82-4ffe-a90a-aa18dfea3f89.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0a5bc-75de-14b1-aba0-dd791b1a50e3\"}",
+    "body" : "{\"session_id\":\"01f0a5bc-75de-14b1-aba0-dd791b1a50e3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b7cfeca3-2f54-4a9b-84b4-d99dedd08fe3",
       "date" : "Fri, 10 Oct 2025 09:35:29 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testintervaltypes/mappings/api_2.0_sql_sessions-3d7dfded-e382-4cd9-9ca9-3236a8eb898f.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testintervaltypes/mappings/api_2.0_sql_sessions-3d7dfded-e382-4cd9-9ca9-3236a8eb898f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-01a3-168f-afee-88a7577b77a2\"}",
+    "body" : "{\"session_id\":\"01f099da-01a3-168f-afee-88a7577b77a2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "98421f70-1907-4232-b5f7-ead4589c3116",
       "date" : "Thu, 25 Sep 2025 06:36:45 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testintervaltypes/mappings/api_2.0_sql_sessions-b19f0154-0cb1-4324-b473-d640d9004029.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testintervaltypes/mappings/api_2.0_sql_sessions-b19f0154-0cb1-4324-b473-d640d9004029.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-0305-1155-b888-e5e52dce9ad8\"}",
+    "body" : "{\"session_id\":\"01f099da-0305-1155-b888-e5e52dce9ad8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "f92576ba-2a8d-4184-84d6-aaa4370d12ac",
       "date" : "Thu, 25 Sep 2025 06:36:48 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation1/mappings/api_2.0_sql_sessions-18225c5a-33a9-4929-86ed-a8a65c74809a.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation1/mappings/api_2.0_sql_sessions-18225c5a-33a9-4929-86ed-a8a65c74809a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-2209-167d-b30a-82c2f973cae2\"}",
+    "body" : "{\"session_id\":\"01f099da-2209-167d-b30a-82c2f973cae2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d68890df-28fd-4dee-a8d1-a594f8998892",
       "date" : "Thu, 25 Sep 2025 06:37:40 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation1/mappings/api_2.0_sql_sessions-c543753a-8ac5-4132-af04-5d3b00acd131.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation1/mappings/api_2.0_sql_sessions-c543753a-8ac5-4132-af04-5d3b00acd131.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-20b1-1c28-83c5-6283cd725115\"}",
+    "body" : "{\"session_id\":\"01f099da-20b1-1c28-83c5-6283cd725115\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6b1d835a-9e8c-4e09-b47e-5796a9bf408b",
       "date" : "Thu, 25 Sep 2025 06:37:37 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation2/mappings/api_2.0_sql_sessions-952ea4c4-6fc5-4969-8477-06bf5516b89f.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation2/mappings/api_2.0_sql_sessions-952ea4c4-6fc5-4969-8477-06bf5516b89f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-294b-1f1a-a61e-6f874abfb7ab\"}",
+    "body" : "{\"session_id\":\"01f099da-294b-1f1a-a61e-6f874abfb7ab\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "23b41ae2-9513-4ba1-b148-64071fbf4fb0",
       "date" : "Thu, 25 Sep 2025 06:37:52 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation2/mappings/api_2.0_sql_sessions-da52820b-6bd7-42ba-aae3-ac0795891cc0.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation2/mappings/api_2.0_sql_sessions-da52820b-6bd7-42ba-aae3-ac0795891cc0.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-27ef-192f-8010-aec993d8cc1a\"}",
+    "body" : "{\"session_id\":\"01f099da-27ef-192f-8010-aec993d8cc1a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "08859c69-a9a0-4de5-af6e-b49fcef42977",
       "date" : "Thu, 25 Sep 2025 06:37:50 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation3/mappings/api_2.0_sql_sessions-0ced5099-6504-4c7c-9d83-536fc32b42c9.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation3/mappings/api_2.0_sql_sessions-0ced5099-6504-4c7c-9d83-536fc32b42c9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-30a3-1a0d-b36a-3ff69bfbe5e6\"}",
+    "body" : "{\"session_id\":\"01f099da-30a3-1a0d-b36a-3ff69bfbe5e6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2b0613ab-3bcd-435b-b8e9-909e876adc21",
       "date" : "Thu, 25 Sep 2025 06:38:04 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation3/mappings/api_2.0_sql_sessions-c8739db4-c010-479a-8104-ae59aea3c5c1.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testnullhandling.invocation3/mappings/api_2.0_sql_sessions-c8739db4-c010-479a-8104-ae59aea3c5c1.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-2f3b-10fb-b5c3-39ca33aa3bb2\"}",
+    "body" : "{\"session_id\":\"01f099da-2f3b-10fb-b5c3-39ca33aa3bb2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ef7fd56d-54bd-4734-8977-2c81ebf3b42f",
       "date" : "Thu, 25 Sep 2025 06:38:02 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/teststringedgecases/mappings/api_2.0_sql_sessions-7e006a3f-ed4a-4c2e-b1d4-c017a250a1f0.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/teststringedgecases/mappings/api_2.0_sql_sessions-7e006a3f-ed4a-4c2e-b1d4-c017a250a1f0.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-fbae-1362-8138-0e925847daab\"}",
+    "body" : "{\"session_id\":\"01f099d9-fbae-1362-8138-0e925847daab\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c6ba156b-4686-4c5b-93b5-62d8d55bc594",
       "date" : "Thu, 25 Sep 2025 06:36:35 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/teststringedgecases/mappings/api_2.0_sql_sessions-b7f01896-457f-4ccb-a937-cbd097c47214.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/teststringedgecases/mappings/api_2.0_sql_sessions-b7f01896-457f-4ccb-a937-cbd097c47214.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-fa50-171a-a0eb-6f03350a6c68\"}",
+    "body" : "{\"session_id\":\"01f099d9-fa50-171a-a0eb-6f03350a6c68\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "cbd853d8-856a-4e0f-9cb5-3a250ab46827",
       "date" : "Thu, 25 Sep 2025 06:36:33 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestamp/mappings/api_2.0_sql_sessions-2d408991-6ff3-4c55-9f68-9b041cf1ae34.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestamp/mappings/api_2.0_sql_sessions-2d408991-6ff3-4c55-9f68-9b041cf1ae34.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-11c8-1c82-b327-d1694bd2aa09\"}",
+    "body" : "{\"session_id\":\"01f099da-11c8-1c82-b327-d1694bd2aa09\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ffcf2c75-8d81-4506-8817-a765ed7aefe8",
       "date" : "Thu, 25 Sep 2025 06:37:12 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestamp/mappings/api_2.0_sql_sessions-a08231b0-cec1-440c-91e8-ad5c724b1d52.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestamp/mappings/api_2.0_sql_sessions-a08231b0-cec1-440c-91e8-ad5c724b1d52.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099da-132d-1564-858e-107cee635263\"}",
+    "body" : "{\"session_id\":\"01f099da-132d-1564-858e-107cee635263\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "523bcb1e-fddf-40a3-8cde-59b344afaea1",
       "date" : "Thu, 25 Sep 2025 06:37:15 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestampwithtimezoneconversion/mappings/api_2.0_sql_sessions-606d7d6a-058d-4802-bc75-b8cdc47a2054.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestampwithtimezoneconversion/mappings/api_2.0_sql_sessions-606d7d6a-058d-4802-bc75-b8cdc47a2054.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-de16-1f7e-8385-833a776bf372\"}",
+    "body" : "{\"session_id\":\"01f099d9-de16-1f7e-8385-833a776bf372\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "47cfe690-4b8e-4921-b0ef-885492b2c6d0",
       "date" : "Thu, 25 Sep 2025 06:35:46 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestampwithtimezoneconversion/mappings/api_2.0_sql_sessions-6bef99ed-2da2-4555-bf48-8964387c1213.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testtimestampwithtimezoneconversion/mappings/api_2.0_sql_sessions-6bef99ed-2da2-4555-bf48-8964387c1213.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-df73-1f50-a584-a66fa91092fa\"}",
+    "body" : "{\"session_id\":\"01f099d9-df73-1f50-a584-a66fa91092fa\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8f6c1eab-87bf-45a8-a1ee-e53e890a372c",
       "date" : "Thu, 25 Sep 2025 06:35:48 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testvarianttypes/mappings/api_2.0_sql_sessions-cc6a077c-25b3-49e1-b495-ab3737f72e98.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testvarianttypes/mappings/api_2.0_sql_sessions-cc6a077c-25b3-49e1-b495-ab3737f72e98.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-ec13-10d9-b83f-64d84d24f06b\"}",
+    "body" : "{\"session_id\":\"01f099d9-ec13-10d9-b83f-64d84d24f06b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9fc9e81c-0f1a-40be-b58f-d3cd99cbeed6",
       "date" : "Thu, 25 Sep 2025 06:36:09 GMT",

--- a/src/test/resources/sqlexecapi/datatypesintegrationtests/testvarianttypes/mappings/api_2.0_sql_sessions-e8ae2a66-faaa-4f8a-b5bf-c286ffc4e634.json
+++ b/src/test/resources/sqlexecapi/datatypesintegrationtests/testvarianttypes/mappings/api_2.0_sql_sessions-e8ae2a66-faaa-4f8a-b5bf-c286ffc4e634.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-ed7b-1984-90ea-8f21f9a154e4\"}",
+    "body" : "{\"session_id\":\"01f099d9-ed7b-1984-90ea-8f21f9a154e4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4d2dadf2-47f3-4d9c-9f83-6c6429b9aaa1",
       "date" : "Thu, 25 Sep 2025 06:36:11 GMT",

--- a/src/test/resources/sqlexecapi/enablemultiplecatalogsupportintegrationtests/testgetschemaswithnullcatalogmultiplecatalogsupportdisabled/mappings/api_2.0_sql_sessions-a918dfd4-1da2-433f-ad20-dff26a1c05b5.json
+++ b/src/test/resources/sqlexecapi/enablemultiplecatalogsupportintegrationtests/testgetschemaswithnullcatalogmultiplecatalogsupportdisabled/mappings/api_2.0_sql_sessions-a918dfd4-1da2-433f-ad20-dff26a1c05b5.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0a40a-1175-1540-aec7-4e8dcc518dd4\"}",
+    "body" : "{\"session_id\":\"01f0a40a-1175-1540-aec7-4e8dcc518dd4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "455bd621-0ef4-4edd-9a58-fdf7cf741915",
       "date" : "Wed, 8 Oct 2025 05:45:59 GMT",

--- a/src/test/resources/sqlexecapi/enablemultiplecatalogsupportintegrationtests/testgetschemaswithnullcatalogmultiplecatalogsupportenabled/mappings/api_2.0_sql_sessions-c487470c-2f7e-47f4-9304-87cc593989b2.json
+++ b/src/test/resources/sqlexecapi/enablemultiplecatalogsupportintegrationtests/testgetschemaswithnullcatalogmultiplecatalogsupportenabled/mappings/api_2.0_sql_sessions-c487470c-2f7e-47f4-9304-87cc593989b2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0a40a-157e-1bf1-af30-08c61495db43\"}",
+    "body" : "{\"session_id\":\"01f0a40a-157e-1bf1-af30-08c61495db43\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "af87d496-f8b3-41be-9110-5ba1fec57fba",
       "date" : "Wed, 8 Oct 2025 05:46:06 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testaccessingclosedresultset/mappings/api_2.0_sql_sessions-dc0b7a6a-233a-4810-85b4-7b666b2ec76b.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testaccessingclosedresultset/mappings/api_2.0_sql_sessions-dc0b7a6a-233a-4810-85b4-7b666b2ec76b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-0688-1a28-afc1-cbc3e651063f\"}",
+    "body" : "{\"session_id\":\"01f099d9-0688-1a28-afc1-cbc3e651063f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "96be125d-4ed1-4eb0-848b-52319f0c0657",
       "date" : "Thu, 25 Sep 2025 06:29:44 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testcallingunsupportedsqlfeature/mappings/api_2.0_sql_sessions-b7752ddc-59a2-428c-abf5-33e12e0af8a8.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testcallingunsupportedsqlfeature/mappings/api_2.0_sql_sessions-b7752ddc-59a2-428c-abf5-33e12e0af8a8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-2614-1515-bb7c-2ce3328fc6ef\"}",
+    "body" : "{\"session_id\":\"01f099d9-2614-1515-bb7c-2ce3328fc6ef\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "271d8c4d-2ea9-4dcd-87bf-5fac19868bf6",
       "date" : "Thu, 25 Sep 2025 06:30:37 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testcallingunsupportedsqlfeature/mappings/api_2.0_sql_sessions-cfe5ff62-6483-4026-9fe2-d361b7b49ead.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testcallingunsupportedsqlfeature/mappings/api_2.0_sql_sessions-cfe5ff62-6483-4026-9fe2-d361b7b49ead.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-299a-111a-af63-acd32b2c37e3\"}",
+    "body" : "{\"session_id\":\"01f099d9-299a-111a-af63-acd32b2c37e3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bd532bf7-69e5-4bf2-8273-66ebc88ee7d5",
       "date" : "Thu, 25 Sep 2025 06:30:43 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withdelete_throwssqlexception/mappings/api_2.0_sql_sessions-4f78cc51-8cbf-4995-a91e-0c2eb1d7bdff.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withdelete_throwssqlexception/mappings/api_2.0_sql_sessions-4f78cc51-8cbf-4995-a91e-0c2eb1d7bdff.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-4164-104e-a322-81abee745a33\"}",
+    "body" : "{\"session_id\":\"01f10bd5-4164-104e-a322-81abee745a33\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3a31932c-fe28-41fe-ba48-dc01b6706f8d",
       "date" : "Tue, 17 Feb 2026 07:49:57 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withinsert_throwssqlexception/mappings/api_2.0_sql_sessions-84b85efe-3864-4274-81b1-7e0e83fc133b.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withinsert_throwssqlexception/mappings/api_2.0_sql_sessions-84b85efe-3864-4274-81b1-7e0e83fc133b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-36e6-1b17-a990-0c381635c8fa\"}",
+    "body" : "{\"session_id\":\"01f10bd5-36e6-1b17-a990-0c381635c8fa\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "1c240272-abd9-45a1-8ac8-69280849d5fe",
       "date" : "Tue, 17 Feb 2026 07:49:40 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withupdate_throwssqlexception/mappings/api_2.0_sql_sessions-8321e621-3880-4bf7-ad29-b63b9421fb9d.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecutequery_withupdate_throwssqlexception/mappings/api_2.0_sql_sessions-8321e621-3880-4bf7-ad29-b63b9421fb9d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-5097-108b-8fb7-cfc6873a0e27\"}",
+    "body" : "{\"session_id\":\"01f10bd5-5097-108b-8fb7-cfc6873a0e27\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "966c1a00-ee66-486d-a291-fc7fe01c78f2",
       "date" : "Tue, 17 Feb 2026 07:50:23 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecuteupdate_withselect_throwssqlexception/mappings/api_2.0_sql_sessions-7200d45b-d625-4d8a-85b2-9622348e7c3d.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testexecuteupdate_withselect_throwssqlexception/mappings/api_2.0_sql_sessions-7200d45b-d625-4d8a-85b2-9622348e7c3d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-3335-11a0-bd6a-e1a7822ec4f9\"}",
+    "body" : "{\"session_id\":\"01f10bd5-3335-11a0-bd6a-e1a7822ec4f9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "14398697-1771-41c7-9280-598a32c01cb0",
       "date" : "Tue, 17 Feb 2026 07:49:34 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testfailuretoloaddriver/mappings/api_2.0_sql_sessions-a5b25c61-376b-4310-8509-9870c0c80a7b.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testfailuretoloaddriver/mappings/api_2.0_sql_sessions-a5b25c61-376b-4310-8509-9870c0c80a7b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-240b-1eee-87b7-6fb3a3c56e7c\"}",
+    "body" : "{\"session_id\":\"01f099d9-240b-1eee-87b7-6fb3a3c56e7c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "35195034-871d-405c-8525-897de7a2856c",
       "date" : "Thu, 25 Sep 2025 06:30:34 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testinvalidhostname/mappings/api_2.0_sql_sessions-5260a9eb-0838-4b10-a039-00a76d77f174.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testinvalidhostname/mappings/api_2.0_sql_sessions-5260a9eb-0838-4b10-a039-00a76d77f174.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-11a7-11e7-bc22-ffe393ab36ca\"}",
+    "body" : "{\"session_id\":\"01f099d9-11a7-11e7-bc22-ffe393ab36ca\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b3e165ad-109a-4969-a78e-76380fac9031",
       "date" : "Thu, 25 Sep 2025 06:30:03 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testinvalidurl/mappings/api_2.0_sql_sessions-cf747b8b-4c92-4187-ae9a-df3045665a9e.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testinvalidurl/mappings/api_2.0_sql_sessions-cf747b8b-4c92-4187-ae9a-df3045665a9e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-21fb-1f06-b85f-139b461e073c\"}",
+    "body" : "{\"session_id\":\"01f099d9-21fb-1f06-b85f-139b461e073c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "82625ca8-4c78-4327-980f-0dc05bfa5126",
       "date" : "Thu, 25 Sep 2025 06:30:30 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testpreparedstatement_statementmethodswithsql_throwexception/mappings/api_2.0_sql_sessions-7d3264c0-f72c-4fe2-99f3-b6f9907a895f.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testpreparedstatement_statementmethodswithsql_throwexception/mappings/api_2.0_sql_sessions-7d3264c0-f72c-4fe2-99f3-b6f9907a895f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-310d-105c-922d-e291194305bb\"}",
+    "body" : "{\"session_id\":\"01f10bd5-310d-105c-922d-e291194305bb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "1321f197-21d8-4eb3-9f0b-8e118e26ca8d",
       "date" : "Tue, 17 Feb 2026 07:49:30 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testquerysyntaxerror/mappings/api_2.0_sql_sessions-96617860-31af-4ec5-a719-80c91e805f76.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testquerysyntaxerror/mappings/api_2.0_sql_sessions-96617860-31af-4ec5-a719-80c91e805f76.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-1872-144c-925f-c96c0b76f391\"}",
+    "body" : "{\"session_id\":\"01f099d9-1872-144c-925f-c96c0b76f391\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2c6615a2-93ed-4be5-a470-56f4c43d698f",
       "date" : "Thu, 25 Sep 2025 06:30:14 GMT",

--- a/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testquerysyntaxerror/mappings/api_2.0_sql_sessions-a7761b3b-61a8-457b-a179-0905ba30220c.json
+++ b/src/test/resources/sqlexecapi/errorhandlingintegrationtests/testquerysyntaxerror/mappings/api_2.0_sql_sessions-a7761b3b-61a8-457b-a179-0905ba30220c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-1c21-189c-985d-60894eb5ca63\"}",
+    "body" : "{\"session_id\":\"01f099d9-1c21-189c-985d-60894eb5ca63\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3b155ac3-985f-4107-8103-b39d8bcfe1ef",
       "date" : "Thu, 25 Sep 2025 06:30:20 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testcomplexqueryjoins/mappings/api_2.0_sql_sessions-561ebede-9f91-4973-b011-293201bbda56.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testcomplexqueryjoins/mappings/api_2.0_sql_sessions-561ebede-9f91-4973-b011-293201bbda56.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-d187-1aac-a9f5-4d24a5388cff\"}",
+    "body" : "{\"session_id\":\"01f099d8-d187-1aac-a9f5-4d24a5388cff\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b7dd14df-daa6-4e84-98ea-d13256f5c76c",
       "date" : "Thu, 25 Sep 2025 06:28:15 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testcomplexquerysubqueries/mappings/api_2.0_sql_sessions-315944c5-e980-443a-9686-69958d2dd8a0.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testcomplexquerysubqueries/mappings/api_2.0_sql_sessions-315944c5-e980-443a-9686-69958d2dd8a0.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-b968-13af-86a5-a5e53d46ded5\"}",
+    "body" : "{\"session_id\":\"01f099d8-b968-13af-86a5-a5e53d46ded5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c890660e-e24b-4d75-99e8-37144de56c5a",
       "date" : "Thu, 25 Sep 2025 06:27:35 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testcompoundstatements/mappings/api_2.0_sql_sessions-131f5774-82aa-4d45-987a-ecce3f68c4d2.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testcompoundstatements/mappings/api_2.0_sql_sessions-131f5774-82aa-4d45-987a-ecce3f68c4d2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-a017-1fb4-a9cf-ef3dbefbaf35\"}",
+    "body" : "{\"session_id\":\"01f099d8-a017-1fb4-a9cf-ef3dbefbaf35\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8ca4b59c-55fa-4150-ae8e-cd52006ab1c3",
       "date" : "Thu, 25 Sep 2025 06:26:52 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testdeletestatement/mappings/api_2.0_sql_sessions-85775860-c100-4ed3-82ca-b01783d4fdec.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testdeletestatement/mappings/api_2.0_sql_sessions-85775860-c100-4ed3-82ca-b01783d4fdec.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-84a1-1245-9291-ba68ff43dd27\"}",
+    "body" : "{\"session_id\":\"01f099d8-84a1-1245-9291-ba68ff43dd27\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3c1328b8-d12e-4742-b8d8-61c2f105af55",
       "date" : "Thu, 25 Sep 2025 06:26:06 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_deletestatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-959d2320-5fb6-4470-a114-eae46bd9f48d.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_deletestatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-959d2320-5fb6-4470-a114-eae46bd9f48d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-5fc7-1f53-9c48-ad7f9a30d63c\"}",
+    "body" : "{\"session_id\":\"01f10bcb-5fc7-1f53-9c48-ad7f9a30d63c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "431c372e-592a-4822-ba20-c8fb58fde1e4",
       "date" : "Tue, 17 Feb 2026 06:39:13 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_insertstatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-fe5df1d6-9fe3-40d5-996e-436aba9716b2.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_insertstatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-fe5df1d6-9fe3-40d5-996e-436aba9716b2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-9074-1ff9-8002-2ef492bf7043\"}",
+    "body" : "{\"session_id\":\"01f10bcb-9074-1ff9-8002-2ef492bf7043\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "87f13cc9-4020-4b85-b88e-e82d24cee22a",
       "date" : "Tue, 17 Feb 2026 06:40:35 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_selectquery_getresultsetreturnsresultset/mappings/api_2.0_sql_sessions-07431962-da6e-4992-949b-5199b2df14d4.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_selectquery_getresultsetreturnsresultset/mappings/api_2.0_sql_sessions-07431962-da6e-4992-949b-5199b2df14d4.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-8c58-1399-8580-60c4ca949a8a\"}",
+    "body" : "{\"session_id\":\"01f10bcb-8c58-1399-8580-60c4ca949a8a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d0a8f141-6eb4-46d5-a0c7-724b71753996",
       "date" : "Tue, 17 Feb 2026 06:40:28 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_updatestatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-c669ae29-ef0a-431c-9e1f-d67af9bd396a.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecute_updatestatement_getresultsetreturnsnull/mappings/api_2.0_sql_sessions-c669ae29-ef0a-431c-9e1f-d67af9bd396a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-6efb-1ce9-be98-c02b6981c18d\"}",
+    "body" : "{\"session_id\":\"01f10bcb-6efb-1ce9-be98-c02b6981c18d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "7f19bf6e-f868-4f64-b020-ead1c73fa5a4",
       "date" : "Tue, 17 Feb 2026 06:39:39 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecuteasyncstatement/mappings/api_2.0_sql_sessions-0b72fd53-0593-4040-adb9-18ca5ad6518a.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecuteasyncstatement/mappings/api_2.0_sql_sessions-0b72fd53-0593-4040-adb9-18ca5ad6518a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-b253-1aa7-9685-b2705a2e905b\"}",
+    "body" : "{\"session_id\":\"01f099d8-b253-1aa7-9685-b2705a2e905b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b0ca9c10-3710-4cb3-a4c7-f7d670be0778",
       "date" : "Thu, 25 Sep 2025 06:27:23 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testexecuteasyncstatement/mappings/api_2.0_sql_sessions-253be7a4-8121-490e-844b-eabdfd8f46ae.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testexecuteasyncstatement/mappings/api_2.0_sql_sessions-253be7a4-8121-490e-844b-eabdfd8f46ae.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-b5be-1b8d-a666-a82f0f2ba734\"}",
+    "body" : "{\"session_id\":\"01f099d8-b5be-1b8d-a666-a82f0f2ba734\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "85fcd97a-2e5a-4bc8-a7ef-2b730227f6ec",
       "date" : "Thu, 25 Sep 2025 06:27:28 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testgetmoreresults_advancespastresult/mappings/api_2.0_sql_sessions-82313db6-7fef-4438-b9bc-61bbf7efd896.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testgetmoreresults_advancespastresult/mappings/api_2.0_sql_sessions-82313db6-7fef-4438-b9bc-61bbf7efd896.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-7d80-16da-85ad-f07037d300df\"}",
+    "body" : "{\"session_id\":\"01f10bcb-7d80-16da-85ad-f07037d300df\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e2d7ea7c-9f25-48a0-a758-1194db57e0dc",
       "date" : "Tue, 17 Feb 2026 06:40:03 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testgetresultset_afterexecutequery/mappings/api_2.0_sql_sessions-f9c9f541-4f3b-4a8c-8110-547d347e3507.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testgetresultset_afterexecutequery/mappings/api_2.0_sql_sessions-f9c9f541-4f3b-4a8c-8110-547d347e3507.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bcb-9b3e-1d04-a37d-9c91d3d1ba02\"}",
+    "body" : "{\"session_id\":\"01f10bcb-9b3e-1d04-a37d-9c91d3d1ba02\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "34b7c7f0-a837-4aee-8ede-e5965aaf9c45",
       "date" : "Tue, 17 Feb 2026 06:40:53 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testgetupdatecount_afterexecuteupdate/mappings/api_2.0_sql_sessions-19eac59c-0aee-46af-a139-df2d7770315c.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testgetupdatecount_afterexecuteupdate/mappings/api_2.0_sql_sessions-19eac59c-0aee-46af-a139-df2d7770315c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db2-9e41-10a8-b5be-11f7dcb5d2c5\"}",
+    "body" : "{\"session_id\":\"01f12db2-9e41-10a8-b5be-11f7dcb5d2c5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "483751d5-c9d7-4001-a082-823a20a0ecae",
       "date" : "Wed, 1 Apr 2026 10:07:40 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testinsertstatement/mappings/api_2.0_sql_sessions-5141475a-2ac0-4d2d-bc5e-28805dc052da.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testinsertstatement/mappings/api_2.0_sql_sessions-5141475a-2ac0-4d2d-bc5e-28805dc052da.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-c565-1713-b114-a1a196e431e8\"}",
+    "body" : "{\"session_id\":\"01f099d8-c565-1713-b114-a1a196e431e8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "7d41c538-516f-475f-8767-8f0b3712fac9",
       "date" : "Thu, 25 Sep 2025 06:27:55 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testpreparedstatementbatch_clearbatch/mappings/api_2.0_sql_sessions-bb0ab062-16fd-40ad-b88c-65f0326e0a9c.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testpreparedstatementbatch_clearbatch/mappings/api_2.0_sql_sessions-bb0ab062-16fd-40ad-b88c-65f0326e0a9c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db2-9099-1dbf-9db9-b7aa30f83c51\"}",
+    "body" : "{\"session_id\":\"01f12db2-9099-1dbf-9db9-b7aa30f83c51\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3b39c170-7bc2-4e17-b7f4-4a558ca484de",
       "date" : "Wed, 1 Apr 2026 10:07:17 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testpreparedstatementbatch_multipleinserts/mappings/api_2.0_sql_sessions-4a4a38e5-2eda-4bed-9ed8-1321eb30ff29.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testpreparedstatementbatch_multipleinserts/mappings/api_2.0_sql_sessions-4a4a38e5-2eda-4bed-9ed8-1321eb30ff29.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db2-a963-1f60-8602-4baa076fe7b1\"}",
+    "body" : "{\"session_id\":\"01f12db2-a963-1f60-8602-4baa076fe7b1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bc882ee1-52d4-41a8-b8e8-f75d662e3ec9",
       "date" : "Wed, 1 Apr 2026 10:07:59 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_closeandisclosed/mappings/api_2.0_sql_sessions-494b69f1-fa58-422b-ac1e-ce171fd8b909.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_closeandisclosed/mappings/api_2.0_sql_sessions-494b69f1-fa58-422b-ac1e-ce171fd8b909.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-d84b-14ee-856d-95d54ab0ca1b\"}",
+    "body" : "{\"session_id\":\"01f10beb-d84b-14ee-856d-95d54ab0ca1b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "451c98d9-c8bb-4981-a706-0a9607ac12c3",
       "date" : "Tue, 17 Feb 2026 10:31:39 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_enquoteidentifier/mappings/api_2.0_sql_sessions-b4dccb9f-a3e2-45d0-bfa9-f55572cca404.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_enquoteidentifier/mappings/api_2.0_sql_sessions-b4dccb9f-a3e2-45d0-bfa9-f55572cca404.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-47da-1827-a919-0db9944746e4\"}",
+    "body" : "{\"session_id\":\"01f10c18-47da-1827-a919-0db9944746e4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d943fb39-ee2d-449b-920d-fe4fa2203851",
       "date" : "Tue, 17 Feb 2026 15:49:44 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_enquoteliteral/mappings/api_2.0_sql_sessions-346a50a2-cc9d-4452-ac96-5fee835a9654.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_enquoteliteral/mappings/api_2.0_sql_sessions-346a50a2-cc9d-4452-ac96-5fee835a9654.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-45c4-17e8-bb5b-7f150e1a055c\"}",
+    "body" : "{\"session_id\":\"01f10c18-45c4-17e8-bb5b-7f150e1a055c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "af1a2a44-1f0d-4902-b631-937b3e209478",
       "date" : "Tue, 17 Feb 2026 15:49:41 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_fetchdirection/mappings/api_2.0_sql_sessions-2331b5ee-6a0c-4e1f-a350-79e305bbd1b3.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_fetchdirection/mappings/api_2.0_sql_sessions-2331b5ee-6a0c-4e1f-a350-79e305bbd1b3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-49d6-10ae-b78f-9b6faef8fc44\"}",
+    "body" : "{\"session_id\":\"01f10c18-49d6-10ae-b78f-9b6faef8fc44\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "427d1749-a475-4d4f-abcc-10f2decd04a6",
       "date" : "Tue, 17 Feb 2026 15:49:48 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_fetchsize/mappings/api_2.0_sql_sessions-9c218004-4f8e-4655-8a2d-36b43cb8d8a9.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_fetchsize/mappings/api_2.0_sql_sessions-9c218004-4f8e-4655-8a2d-36b43cb8d8a9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-3512-1f03-a176-a33178b9851b\"}",
+    "body" : "{\"session_id\":\"01f10c86-3512-1f03-a176-a33178b9851b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c336a171-f8cb-4008-b360-e51f65b6ee0e",
       "date" : "Wed, 18 Feb 2026 04:56:38 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getconnection/mappings/api_2.0_sql_sessions-e2097e25-c4c3-47b2-b940-971cf7657c39.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getconnection/mappings/api_2.0_sql_sessions-e2097e25-c4c3-47b2-b940-971cf7657c39.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-d65f-1c8c-b255-e8b96afbaec0\"}",
+    "body" : "{\"session_id\":\"01f10beb-d65f-1c8c-b255-e8b96afbaec0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6ae06523-c164-4543-b849-9894ca3cddf4",
       "date" : "Tue, 17 Feb 2026 10:31:36 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getresultsetconcurrency/mappings/api_2.0_sql_sessions-f345c812-45f4-44c0-bb95-790bd55e2807.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getresultsetconcurrency/mappings/api_2.0_sql_sessions-f345c812-45f4-44c0-bb95-790bd55e2807.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-3969-1b99-8f36-2daebc13ffdb\"}",
+    "body" : "{\"session_id\":\"01f10c86-3969-1b99-8f36-2daebc13ffdb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c6052b6f-1434-4afd-91cf-49e2f2bbd3ad",
       "date" : "Wed, 18 Feb 2026 04:56:45 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getresultsettype/mappings/api_2.0_sql_sessions-54382f64-d021-47a6-b37f-1c69188b7968.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_getresultsettype/mappings/api_2.0_sql_sessions-54382f64-d021-47a6-b37f-1c69188b7968.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-3751-1c93-9416-57339cc40c8b\"}",
+    "body" : "{\"session_id\":\"01f10c86-3751-1c93-9416-57339cc40c8b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3592dcc1-0e18-4835-bd85-25dc9d9b7ab0",
       "date" : "Wed, 18 Feb 2026 04:56:41 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_issimpleidentifier/mappings/api_2.0_sql_sessions-444182e1-693f-4eab-b0c2-f4fb809a00c1.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_issimpleidentifier/mappings/api_2.0_sql_sessions-444182e1-693f-4eab-b0c2-f4fb809a00c1.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-4bcd-1297-a276-1fb64b262312\"}",
+    "body" : "{\"session_id\":\"01f10c18-4bcd-1297-a276-1fb64b262312\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "7cadecdd-f81f-4c2b-9a93-423c916bb983",
       "date" : "Tue, 17 Feb 2026 15:49:51 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_maxrows/mappings/api_2.0_sql_sessions-4f4ac327-5d83-40ee-afc4-985bed17f9d2.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_maxrows/mappings/api_2.0_sql_sessions-4f4ac327-5d83-40ee-afc4-985bed17f9d2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-d46d-15fd-9ba4-e08298e19de1\"}",
+    "body" : "{\"session_id\":\"01f10beb-d46d-15fd-9ba4-e08298e19de1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d53533b1-41ee-468c-ab4d-3fabd82d5c6d",
       "date" : "Tue, 17 Feb 2026 10:31:33 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_querytimeout/mappings/api_2.0_sql_sessions-1bae087b-7490-4241-9e9d-beca0e78deb4.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_querytimeout/mappings/api_2.0_sql_sessions-1bae087b-7490-4241-9e9d-beca0e78deb4.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-d259-1f1c-a639-e45ecf652112\"}",
+    "body" : "{\"session_id\":\"01f10beb-d259-1f1c-a639-e45ecf652112\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a15044c2-eb93-4a81-a50c-7e8854645e26",
       "date" : "Tue, 17 Feb 2026 10:31:29 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_warnings/mappings/api_2.0_sql_sessions-d9b51c62-6437-4012-8321-310e0356b3ee.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatement_warnings/mappings/api_2.0_sql_sessions-d9b51c62-6437-4012-8321-310e0356b3ee.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10beb-da3f-1035-90b4-6dad788922e8\"}",
+    "body" : "{\"session_id\":\"01f10beb-da3f-1035-90b4-6dad788922e8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2abbd645-df63-4b53-bca9-77218eb5e4b5",
       "date" : "Tue, 17 Feb 2026 10:31:43 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_clearbatch/mappings/api_2.0_sql_sessions-41b9707b-f839-47ec-a7b5-6c2b9b87eb4f.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_clearbatch/mappings/api_2.0_sql_sessions-41b9707b-f839-47ec-a7b5-6c2b9b87eb4f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-ce6e-1dad-9c69-5bc0cd4acbe0\"}",
+    "body" : "{\"session_id\":\"01f10bd5-ce6e-1dad-9c69-5bc0cd4acbe0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a304c81a-24c4-4d1b-8115-5b74fc240a45",
       "date" : "Tue, 17 Feb 2026 07:53:54 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_emptybatch/mappings/api_2.0_sql_sessions-2fa383b8-7eed-49c1-94db-b1185e6a9b33.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_emptybatch/mappings/api_2.0_sql_sessions-2fa383b8-7eed-49c1-94db-b1185e6a9b33.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-cc3d-1393-85b3-cf1af01c6e56\"}",
+    "body" : "{\"session_id\":\"01f10bd5-cc3d-1393-85b3-cf1af01c6e56\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "5c98dc01-88f6-4831-b62f-d0984367e304",
       "date" : "Tue, 17 Feb 2026 07:53:50 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_mixeddmloperations/mappings/api_2.0_sql_sessions-f36ee740-f939-4d57-8124-812f7d0b07b1.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_mixeddmloperations/mappings/api_2.0_sql_sessions-f36ee740-f939-4d57-8124-812f7d0b07b1.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-f98a-1d64-8e3f-921e1a8f1ec5\"}",
+    "body" : "{\"session_id\":\"01f10bd5-f98a-1d64-8e3f-921e1a8f1ec5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b8c8f052-39a4-4f34-aa19-0032f7e6a797",
       "date" : "Tue, 17 Feb 2026 07:55:06 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_multipleinserts/mappings/api_2.0_sql_sessions-b5a95f08-8dbf-41bc-b0f6-edd6c12f519a.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/teststatementbatch_multipleinserts/mappings/api_2.0_sql_sessions-b5a95f08-8dbf-41bc-b0f6-edd6c12f519a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd5-e6ab-1af5-abe9-3e61bfb04620\"}",
+    "body" : "{\"session_id\":\"01f10bd5-e6ab-1af5-abe9-3e61bfb04620\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3c51f8e9-83b7-46bc-ba84-478d88f6a445",
       "date" : "Tue, 17 Feb 2026 07:54:35 GMT",

--- a/src/test/resources/sqlexecapi/executionintegrationtests/testupdatestatement/mappings/api_2.0_sql_sessions-83593d2b-a857-4c16-8192-2f95fc27b43a.json
+++ b/src/test/resources/sqlexecapi/executionintegrationtests/testupdatestatement/mappings/api_2.0_sql_sessions-83593d2b-a857-4c16-8192-2f95fc27b43a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-922e-13c4-8af2-b4498343b4f4\"}",
+    "body" : "{\"session_id\":\"01f099d8-922e-13c4-8af2-b4498343b4f4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ee486721-5e23-4fe1-a527-35f33f8b5489",
       "date" : "Thu, 25 Sep 2025 06:26:29 GMT",

--- a/src/test/resources/sqlexecapi/m2mauthintegrationtests/testsuccessfulm2mconnection/mappings/api_2.0_sql_sessions-5ab83334-14bd-4bef-8685-3fc530d81413.json
+++ b/src/test/resources/sqlexecapi/m2mauthintegrationtests/testsuccessfulm2mconnection/mappings/api_2.0_sql_sessions-5ab83334-14bd-4bef-8685-3fc530d81413.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01efcd90-a61c-1462-b907-a875b78e92d2\"}",
+    "body" : "{\"session_id\":\"01efcd90-a61c-1462-b907-a875b78e92d2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bd431111-5b97-4f92-9ffc-b884edcd5e88",
       "date" : "Wed, 8 Jan 2025 07:17:41 GMT",

--- a/src/test/resources/sqlexecapi/m2mauthintegrationtests/testsuccessfulm2mconnectionwithsecretfromuserpassword/mappings/api_2.0_sql_sessions-5ab83334-14bd-4bef-8685-3fc530d81413.json
+++ b/src/test/resources/sqlexecapi/m2mauthintegrationtests/testsuccessfulm2mconnectionwithsecretfromuserpassword/mappings/api_2.0_sql_sessions-5ab83334-14bd-4bef-8685-3fc530d81413.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01efcd90-a61c-1462-b907-a875b78e92d2\"}",
+    "body" : "{\"session_id\":\"01efcd90-a61c-1462-b907-a875b78e92d2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bd431111-5b97-4f92-9ffc-b884edcd5e88",
       "date" : "Wed, 8 Jan 2025 07:17:41 GMT",

--- a/src/test/resources/sqlexecapi/m2mprivatekeycredentialsintegrationtests/testsuccessfulm2mprivatekeycredentialsconnection/mappings/api_2.0_sql_sessions-6862353a-33da-4a2b-a025-dca1cb5de5c6.json
+++ b/src/test/resources/sqlexecapi/m2mprivatekeycredentialsintegrationtests/testsuccessfulm2mprivatekeycredentialsconnection/mappings/api_2.0_sql_sessions-6862353a-33da-4a2b-a025-dca1cb5de5c6.json
@@ -11,7 +11,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01efcf24-8334-137e-93e6-84ca3d88c96a\"}",
+    "body" : "{\"session_id\":\"01efcf24-8334-137e-93e6-84ca3d88c96a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bfb3ddd8-9bb9-4d18-860e-7af8569c1262",
       "date" : "Fri, 10 Jan 2025 07:28:39 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testcatalogandschemainformation/mappings/api_2.0_sql_sessions-658a6dd5-ddb8-4faf-82ab-5d7419452794.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testcatalogandschemainformation/mappings/api_2.0_sql_sessions-658a6dd5-ddb8-4faf-82ab-5d7419452794.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-f747-16e2-b654-e71d76b5d16d\"}",
+    "body" : "{\"session_id\":\"01f099d8-f747-16e2-b654-e71d76b5d16d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d0a1c8c3-1340-4783-8951-fa26a57999f0",
       "date" : "Thu, 25 Sep 2025 06:29:18 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testcatalogandschemainformation/mappings/api_2.0_sql_sessions-f3ad9c02-f5fe-49f8-89a8-a69a3be842d3.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testcatalogandschemainformation/mappings/api_2.0_sql_sessions-f3ad9c02-f5fe-49f8-89a8-a69a3be842d3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0da8c-e18f-1d27-a474-e36ac061e8c4\"}",
+    "body" : "{\"session_id\":\"01f0da8c-e18f-1d27-a474-e36ac061e8c4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3fd07e8c-7d1c-9757-828c-254acbfdbf7e",
       "date" : "Tue, 16 Dec 2025 14:38:26 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_allbooleanproperties/mappings/api_2.0_sql_sessions-01842ca1-0808-4641-91a0-4a873819e4ef.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_allbooleanproperties/mappings/api_2.0_sql_sessions-01842ca1-0808-4641-91a0-4a873819e4ef.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-e2d6-176c-ac04-946f2757cea2\"}",
+    "body" : "{\"session_id\":\"01f10c30-e2d6-176c-ac04-946f2757cea2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c68bd7fa-3fd7-40f7-93b4-3bbc3f88bcb9",
       "date" : "Tue, 17 Feb 2026 18:45:52 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_allstringandintproperties/mappings/api_2.0_sql_sessions-59cd8f27-8f5a-49b9-81b0-45135c952642.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_allstringandintproperties/mappings/api_2.0_sql_sessions-59cd8f27-8f5a-49b9-81b0-45135c952642.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-4e8e-1be5-bd64-7204a86aa5df\"}",
+    "body" : "{\"session_id\":\"01f10c31-4e8e-1be5-bd64-7204a86aa5df\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "df6107a7-e5c0-4b66-b96e-b4919ca8f663",
       "date" : "Tue, 17 Feb 2026 18:48:53 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getattributes/mappings/api_2.0_sql_sessions-869ad5a9-cc61-4100-bee6-d98fdea09fe6.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getattributes/mappings/api_2.0_sql_sessions-869ad5a9-cc61-4100-bee6-d98fdea09fe6.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-6f43-1e27-8b8c-ecf79c1a72ad\"}",
+    "body" : "{\"session_id\":\"01f10c31-6f43-1e27-8b8c-ecf79c1a72ad\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "41136297-2f4b-4367-9b17-5119324c2ca5",
       "date" : "Tue, 17 Feb 2026 18:49:48 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getbestrowidentifier/mappings/api_2.0_sql_sessions-0dfeea7e-e236-4ed8-bebd-2ae9a9532890.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getbestrowidentifier/mappings/api_2.0_sql_sessions-0dfeea7e-e236-4ed8-bebd-2ae9a9532890.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-3039-1d6d-82f1-53edb72a8985\"}",
+    "body" : "{\"session_id\":\"01f10c31-3039-1d6d-82f1-53edb72a8985\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ab1aca93-ed0c-49aa-8a2c-fa2edb402606",
       "date" : "Tue, 17 Feb 2026 18:48:02 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getclientinfoproperties/mappings/api_2.0_sql_sessions-9267e2ce-a812-4498-a3f0-81b13df7b461.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getclientinfoproperties/mappings/api_2.0_sql_sessions-9267e2ce-a812-4498-a3f0-81b13df7b461.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-5dfd-1aa4-a209-675d58e8fb8f\"}",
+    "body" : "{\"session_id\":\"01f10c31-5dfd-1aa4-a209-675d58e8fb8f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2be17112-f8a8-45dd-bb38-31714acf54bb",
       "date" : "Tue, 17 Feb 2026 18:49:19 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcolumnprivileges/mappings/api_2.0_sql_sessions-95a960cf-6275-4e66-9dc0-15221b337dd2.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcolumnprivileges/mappings/api_2.0_sql_sessions-95a960cf-6275-4e66-9dc0-15221b337dd2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-fde9-10f1-bc3f-66e3b3a4d449\"}",
+    "body" : "{\"session_id\":\"01f10c30-fde9-10f1-bc3f-66e3b3a4d449\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "f6bcb386-d4b3-404d-be4c-83e78897f4dc",
       "date" : "Tue, 17 Feb 2026 18:46:38 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcolumns/mappings/api_2.0_sql_sessions-5901b258-7a7d-4ae8-81a1-a104aac4e4a2.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcolumns/mappings/api_2.0_sql_sessions-5901b258-7a7d-4ae8-81a1-a104aac4e4a2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-1520-18d4-a85b-22b0206f75da\"}",
+    "body" : "{\"session_id\":\"01f10c19-1520-18d4-a85b-22b0206f75da\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "97e23033-ae3c-4b5d-a356-d35519f277a3",
       "date" : "Tue, 17 Feb 2026 15:55:29 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getconnection/mappings/api_2.0_sql_sessions-43fcf9f4-553f-4e6a-a9c2-c8e9aab5ea52.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getconnection/mappings/api_2.0_sql_sessions-43fcf9f4-553f-4e6a-a9c2-c8e9aab5ea52.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-50d1-14a4-9ffc-908484b083d9\"}",
+    "body" : "{\"session_id\":\"01f10c31-50d1-14a4-9ffc-908484b083d9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "10d10b06-e69c-4bb1-91c6-3760c8acde62",
       "date" : "Tue, 17 Feb 2026 18:48:57 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcrossreference/mappings/api_2.0_sql_sessions-1a286e28-c588-4013-a81e-276cc9df0380.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getcrossreference/mappings/api_2.0_sql_sessions-1a286e28-c588-4013-a81e-276cc9df0380.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-1a70-1edb-9781-c9a776f15707\"}",
+    "body" : "{\"session_id\":\"01f10c31-1a70-1edb-9781-c9a776f15707\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9333c989-0d3b-4c5d-b28c-6a2fd44df290",
       "date" : "Tue, 17 Feb 2026 18:47:26 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getdriverversion/mappings/api_2.0_sql_sessions-7ba92490-19a0-451a-90c8-1bc0c6c00f34.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getdriverversion/mappings/api_2.0_sql_sessions-7ba92490-19a0-451a-90c8-1bc0c6c00f34.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-1ebf-16a5-ac04-dce372f5ad66\"}",
+    "body" : "{\"session_id\":\"01f10c19-1ebf-16a5-ac04-dce372f5ad66\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d9ddcdb1-d0d7-41c3-b8f2-e0445e6a79f4",
       "date" : "Tue, 17 Feb 2026 15:55:45 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getexportedkeys/mappings/api_2.0_sql_sessions-6900fc6e-0e20-4be2-b955-3862cfa804d5.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getexportedkeys/mappings/api_2.0_sql_sessions-6900fc6e-0e20-4be2-b955-3862cfa804d5.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-732b-19d3-bfd9-17ce40cf3a0c\"}",
+    "body" : "{\"session_id\":\"01f10c31-732b-19d3-bfd9-17ce40cf3a0c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "1ae8fcc7-5609-4c0e-9119-948e32400d67",
       "date" : "Tue, 17 Feb 2026 18:49:55 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getfunctioncolumns/mappings/api_2.0_sql_sessions-998ad9fa-55d8-47b1-8c2c-86d01abc4108.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getfunctioncolumns/mappings/api_2.0_sql_sessions-998ad9fa-55d8-47b1-8c2c-86d01abc4108.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-fbef-19b5-a03d-2b4ee24661f0\"}",
+    "body" : "{\"session_id\":\"01f10c30-fbef-19b5-a03d-2b4ee24661f0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8e38a4bb-23a4-4d4c-a73c-9bb9e3c8978f",
       "date" : "Tue, 17 Feb 2026 18:46:35 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getfunctions/mappings/api_2.0_sql_sessions-e86b5de5-e2ac-4df4-b302-b9dbbd79de85.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getfunctions/mappings/api_2.0_sql_sessions-e86b5de5-e2ac-4df4-b302-b9dbbd79de85.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-8295-10e4-aa24-339a140c858e\"}",
+    "body" : "{\"session_id\":\"01f10c31-8295-10e4-aa24-339a140c858e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6006ed02-e5fb-4f07-a26c-dbec97c0156b",
       "date" : "Tue, 17 Feb 2026 18:50:20 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getimportedkeys/mappings/api_2.0_sql_sessions-b4f3f145-2753-447b-a1db-902d93ffcd9e.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getimportedkeys/mappings/api_2.0_sql_sessions-b4f3f145-2753-447b-a1db-902d93ffcd9e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-52c5-17d1-89b1-170628d29403\"}",
+    "body" : "{\"session_id\":\"01f10c31-52c5-17d1-89b1-170628d29403\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "318ddcc2-3817-4a0e-8462-264b6ea10bc8",
       "date" : "Tue, 17 Feb 2026 18:49:00 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getindexinfo/mappings/api_2.0_sql_sessions-3f378028-541d-4181-a236-70c690e0f319.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getindexinfo/mappings/api_2.0_sql_sessions-3f378028-541d-4181-a236-70c690e0f319.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-6396-16ef-a32f-371f53339c74\"}",
+    "body" : "{\"session_id\":\"01f10c31-6396-16ef-a32f-371f53339c74\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "dbceceb4-402e-4e18-bbe0-94262e53c4f3",
       "date" : "Tue, 17 Feb 2026 18:49:28 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprimarykeys/mappings/api_2.0_sql_sessions-145b6e25-f6ed-416a-ac2a-341c9922c484.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprimarykeys/mappings/api_2.0_sql_sessions-145b6e25-f6ed-416a-ac2a-341c9922c484.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-0982-1c9f-afac-16991ea98b7f\"}",
+    "body" : "{\"session_id\":\"01f10c19-0982-1c9f-afac-16991ea98b7f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "67802be1-7338-47ff-8d92-8d9f0cf881f9",
       "date" : "Tue, 17 Feb 2026 15:55:09 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprocedurecolumns/mappings/api_2.0_sql_sessions-5d2fc1ed-dbaf-41a7-8046-7a5b7bf1f036.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprocedurecolumns/mappings/api_2.0_sql_sessions-5d2fc1ed-dbaf-41a7-8046-7a5b7bf1f036.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-6d46-125d-ac4b-cdddf8208c3d\"}",
+    "body" : "{\"session_id\":\"01f10c31-6d46-125d-ac4b-cdddf8208c3d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "1a640d4c-fa76-40c4-8532-c3ff4ae4258b",
       "date" : "Tue, 17 Feb 2026 18:49:45 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprocedures/mappings/api_2.0_sql_sessions-c122725d-7a6f-4b10-b66c-af2a35c920d0.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getprocedures/mappings/api_2.0_sql_sessions-c122725d-7a6f-4b10-b66c-af2a35c920d0.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-713c-1538-9b3e-a7886fd98b6e\"}",
+    "body" : "{\"session_id\":\"01f10c31-713c-1538-9b3e-a7886fd98b6e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d5a10725-82e8-47ed-912b-6f031e00c370",
       "date" : "Tue, 17 Feb 2026 18:49:51 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getpseudocolumns/mappings/api_2.0_sql_sessions-de575989-1f75-4f54-a69d-3441df1e8f90.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getpseudocolumns/mappings/api_2.0_sql_sessions-de575989-1f75-4f54-a69d-3441df1e8f90.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-08fd-126d-a624-62ae4755c690\"}",
+    "body" : "{\"session_id\":\"01f10c31-08fd-126d-a624-62ae4755c690\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "216456a6-1187-4187-90cd-01ff75ebabb0",
       "date" : "Tue, 17 Feb 2026 18:46:56 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getrowidlifetime/mappings/api_2.0_sql_sessions-86655cb6-2e91-4cc5-80db-3c74dab41a00.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getrowidlifetime/mappings/api_2.0_sql_sessions-86655cb6-2e91-4cc5-80db-3c74dab41a00.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-e500-1640-be98-996f19dff5e7\"}",
+    "body" : "{\"session_id\":\"01f10c30-e500-1640-be98-996f19dff5e7\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bd85dd94-3ecc-4308-9d1f-eecb2ba8ec46",
       "date" : "Tue, 17 Feb 2026 18:45:56 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getschemas_withcatalog/mappings/api_2.0_sql_sessions-b53b0e57-2d56-449c-892c-bd13e301e41e.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getschemas_withcatalog/mappings/api_2.0_sql_sessions-b53b0e57-2d56-449c-892c-bd13e301e41e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-9f7b-17ad-b457-0ef9b6a04a2f\"}",
+    "body" : "{\"session_id\":\"01f10c31-9f7b-17ad-b457-0ef9b6a04a2f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "abcef887-674f-420f-94f3-b1b37ed1f6f6",
       "date" : "Tue, 17 Feb 2026 18:51:09 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getsupertables/mappings/api_2.0_sql_sessions-98ff1743-895a-465d-8cb3-fc2ae373f4b5.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getsupertables/mappings/api_2.0_sql_sessions-98ff1743-895a-465d-8cb3-fc2ae373f4b5.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-e702-14d4-a7d2-43d3b1c338ee\"}",
+    "body" : "{\"session_id\":\"01f10c30-e702-14d4-a7d2-43d3b1c338ee\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6c8aa690-de32-469b-aa56-9b47350be5be",
       "date" : "Tue, 17 Feb 2026 18:45:59 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getsupertypes/mappings/api_2.0_sql_sessions-420fa2ae-8e10-4a84-817e-f7a161f2a5c9.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getsupertypes/mappings/api_2.0_sql_sessions-420fa2ae-8e10-4a84-817e-f7a161f2a5c9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-1874-11ff-a9a0-a33bec5a8e00\"}",
+    "body" : "{\"session_id\":\"01f10c31-1874-11ff-a9a0-a33bec5a8e00\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8792a413-5fa5-401b-8fdd-d5d51354e6c0",
       "date" : "Tue, 17 Feb 2026 18:47:22 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettableprivileges/mappings/api_2.0_sql_sessions-70ed0fbd-ac9d-4778-ba37-b935ccb6b051.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettableprivileges/mappings/api_2.0_sql_sessions-70ed0fbd-ac9d-4778-ba37-b935ccb6b051.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c30-f9e2-1762-92a1-461fb1b4b68f\"}",
+    "body" : "{\"session_id\":\"01f10c30-f9e2-1762-92a1-461fb1b4b68f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "55454310-2ad4-4a2e-bd70-221ff2283a2a",
       "date" : "Tue, 17 Feb 2026 18:46:31 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettabletypes/mappings/api_2.0_sql_sessions-1e361a34-aa06-4c95-acd1-36ffe1ec5b5f.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettabletypes/mappings/api_2.0_sql_sessions-1e361a34-aa06-4c95-acd1-36ffe1ec5b5f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-0774-17a9-beb4-a1c1f3cab64d\"}",
+    "body" : "{\"session_id\":\"01f10c19-0774-17a9-beb4-a1c1f3cab64d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d58f5e74-fde8-40c7-ac5e-45220341dad7",
       "date" : "Tue, 17 Feb 2026 15:55:06 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettypeinfo/mappings/api_2.0_sql_sessions-5e85e529-0212-49ef-a95a-9109b854efc8.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_gettypeinfo/mappings/api_2.0_sql_sessions-5e85e529-0212-49ef-a95a-9109b854efc8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-6b48-1a5f-9e65-0d5581df5f21\"}",
+    "body" : "{\"session_id\":\"01f10c31-6b48-1a5f-9e65-0d5581df5f21\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "17c91fff-b3aa-41bd-ad8f-cd7eca909869",
       "date" : "Tue, 17 Feb 2026 18:49:41 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getudts/mappings/api_2.0_sql_sessions-254ab37a-f3d1-44d1-a18b-ebf0c8aea4ec.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getudts/mappings/api_2.0_sql_sessions-254ab37a-f3d1-44d1-a18b-ebf0c8aea4ec.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-605c-1b70-9954-3b6ee1496324\"}",
+    "body" : "{\"session_id\":\"01f10c31-605c-1b70-9954-3b6ee1496324\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "5771a1b6-5266-45e0-92da-490cd8505e3d",
       "date" : "Tue, 17 Feb 2026 18:49:23 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_geturl/mappings/api_2.0_sql_sessions-5e6e9a97-db08-4cd2-add6-b5b088864137.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_geturl/mappings/api_2.0_sql_sessions-5e6e9a97-db08-4cd2-add6-b5b088864137.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-056e-1667-b722-7b9c6e705ed9\"}",
+    "body" : "{\"session_id\":\"01f10c19-056e-1667-b722-7b9c6e705ed9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "318aee5b-e63a-4b5a-826f-a00be8ee374f",
       "date" : "Tue, 17 Feb 2026 15:55:03 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getversioncolumns/mappings/api_2.0_sql_sessions-d5be4741-c61e-417f-afb1-19ccb41cfb85.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_getversioncolumns/mappings/api_2.0_sql_sessions-d5be4741-c61e-417f-afb1-19ccb41cfb85.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-7ad5-19c7-866e-1f60a6931419\"}",
+    "body" : "{\"session_id\":\"01f10c31-7ad5-19c7-866e-1f60a6931419\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9a1daeed-b0bf-4fdd-a368-a046206667b6",
       "date" : "Tue, 17 Feb 2026 18:50:07 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_supportsresultsettype/mappings/api_2.0_sql_sessions-c971f73d-7d86-4571-87ca-34898ef42919.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_supportsresultsettype/mappings/api_2.0_sql_sessions-c971f73d-7d86-4571-87ca-34898ef42919.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-0333-171c-ade1-eb6160bbac26\"}",
+    "body" : "{\"session_id\":\"01f10c19-0333-171c-ade1-eb6160bbac26\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "90a80d03-1732-4c85-8ecd-c6d6d4d39959",
       "date" : "Tue, 17 Feb 2026 15:54:59 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_supportstransactions/mappings/api_2.0_sql_sessions-466c5e37-8578-47f6-8c30-9ab316e99f19.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_supportstransactions/mappings/api_2.0_sql_sessions-466c5e37-8578-47f6-8c30-9ab316e99f19.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c19-1310-16d4-84e2-f2a9b6b86c7c\"}",
+    "body" : "{\"session_id\":\"01f10c19-1310-16d4-84e2-f2a9b6b86c7c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "31bc7d0f-c25a-4c4a-a8fe-1754ba8d3429",
       "date" : "Tue, 17 Feb 2026 15:55:25 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_wrappermethods/mappings/api_2.0_sql_sessions-942560a2-9c32-4805-bde8-d565bbd380e3.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadata_wrappermethods/mappings/api_2.0_sql_sessions-942560a2-9c32-4805-bde8-d565bbd380e3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c31-1671-1000-85c0-7100cae5121c\"}",
+    "body" : "{\"session_id\":\"01f10c31-1671-1000-85c0-7100cae5121c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b2ec0f72-b8a7-4b59-8f9d-d65c88027805",
       "date" : "Tue, 17 Feb 2026 18:47:19 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadataretrieval/mappings/api_2.0_sql_sessions-d9ae97a1-fe50-4913-be0d-3d552c94b0b4.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testdatabasemetadataretrieval/mappings/api_2.0_sql_sessions-d9ae97a1-fe50-4913-be0d-3d552c94b0b4.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-e9aa-1378-bf09-ac56e2256baa\"}",
+    "body" : "{\"session_id\":\"01f099d8-e9aa-1378-bf09-ac56e2256baa\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "394cc122-32bd-4edf-b2b2-ad1e62b4e8a3",
       "date" : "Thu, 25 Sep 2025 06:28:56 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testgetproceduresandprocedurecolumns/mappings/api_2.0_sql_sessions-d197484c-9561-492a-a8ae-353215e29d36.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testgetproceduresandprocedurecolumns/mappings/api_2.0_sql_sessions-d197484c-9561-492a-a8ae-353215e29d36.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f120ae-31c4-1320-bd95-be67b736f93b\"}",
+    "body" : "{\"session_id\":\"01f120ae-31c4-1320-bd95-be67b736f93b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a307e1c8-a573-4618-ad40-1e59fb204fa2",
       "date" : "Sun, 15 Mar 2026 20:33:15 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testgettypeinfo_returnstypecatalog/mappings/api_2.0_sql_sessions-ba9b923d-c19c-4f6a-92d8-9ddc4fe9b11a.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testgettypeinfo_returnstypecatalog/mappings/api_2.0_sql_sessions-ba9b923d-c19c-4f6a-92d8-9ddc4fe9b11a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-242d-1a22-84a5-7b9957602605\"}",
+    "body" : "{\"session_id\":\"01f10bea-242d-1a22-84a5-7b9957602605\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "1bdb28d3-d05b-49a9-9d89-cbdcd187a26a",
       "date" : "Tue, 17 Feb 2026 10:19:28 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testmetadataoperationswithhyphenatedidentifiers/mappings/api_2.0_sql_sessions-44d9b810-a811-4fa9-98c7-e5d54a7f86bf.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testmetadataoperationswithhyphenatedidentifiers/mappings/api_2.0_sql_sessions-44d9b810-a811-4fa9-98c7-e5d54a7f86bf.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f0db1e-4c4f-1069-bebb-47a7fa2118a1\"}",
+    "body" : "{\"session_id\":\"01f0db1e-4c4f-1069-bebb-47a7fa2118a1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e8dff6c8-d81d-9559-8e4f-3ec715281bea",
       "date" : "Wed, 17 Dec 2025 07:59:22 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testparametermetadata_getparametercount/mappings/api_2.0_sql_sessions-fc3aba3e-1c49-4cae-8a09-89e96c69e842.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testparametermetadata_getparametercount/mappings/api_2.0_sql_sessions-fc3aba3e-1c49-4cae-8a09-89e96c69e842.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-2a31-1840-9487-6497d1198aa6\"}",
+    "body" : "{\"session_id\":\"01f10bea-2a31-1840-9487-6497d1198aa6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ddcc9387-bd87-483b-93be-8d5c9d755e24",
       "date" : "Tue, 17 Feb 2026 10:19:38 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testparametermetadata_noparameters/mappings/api_2.0_sql_sessions-96e31ecc-5b94-4d9a-b523-69ee5ce4922d.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testparametermetadata_noparameters/mappings/api_2.0_sql_sessions-96e31ecc-5b94-4d9a-b523-69ee5ce4922d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-52d4-190c-8a8c-d256f0e76e66\"}",
+    "body" : "{\"session_id\":\"01f10bea-52d4-190c-8a8c-d256f0e76e66\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "0461874f-fe8c-409f-8fda-b398a22cb601",
       "date" : "Tue, 17 Feb 2026 10:20:46 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_booleanproperties/mappings/api_2.0_sql_sessions-728fe2b5-2391-465c-8eb6-d60a6b6a9add.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_booleanproperties/mappings/api_2.0_sql_sessions-728fe2b5-2391-465c-8eb6-d60a6b6a9add.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-2680-1b1b-9bfc-c04a34302517\"}",
+    "body" : "{\"session_id\":\"01f10bea-2680-1b1b-9bfc-c04a34302517\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c4f5308c-e562-4115-b082-a8ffabd52a9a",
       "date" : "Tue, 17 Feb 2026 10:19:32 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columnclassname/mappings/api_2.0_sql_sessions-a3bc919b-6546-474f-9b95-beecf572862e.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columnclassname/mappings/api_2.0_sql_sessions-a3bc919b-6546-474f-9b95-beecf572862e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-54cf-1176-a84d-47838b1b197e\"}",
+    "body" : "{\"session_id\":\"01f10bea-54cf-1176-a84d-47838b1b197e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2ad42799-111c-4ccd-a796-6c7e89bb556c",
       "date" : "Tue, 17 Feb 2026 10:20:49 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columndisplaysize/mappings/api_2.0_sql_sessions-4e023f19-6124-4280-86b3-401144418a68.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columndisplaysize/mappings/api_2.0_sql_sessions-4e023f19-6124-4280-86b3-401144418a68.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-584f-19c4-bda9-c9ebf399a0a0\"}",
+    "body" : "{\"session_id\":\"01f10bea-584f-19c4-bda9-c9ebf399a0a0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "66bb1ade-8562-4334-8827-48b2960dfb60",
       "date" : "Tue, 17 Feb 2026 10:20:55 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columnlabelandtypename/mappings/api_2.0_sql_sessions-fdbaf7c7-40e1-48d3-9e29-7b7bcefd7e28.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_columnlabelandtypename/mappings/api_2.0_sql_sessions-fdbaf7c7-40e1-48d3-9e29-7b7bcefd7e28.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-4521-16e5-bff4-88bc8730ceb5\"}",
+    "body" : "{\"session_id\":\"01f10bea-4521-16e5-bff4-88bc8730ceb5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9ed143b2-ea29-4cdd-bdaa-bacaeb1c9e4f",
       "date" : "Tue, 17 Feb 2026 10:20:23 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_multipledatatypes/mappings/api_2.0_sql_sessions-9ed35720-78fe-4d90-aa10-4ea371bc2676.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_multipledatatypes/mappings/api_2.0_sql_sessions-9ed35720-78fe-4d90-aa10-4ea371bc2676.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-48b8-13a4-9173-f82d901201be\"}",
+    "body" : "{\"session_id\":\"01f10bea-48b8-13a4-9173-f82d901201be\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6b9ef058-1c52-4005-99bf-93bef177c73a",
       "date" : "Tue, 17 Feb 2026 10:20:29 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_precisionandscale/mappings/api_2.0_sql_sessions-2d9f28b2-94fa-46f8-b781-7eb8e4901732.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_precisionandscale/mappings/api_2.0_sql_sessions-2d9f28b2-94fa-46f8-b781-7eb8e4901732.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-392a-1ded-a6ba-7bcccb03a9c0\"}",
+    "body" : "{\"session_id\":\"01f10bea-392a-1ded-a6ba-7bcccb03a9c0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3bc4b352-fa74-4dc5-9c8c-51d18391ce79",
       "date" : "Tue, 17 Feb 2026 10:20:03 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_signedproperty/mappings/api_2.0_sql_sessions-f6e6ee87-34c5-4165-ab8b-cd5770778019.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadata_signedproperty/mappings/api_2.0_sql_sessions-f6e6ee87-34c5-4165-ab8b-cd5770778019.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bea-2c59-1751-bad2-a246a6b5c64a\"}",
+    "body" : "{\"session_id\":\"01f10bea-2c59-1751-bad2-a246a6b5c64a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "75dc7107-831a-4eca-9b8a-60b06a9e43c4",
       "date" : "Tue, 17 Feb 2026 10:19:41 GMT",

--- a/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadataretrieval/mappings/api_2.0_sql_sessions-e510a85b-4543-4f9e-ab4e-ec6a7198efad.json
+++ b/src/test/resources/sqlexecapi/metadataintegrationtests/testresultsetmetadataretrieval/mappings/api_2.0_sql_sessions-e510a85b-4543-4f9e-ab4e-ec6a7198efad.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-ebd1-1a09-8e84-fada7a718dd5\"}",
+    "body" : "{\"session_id\":\"01f099d8-ebd1-1a09-8e84-fada7a718dd5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "574fbf06-cef4-449b-8333-d349e9ec3d00",
       "date" : "Thu, 25 Sep 2025 06:28:59 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testcleanup_dropschemaandtables/mappings/api_2.0_sql_sessions-229daa63-feb4-4d3d-ad25-55aaa08cc603.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testcleanup_dropschemaandtables/mappings/api_2.0_sql_sessions-229daa63-feb4-4d3d-ad25-55aaa08cc603.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-90dc-1833-8e95-bcc314d90290\"}",
+    "body" : "{\"session_id\":\"01f13244-90dc-1833-8e95-bcc314d90290\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3ec68e5a-1769-47d4-8e0b-98d2a64426f4",
       "date" : "Tue, 7 Apr 2026 05:42:29 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_fullyspecified/mappings/api_2.0_sql_sessions-c0f48ff0-2ec0-4aa3-9623-40a08c9cd0a9.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_fullyspecified/mappings/api_2.0_sql_sessions-c0f48ff0-2ec0-4aa3-9623-40a08c9cd0a9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-893e-1704-bf98-538047494879\"}",
+    "body" : "{\"session_id\":\"01f13244-893e-1704-bf98-538047494879\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "fa47c5b2-47ac-463b-868d-bec514a83a8b",
       "date" : "Tue, 7 Apr 2026 05:42:16 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullcatalogsexplicitschemas/mappings/api_2.0_sql_sessions-d2710a1e-d043-4c21-933e-f60a217e271e.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullcatalogsexplicitschemas/mappings/api_2.0_sql_sessions-d2710a1e-d043-4c21-933e-f60a217e271e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-8014-1cd9-bb13-7599125bbca1\"}",
+    "body" : "{\"session_id\":\"01f13244-8014-1cd9-bb13-7599125bbca1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "30b05042-1447-4af1-b3bd-391a8e5f6efb",
       "date" : "Tue, 7 Apr 2026 05:42:01 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullcatalogsnullschemas/mappings/api_2.0_sql_sessions-bf490a64-aaa8-42c0-a5f9-d95bee881b63.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullcatalogsnullschemas/mappings/api_2.0_sql_sessions-bf490a64-aaa8-42c0-a5f9-d95bee881b63.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-7746-1975-b690-bf10f5da98b2\"}",
+    "body" : "{\"session_id\":\"01f13244-7746-1975-b690-bf10f5da98b2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c290dc63-64dc-43cb-890f-32e112370ed0",
       "date" : "Tue, 7 Apr 2026 05:41:46 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullforeigntablereturnsempty/mappings/api_2.0_sql_sessions-5852ad93-bb20-4968-be15-71c3607e3061.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetcrossreference_nullforeigntablereturnsempty/mappings/api_2.0_sql_sessions-5852ad93-bb20-4968-be15-71c3607e3061.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-8cd6-1677-9adb-e6463f2bb9c1\"}",
+    "body" : "{\"session_id\":\"01f13244-8cd6-1677-9adb-e6463f2bb9c1\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "88a0d9cc-b543-469f-891e-1dbb150ea79b",
       "date" : "Tue, 7 Apr 2026 05:42:22 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetimportedkeys_fullyspecified/mappings/api_2.0_sql_sessions-4630474d-1b6b-4a14-81a6-1a781ccb0e73.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetimportedkeys_fullyspecified/mappings/api_2.0_sql_sessions-4630474d-1b6b-4a14-81a6-1a781ccb0e73.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-71d5-1dd1-8ab7-19108b54750c\"}",
+    "body" : "{\"session_id\":\"01f13244-71d5-1dd1-8ab7-19108b54750c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "93629673-9130-4ec1-a522-adadb2d4d243",
       "date" : "Tue, 7 Apr 2026 05:41:37 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetimportedkeys_nullcatalognullschema/mappings/api_2.0_sql_sessions-4f54e9bb-995d-4c33-a9b9-b81de5025c4b.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetimportedkeys_nullcatalognullschema/mappings/api_2.0_sql_sessions-4f54e9bb-995d-4c33-a9b9-b81de5025c4b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-6a84-1036-99a5-6e19e75ca3bb\"}",
+    "body" : "{\"session_id\":\"01f13244-6a84-1036-99a5-6e19e75ca3bb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "58744da1-66d5-4737-9eac-937a0198881e",
       "date" : "Tue, 7 Apr 2026 05:41:25 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_fullyspecified/mappings/api_2.0_sql_sessions-03fca804-1d3c-41b6-bcac-373a49ac2404.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_fullyspecified/mappings/api_2.0_sql_sessions-03fca804-1d3c-41b6-bcac-373a49ac2404.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-62f3-10df-954e-734551109859\"}",
+    "body" : "{\"session_id\":\"01f13244-62f3-10df-954e-734551109859\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2d1a122f-2d83-4d75-be64-9bb15c3399d6",
       "date" : "Tue, 7 Apr 2026 05:41:12 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_nullcatalogexplicitschema/mappings/api_2.0_sql_sessions-dd43b43f-8a9e-4cd8-b5e0-447b27ef846d.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_nullcatalogexplicitschema/mappings/api_2.0_sql_sessions-dd43b43f-8a9e-4cd8-b5e0-447b27ef846d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-5c5d-1aab-af13-5efdc0ae3a5d\"}",
+    "body" : "{\"session_id\":\"01f13244-5c5d-1aab-af13-5efdc0ae3a5d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "554aedd3-79d4-4fd1-a828-13e8c80724b7",
       "date" : "Tue, 7 Apr 2026 05:41:01 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_nullcatalognullschema/mappings/api_2.0_sql_sessions-27ef1f59-a189-45bf-89d6-e5f0a90b28f5.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testgetprimarykeys_nullcatalognullschema/mappings/api_2.0_sql_sessions-27ef1f59-a189-45bf-89d6-e5f0a90b28f5.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-54cb-1aa9-8e26-41475de47a45\"}",
+    "body" : "{\"session_id\":\"01f13244-54cb-1aa9-8e26-41475de47a45\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9971391f-554a-47d3-9b26-96a5fc6c5c87",
       "date" : "Tue, 7 Apr 2026 05:40:48 GMT",

--- a/src/test/resources/sqlexecapi/metadatanullresolutiontests/testsetup_createschemaandtables/mappings/api_2.0_sql_sessions-3d739611-cabd-4d18-9e67-b7681df84211.json
+++ b/src/test/resources/sqlexecapi/metadatanullresolutiontests/testsetup_createschemaandtables/mappings/api_2.0_sql_sessions-3d739611-cabd-4d18-9e67-b7681df84211.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f13244-4b8a-1ad1-9e09-8bb1820d2019\"}",
+    "body" : "{\"session_id\":\"01f13244-4b8a-1ad1-9e09-8bb1820d2019\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c9fff6ac-42e4-40b2-8e8c-a6299dd45694",
       "date" : "Tue, 7 Apr 2026 05:40:33 GMT",

--- a/src/test/resources/sqlexecapi/multichunkexecutionintegrationtests/testmultichunkselect/mappings/api_2.0_sql_sessions-57f03ab4-13d4-45f0-9687-0a9337fccfa6.json
+++ b/src/test/resources/sqlexecapi/multichunkexecutionintegrationtests/testmultichunkselect/mappings/api_2.0_sql_sessions-57f03ab4-13d4-45f0-9687-0a9337fccfa6.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099db-0947-1369-b61c-e6e422eb1c1c\"}",
+    "body" : "{\"session_id\":\"01f099db-0947-1369-b61c-e6e422eb1c1c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d8a33a2b-2aa2-4432-9dab-58e90e248715",
       "date" : "Thu, 25 Sep 2025 06:44:08 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_caseinsensitive/mappings/api_2.0_sql_sessions-263496dd-ccf0-41c0-90b1-cba112a5a45f.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_caseinsensitive/mappings/api_2.0_sql_sessions-263496dd-ccf0-41c0-90b1-cba112a5a45f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-6118-1bb4-ad22-b4f1ad9b2de4\"}",
+    "body" : "{\"session_id\":\"01f10bd7-6118-1bb4-ad22-b4f1ad9b2de4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "45b9e889-64c9-4700-968a-f99a3b98cb72",
       "date" : "Tue, 17 Feb 2026 08:05:10 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_caseinsensitive/mappings/api_2.0_sql_sessions-f7049fcb-5479-4cd1-952b-b97ee41a8eff.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_caseinsensitive/mappings/api_2.0_sql_sessions-f7049fcb-5479-4cd1-952b-b97ee41a8eff.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-6288-1a8c-9a52-1abb2e5df6c8\"}",
+    "body" : "{\"session_id\":\"01f10bd7-6288-1a8c-9a52-1abb2e5df6c8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "67d75189-57c7-41fd-b0c9-e6d4ccdaeb96",
       "date" : "Tue, 17 Feb 2026 08:05:12 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_deletereturnsresultset/mappings/api_2.0_sql_sessions-58d245cd-0078-4f4a-8f52-5663cc1fc623.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_deletereturnsresultset/mappings/api_2.0_sql_sessions-58d245cd-0078-4f4a-8f52-5663cc1fc623.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-16ef-1d6f-8a65-2a182865e66d\"}",
+    "body" : "{\"session_id\":\"01f10bd7-16ef-1d6f-8a65-2a182865e66d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "653dff9d-52e3-486a-8deb-25506e95da04",
       "date" : "Tue, 17 Feb 2026 08:03:05 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_deletereturnsresultset/mappings/api_2.0_sql_sessions-824059c2-ae27-40c4-b128-a1eb467e1420.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_deletereturnsresultset/mappings/api_2.0_sql_sessions-824059c2-ae27-40c4-b128-a1eb467e1420.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-1852-139f-8f6e-5a7d7c2d7ace\"}",
+    "body" : "{\"session_id\":\"01f10bd7-1852-139f-8f6e-5a7d7c2d7ace\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ba2707e7-f697-4be6-aac3-d8709e37fa39",
       "date" : "Tue, 17 Feb 2026 08:03:07 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_executequerysucceedswithinsert/mappings/api_2.0_sql_sessions-05521278-1973-428e-b83d-3a3349635704.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_executequerysucceedswithinsert/mappings/api_2.0_sql_sessions-05521278-1973-428e-b83d-3a3349635704.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-80f3-148a-9907-61373459201c\"}",
+    "body" : "{\"session_id\":\"01f10bd7-80f3-148a-9907-61373459201c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a2ff1d9f-c5b4-4556-bbd2-fbaeac8fa1a2",
       "date" : "Tue, 17 Feb 2026 08:06:03 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_executequerysucceedswithinsert/mappings/api_2.0_sql_sessions-b019c115-dc48-4032-b4a9-fe130a519fe9.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_executequerysucceedswithinsert/mappings/api_2.0_sql_sessions-b019c115-dc48-4032-b4a9-fe130a519fe9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-823c-1aa6-9ab6-710cd34d10b4\"}",
+    "body" : "{\"session_id\":\"01f10bd7-823c-1aa6-9ab6-710cd34d10b4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2ee14ecb-cf85-4cd4-a306-e1967583c5d4",
       "date" : "Tue, 17 Feb 2026 08:06:05 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_insertreturnsresultset/mappings/api_2.0_sql_sessions-94ddcabf-5dab-46c4-8c28-140fbab2a2ee.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_insertreturnsresultset/mappings/api_2.0_sql_sessions-94ddcabf-5dab-46c4-8c28-140fbab2a2ee.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-7539-1639-a237-a7b5ce956e02\"}",
+    "body" : "{\"session_id\":\"01f10bd7-7539-1639-a237-a7b5ce956e02\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "0e4d5405-3a20-49c3-b399-f0e75e66b25c",
       "date" : "Tue, 17 Feb 2026 08:05:43 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_insertreturnsresultset/mappings/api_2.0_sql_sessions-dcf03834-d0bb-49f5-865e-b9e4bfade521.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_insertreturnsresultset/mappings/api_2.0_sql_sessions-dcf03834-d0bb-49f5-865e-b9e4bfade521.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-73d6-146a-b370-288da7e0278d\"}",
+    "body" : "{\"session_id\":\"01f10bd7-73d6-146a-b370-288da7e0278d\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "60ed9a8d-41f5-45b3-b598-9f07f9610abc",
       "date" : "Tue, 17 Feb 2026 08:05:41 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_multipleprefixes/mappings/api_2.0_sql_sessions-a5c1cf00-d363-4ab6-8945-6a85db048af8.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_multipleprefixes/mappings/api_2.0_sql_sessions-a5c1cf00-d363-4ab6-8945-6a85db048af8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-2af5-1c50-8396-bc2c1ddc700e\"}",
+    "body" : "{\"session_id\":\"01f10bd7-2af5-1c50-8396-bc2c1ddc700e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "20b1014c-2fff-4161-bde1-70e0dc03a759",
       "date" : "Tue, 17 Feb 2026 08:03:39 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_multipleprefixes/mappings/api_2.0_sql_sessions-a9ae2519-84fa-4c76-a3d1-cf14cb095610.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_multipleprefixes/mappings/api_2.0_sql_sessions-a9ae2519-84fa-4c76-a3d1-cf14cb095610.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-2c4d-1b56-ab81-fb61bbe116dc\"}",
+    "body" : "{\"session_id\":\"01f10bd7-2c4d-1b56-ab81-fb61bbe116dc\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c9741ce1-1ec5-4293-ac73-94a96332a1b1",
       "date" : "Tue, 17 Feb 2026 08:03:41 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_selectstillreturnsresultset/mappings/api_2.0_sql_sessions-688666ab-c97e-40d7-af41-d0ecedbceed4.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_selectstillreturnsresultset/mappings/api_2.0_sql_sessions-688666ab-c97e-40d7-af41-d0ecedbceed4.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-6e16-19ba-b792-c030f753b9e9\"}",
+    "body" : "{\"session_id\":\"01f10bd7-6e16-19ba-b792-c030f753b9e9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "95fd86c7-8a76-43a7-b286-8fa9bcec912c",
       "date" : "Tue, 17 Feb 2026 08:05:31 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_selectstillreturnsresultset/mappings/api_2.0_sql_sessions-aa2057e9-36a2-43e5-89f7-790f469c6147.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_selectstillreturnsresultset/mappings/api_2.0_sql_sessions-aa2057e9-36a2-43e5-89f7-790f469c6147.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-6f79-1a06-a9b0-40dc3c37293b\"}",
+    "body" : "{\"session_id\":\"01f10bd7-6f79-1a06-a9b0-40dc3c37293b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b2c816ea-ecf4-46af-83bb-eaa0908e6da8",
       "date" : "Tue, 17 Feb 2026 08:05:34 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_updatereturnsresultset/mappings/api_2.0_sql_sessions-bf9485b3-6779-4195-acdb-c948eb8c4f11.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_updatereturnsresultset/mappings/api_2.0_sql_sessions-bf9485b3-6779-4195-acdb-c948eb8c4f11.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-42fe-1f37-b2dc-ef74e118d369\"}",
+    "body" : "{\"session_id\":\"01f10bd7-42fe-1f37-b2dc-ef74e118d369\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6fd67daf-09a6-4114-87c0-91a811c1bce2",
       "date" : "Tue, 17 Feb 2026 08:04:19 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_updatereturnsresultset/mappings/api_2.0_sql_sessions-eab9abe2-c778-4a3d-9215-d6c5cca478c8.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testconfigured_updatereturnsresultset/mappings/api_2.0_sql_sessions-eab9abe2-c778-4a3d-9215-d6c5cca478c8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-4468-1c4d-925f-ba3134101ff2\"}",
+    "body" : "{\"session_id\":\"01f10bd7-4468-1c4d-925f-ba3134101ff2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "011442f8-d7be-4b0d-ace1-7e9014b2fa99",
       "date" : "Tue, 17 Feb 2026 08:04:21 GMT",

--- a/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testdefault_insertreturnsnoresultset/mappings/api_2.0_sql_sessions-99ea9586-a785-4030-8eb7-cfb470a34ef9.json
+++ b/src/test/resources/sqlexecapi/nonrowcountqueryprefixesintegrationtests/testdefault_insertreturnsnoresultset/mappings/api_2.0_sql_sessions-99ea9586-a785-4030-8eb7-cfb470a34ef9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bd7-567d-1d4f-9833-1c15b23b9351\"}",
+    "body" : "{\"session_id\":\"01f10bd7-567d-1d4f-9833-1c15b23b9351\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e05cbf47-c8e9-49de-8615-8c9ce1e7c56b",
       "date" : "Tue, 17 Feb 2026 08:04:52 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testclearparameters/mappings/api_2.0_sql_sessions-dbb6c000-1bf1-4b78-8d56-c83f9de21a6c.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testclearparameters/mappings/api_2.0_sql_sessions-dbb6c000-1bf1-4b78-8d56-c83f9de21a6c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-f9c1-1947-8381-7eefa44572ac\"}",
+    "body" : "{\"session_id\":\"01f12daf-f9c1-1947-8381-7eefa44572ac\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c0c90a60-2fe9-444f-8d7a-7f02481e6e51",
       "date" : "Wed, 1 Apr 2026 09:48:45 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testgetmetadata_noresultset/mappings/api_2.0_sql_sessions-1bec8707-140d-4511-90f1-4f8aad53b0d9.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testgetmetadata_noresultset/mappings/api_2.0_sql_sessions-1bec8707-140d-4511-90f1-4f8aad53b0d9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d7-97b1-1ea2-a2b1-0a390a80a0f2\"}",
+    "body" : "{\"session_id\":\"01f099d7-97b1-1ea2-a2b1-0a390a80a0f2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "07a5daf9-471e-9d80-87bb-5f8135251ff0",
       "date" : "Thu, 25 Sep 2025 06:19:29 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testhandlingnullvalueswithpreparedstatement/mappings/api_2.0_sql_sessions-aa8dca6e-1cef-4e76-9ce5-be8edcf98f15.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testhandlingnullvalueswithpreparedstatement/mappings/api_2.0_sql_sessions-aa8dca6e-1cef-4e76-9ce5-be8edcf98f15.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-c3c1-17d3-98fc-8348508c14d6\"}",
+    "body" : "{\"session_id\":\"01f12daf-c3c1-17d3-98fc-8348508c14d6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e87a6aa4-a980-406a-b1a1-1550dc180f16",
       "date" : "Wed, 1 Apr 2026 09:47:15 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testparameterbindinginpreparedstatement/mappings/api_2.0_sql_sessions-8aadda60-6cc9-4822-9189-6228d672b84f.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testparameterbindinginpreparedstatement/mappings/api_2.0_sql_sessions-8aadda60-6cc9-4822-9189-6228d672b84f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-06a3-157b-b26a-fea7f7dab4ae\"}",
+    "body" : "{\"session_id\":\"01f12db0-06a3-157b-b26a-fea7f7dab4ae\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "147c0e7a-5cd5-406d-9f6e-0470141a95e2",
       "date" : "Wed, 1 Apr 2026 09:49:07 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatement_getmetadata_forselect/mappings/api_2.0_sql_sessions-ca07fb6c-6cbf-4ca2-b754-7d0e1ac0f0ac.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatement_getmetadata_forselect/mappings/api_2.0_sql_sessions-ca07fb6c-6cbf-4ca2-b754-7d0e1ac0f0ac.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bec-08f4-128d-9bc7-f27d84ca1ca0\"}",
+    "body" : "{\"session_id\":\"01f10bec-08f4-128d-9bc7-f27d84ca1ca0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d3f62f0f-9df9-4185-9a1c-2150277d16d1",
       "date" : "Tue, 17 Feb 2026 10:33:01 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementcomplexqueryexecution/mappings/api_2.0_sql_sessions-68f82a8b-5c61-4a12-8eae-c0911ea81d52.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementcomplexqueryexecution/mappings/api_2.0_sql_sessions-68f82a8b-5c61-4a12-8eae-c0911ea81d52.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-a585-1463-9710-dd3f51019e22\"}",
+    "body" : "{\"session_id\":\"01f12daf-a585-1463-9710-dd3f51019e22\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ea437994-5454-4d52-8dab-16fcdce7dddd",
       "date" : "Wed, 1 Apr 2026 09:46:24 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementexecution/mappings/api_2.0_sql_sessions-be0356c0-df64-448f-af6a-ee36fd161c3c.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementexecution/mappings/api_2.0_sql_sessions-be0356c0-df64-448f-af6a-ee36fd161c3c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d8-28bf-115f-b012-28525246d415\"}",
+    "body" : "{\"session_id\":\"01f099d8-28bf-115f-b012-28525246d415\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "0bfb6f7b-ac65-45d2-b85a-395ed963e140",
       "date" : "Thu, 25 Sep 2025 06:23:32 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation1/mappings/api_2.0_sql_sessions-21ec555e-3dfb-4dee-b5cf-4a0def46257a.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation1/mappings/api_2.0_sql_sessions-21ec555e-3dfb-4dee-b5cf-4a0def46257a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db9-4a45-1dfd-81e5-39f0c3162e5a\"}",
+    "body" : "{\"session_id\":\"01f12db9-4a45-1dfd-81e5-39f0c3162e5a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "39ca8dfb-b880-45fe-a52a-c0d0a9104b6f",
       "date" : "Wed, 1 Apr 2026 10:55:26 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation1/mappings/api_2.0_sql_sessions-dd0536ca-10b3-4cfb-b510-328f3662fea2.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation1/mappings/api_2.0_sql_sessions-dd0536ca-10b3-4cfb-b510-328f3662fea2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db9-48c8-13e8-9db4-a795d62cb830\"}",
+    "body" : "{\"session_id\":\"01f12db9-48c8-13e8-9db4-a795d62cb830\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "77a28d61-ccd8-43c3-9c6d-4be1b7a5cce5",
       "date" : "Wed, 1 Apr 2026 10:55:23 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation2/mappings/api_2.0_sql_sessions-8dd728b4-842d-42f0-9d94-8c14b318d0ed.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation2/mappings/api_2.0_sql_sessions-8dd728b4-842d-42f0-9d94-8c14b318d0ed.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db9-70de-11bc-a197-13fee8e73d48\"}",
+    "body" : "{\"session_id\":\"01f12db9-70de-11bc-a197-13fee8e73d48\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "424bf2f6-27fc-435d-93f9-ae9441072067",
       "date" : "Wed, 1 Apr 2026 10:56:31 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation2/mappings/api_2.0_sql_sessions-ed62cda0-91b4-4b76-b0d1-a9e37c0bafa7.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testpreparedstatementsetbytesvalidarray.invocation2/mappings/api_2.0_sql_sessions-ed62cda0-91b4-4b76-b0d1-a9e37c0bafa7.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db9-6f84-1e35-bf22-1ed2d6b0281c\"}",
+    "body" : "{\"session_id\":\"01f12db9-6f84-1e35-bf22-1ed2d6b0281c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a5d4e0f3-cfce-4e09-8ed3-0714520c0cb5",
       "date" : "Wed, 1 Apr 2026 10:56:28 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetbigdecimal/mappings/api_2.0_sql_sessions-b60e48bd-b13e-4615-8b98-5790cc9851c3.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetbigdecimal/mappings/api_2.0_sql_sessions-b60e48bd-b13e-4615-8b98-5790cc9851c3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-b387-1fbc-999f-28cc8a179142\"}",
+    "body" : "{\"session_id\":\"01f12db0-b387-1fbc-999f-28cc8a179142\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "10ad9394-bf60-44f7-9f5f-0ba698345c43",
       "date" : "Wed, 1 Apr 2026 09:53:57 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetboolean/mappings/api_2.0_sql_sessions-27f410f0-8a8e-4523-abf6-2042da2c3259.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetboolean/mappings/api_2.0_sql_sessions-27f410f0-8a8e-4523-abf6-2042da2c3259.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-b72e-17d2-906f-b016c0550e91\"}",
+    "body" : "{\"session_id\":\"01f12daf-b72e-17d2-906f-b016c0550e91\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "971de4d5-608f-47fc-87b6-3116e4f2a3cb",
       "date" : "Wed, 1 Apr 2026 09:46:54 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetdate/mappings/api_2.0_sql_sessions-aa50f15a-4d8e-4743-a77f-16a93192c130.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetdate/mappings/api_2.0_sql_sessions-aa50f15a-4d8e-4743-a77f-16a93192c130.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f154e2-e74b-131e-bdf5-198f31c91ac6\"}",
+    "body" : "{\"session_id\":\"01f154e2-e74b-131e-bdf5-198f31c91ac6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "234c72fa-3b8c-4315-b634-63852d86970e",
       "date" : "Thu, 21 May 2026 07:01:34 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetdouble/mappings/api_2.0_sql_sessions-6bb8f65f-ee7b-4924-8139-001ea8591d0b.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetdouble/mappings/api_2.0_sql_sessions-6bb8f65f-ee7b-4924-8139-001ea8591d0b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-158c-1717-bfcd-db42001e3d98\"}",
+    "body" : "{\"session_id\":\"01f12db0-158c-1717-bfcd-db42001e3d98\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "31f65cac-e004-42df-ae8d-f58b2a7c99c4",
       "date" : "Wed, 1 Apr 2026 09:49:32 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetfloat/mappings/api_2.0_sql_sessions-f13dbee6-c4c8-4154-9aea-2bc17ab59c75.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetfloat/mappings/api_2.0_sql_sessions-f13dbee6-c4c8-4154-9aea-2bc17ab59c75.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-c02b-101c-b2ce-5a510ec24dc4\"}",
+    "body" : "{\"session_id\":\"01f12db0-c02b-101c-b2ce-5a510ec24dc4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9fbe1268-e421-48a8-855a-d357fea86a3b",
       "date" : "Wed, 1 Apr 2026 09:54:18 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetlong/mappings/api_2.0_sql_sessions-5768a737-89aa-4333-be40-8da94cb4a296.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetlong/mappings/api_2.0_sql_sessions-5768a737-89aa-4333-be40-8da94cb4a296.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-a6a2-1160-96c0-3e9b073e83f6\"}",
+    "body" : "{\"session_id\":\"01f12db0-a6a2-1160-96c0-3e9b073e83f6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "7acae264-2a9f-4d18-be54-7e7548fd1b89",
       "date" : "Wed, 1 Apr 2026 09:53:35 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetnull_withinttype/mappings/api_2.0_sql_sessions-df859a0e-d339-43ee-9c7f-753c64564d79.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetnull_withinttype/mappings/api_2.0_sql_sessions-df859a0e-d339-43ee-9c7f-753c64564d79.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-ed29-1f45-9f39-35bd9ec50817\"}",
+    "body" : "{\"session_id\":\"01f12daf-ed29-1f45-9f39-35bd9ec50817\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "fbc6637b-db8f-4578-a88b-4532737c9270",
       "date" : "Wed, 1 Apr 2026 09:48:24 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation1/mappings/api_2.0_sql_sessions-14fe8870-da98-422e-a0fd-9071c33ea5ab.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation1/mappings/api_2.0_sql_sessions-14fe8870-da98-422e-a0fd-9071c33ea5ab.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-2d0f-1914-82e9-a5de6b7458d4\"}",
+    "body" : "{\"session_id\":\"01f12db0-2d0f-1914-82e9-a5de6b7458d4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d89d8104-5c8d-439c-9c95-b16548280bcd",
       "date" : "Wed, 1 Apr 2026 09:50:11 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation2/mappings/api_2.0_sql_sessions-2c3f3b33-7343-4f90-8779-8e1e4a726cf3.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation2/mappings/api_2.0_sql_sessions-2c3f3b33-7343-4f90-8779-8e1e4a726cf3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-3c00-109e-a581-f0081bac44f9\"}",
+    "body" : "{\"session_id\":\"01f12db0-3c00-109e-a581-f0081bac44f9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ae30fee1-33f3-49e8-9c06-632f4a8f7221",
       "date" : "Wed, 1 Apr 2026 09:50:36 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation3/mappings/api_2.0_sql_sessions-a809cccd-ce72-40f7-ba03-eff84be6a3d0.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation3/mappings/api_2.0_sql_sessions-a809cccd-ce72-40f7-ba03-eff84be6a3d0.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-48af-1fed-b3fb-19d720886d16\"}",
+    "body" : "{\"session_id\":\"01f12db0-48af-1fed-b3fb-19d720886d16\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "651f6d98-f6e4-4d76-b309-f6837570323e",
       "date" : "Wed, 1 Apr 2026 09:50:58 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation4/mappings/api_2.0_sql_sessions-abc2044a-3dbd-49d6-8190-40b62525b370.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation4/mappings/api_2.0_sql_sessions-abc2044a-3dbd-49d6-8190-40b62525b370.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-5598-192c-9ef2-35796dd71abb\"}",
+    "body" : "{\"session_id\":\"01f12db0-5598-192c-9ef2-35796dd71abb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4503c31d-5d2b-4fad-b60b-a570357ca8a8",
       "date" : "Wed, 1 Apr 2026 09:51:19 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation5/mappings/api_2.0_sql_sessions-876655e1-2f43-4c34-9f12-af453ad3445b.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation5/mappings/api_2.0_sql_sessions-876655e1-2f43-4c34-9f12-af453ad3445b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-632c-1e70-a3c2-e46f78cf190a\"}",
+    "body" : "{\"session_id\":\"01f12db0-632c-1e70-a3c2-e46f78cf190a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2d18e824-7be7-4662-8430-976eb29c325f",
       "date" : "Wed, 1 Apr 2026 09:51:42 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation6/mappings/api_2.0_sql_sessions-8e3d2a30-12b7-416c-87d2-f793d8b71be2.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation6/mappings/api_2.0_sql_sessions-8e3d2a30-12b7-416c-87d2-f793d8b71be2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-7070-1d4c-9b04-addca0299f91\"}",
+    "body" : "{\"session_id\":\"01f12db0-7070-1d4c-9b04-addca0299f91\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ae5bab3c-12f2-4544-aa43-39df7eb98caa",
       "date" : "Wed, 1 Apr 2026 09:52:04 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation7/mappings/api_2.0_sql_sessions-9d48abf7-8ad6-4630-93c4-ab33a392790c.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation7/mappings/api_2.0_sql_sessions-9d48abf7-8ad6-4630-93c4-ab33a392790c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-7cb5-1161-b87b-15ba3bdc0947\"}",
+    "body" : "{\"session_id\":\"01f12db0-7cb5-1161-b87b-15ba3bdc0947\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "f9ff6feb-4a13-4531-98b5-4712f6f89d13",
       "date" : "Wed, 1 Apr 2026 09:52:25 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation8/mappings/api_2.0_sql_sessions-1747cafb-cde0-40b9-bc38-e42b11fe4293.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject.invocation8/mappings/api_2.0_sql_sessions-1747cafb-cde0-40b9-bc38-e42b11fe4293.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12db0-8d6e-1639-a12a-e5d620afebee\"}",
+    "body" : "{\"session_id\":\"01f12db0-8d6e-1639-a12a-e5d620afebee\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "58f7ff0e-724a-440a-8763-d68db85574b3",
       "date" : "Wed, 1 Apr 2026 09:52:53 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject_withoutsqltype/mappings/api_2.0_sql_sessions-55dc4d7e-34ec-4dda-92f2-8bc816dc79ed.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsetobject_withoutsqltype/mappings/api_2.0_sql_sessions-55dc4d7e-34ec-4dda-92f2-8bc816dc79ed.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-df0a-1cb4-bc49-7dbf7d1f5c89\"}",
+    "body" : "{\"session_id\":\"01f12daf-df0a-1cb4-bc49-7dbf7d1f5c89\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4138e568-c3eb-4d8d-8294-e3f78eb0e802",
       "date" : "Wed, 1 Apr 2026 09:48:00 GMT",

--- a/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsettimestamp/mappings/api_2.0_sql_sessions-8fe134d9-1be7-4c09-a3c7-02f1b7977b09.json
+++ b/src/test/resources/sqlexecapi/preparedstatementintegrationtests/testsettimestamp/mappings/api_2.0_sql_sessions-8fe134d9-1be7-4c09-a3c7-02f1b7977b09.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f12daf-d198-15f5-8954-92cd9cf3d6bb\"}",
+    "body" : "{\"session_id\":\"01f12daf-d198-15f5-8954-92cd9cf3d6bb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "182ba727-31b4-4551-8111-39ecc5050341",
       "date" : "Wed, 1 Apr 2026 09:47:38 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testfetchdirection_forwardonly/mappings/api_2.0_sql_sessions-424c2d4e-410b-440d-8914-0cb9cc069ac1.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testfetchdirection_forwardonly/mappings/api_2.0_sql_sessions-424c2d4e-410b-440d-8914-0cb9cc069ac1.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-ea35-1b70-9c1e-7c4fd09926a8\"}",
+    "body" : "{\"session_id\":\"01f10bdd-ea35-1b70-9c1e-7c4fd09926a8\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4227a1ea-1b40-466a-bf8c-2e25db945c31",
       "date" : "Tue, 17 Feb 2026 08:51:57 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testfetchsize_defaultstozero/mappings/api_2.0_sql_sessions-65403bd2-57ce-481e-8ad4-97f8f2e722ee.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testfetchsize_defaultstozero/mappings/api_2.0_sql_sessions-65403bd2-57ce-481e-8ad4-97f8f2e722ee.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-edad-123d-8662-e7e18954998e\"}",
+    "body" : "{\"session_id\":\"01f10bdd-edad-123d-8662-e7e18954998e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "45bf09f3-9c4c-4f0a-adf8-cf3d1a80bdf3",
       "date" : "Tue, 17 Feb 2026 08:52:02 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testfindcolumn/mappings/api_2.0_sql_sessions-4563bbaf-df50-4aa7-bcd6-22a332746981.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testfindcolumn/mappings/api_2.0_sql_sessions-4563bbaf-df50-4aa7-bcd6-22a332746981.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-3fdc-1fd8-b602-63de8db928f6\"}",
+    "body" : "{\"session_id\":\"01f10c86-3fdc-1fd8-b602-63de8db928f6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "fb0856f7-05ae-4670-b9f8-99bc71f1d0e7",
       "date" : "Wed, 18 Feb 2026 04:56:56 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testforwardnavigation_multiplerows/mappings/api_2.0_sql_sessions-7d5f3b82-f73a-434e-90de-ab371e3e627f.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testforwardnavigation_multiplerows/mappings/api_2.0_sql_sessions-7d5f3b82-f73a-434e-90de-ab371e3e627f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-f487-18b6-8c92-1edcebaeed55\"}",
+    "body" : "{\"session_id\":\"01f10bdd-f487-18b6-8c92-1edcebaeed55\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4f50f0b1-de85-4446-9ae5-45ecc6360984",
       "date" : "Tue, 17 Feb 2026 08:52:14 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetbigdecimal/mappings/api_2.0_sql_sessions-7c274ab4-db06-4b0e-9dbf-0f3e70413376.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetbigdecimal/mappings/api_2.0_sql_sessions-7c274ab4-db06-4b0e-9dbf-0f3e70413376.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-f459-1723-bfc3-f367f19e5fb6\"}",
+    "body" : "{\"session_id\":\"01f10c18-f459-1723-bfc3-f367f19e5fb6\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "b61e2e27-1ab6-4400-aaa5-c6a4aa47502a",
       "date" : "Tue, 17 Feb 2026 15:54:34 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetboolean/mappings/api_2.0_sql_sessions-2751e806-651a-492c-9abd-b0f4b77b6928.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetboolean/mappings/api_2.0_sql_sessions-2751e806-651a-492c-9abd-b0f4b77b6928.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-ea27-14f5-8f48-ab8768cab097\"}",
+    "body" : "{\"session_id\":\"01f10c18-ea27-14f5-8f48-ab8768cab097\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "5deaf5c5-9388-416e-8bf1-66a03f8d4126",
       "date" : "Tue, 17 Feb 2026 15:54:17 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetbyte/mappings/api_2.0_sql_sessions-bfd331e5-6d8f-4e31-9f0c-557850bba34b.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetbyte/mappings/api_2.0_sql_sessions-bfd331e5-6d8f-4e31-9f0c-557850bba34b.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-d836-1c8a-8241-f316e7bf1d18\"}",
+    "body" : "{\"session_id\":\"01f10c18-d836-1c8a-8241-f316e7bf1d18\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "46bc3310-e582-4ee6-b98b-5e783173c6d8",
       "date" : "Tue, 17 Feb 2026 15:53:47 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetdate/mappings/api_2.0_sql_sessions-40c0f634-6b87-486e-a0b6-9612a1dd2b28.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetdate/mappings/api_2.0_sql_sessions-40c0f634-6b87-486e-a0b6-9612a1dd2b28.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-dcd8-19e6-8337-7cf18819f27e\"}",
+    "body" : "{\"session_id\":\"01f10c18-dcd8-19e6-8337-7cf18819f27e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c6d8d2be-29d9-4ff0-b29c-084d49adf973",
       "date" : "Tue, 17 Feb 2026 15:53:54 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetdouble/mappings/api_2.0_sql_sessions-e585eb1c-81ff-4fb8-8f94-1b4a8293e69f.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetdouble/mappings/api_2.0_sql_sessions-e585eb1c-81ff-4fb8-8f94-1b4a8293e69f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-ef84-1d67-9bba-ab3577805db9\"}",
+    "body" : "{\"session_id\":\"01f10c18-ef84-1d67-9bba-ab3577805db9\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "677859a4-bb9e-43dd-a58a-38a287486e9b",
       "date" : "Tue, 17 Feb 2026 15:54:26 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetfloat/mappings/api_2.0_sql_sessions-f9e6263a-5e73-4db3-a6db-4bf372687e43.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetfloat/mappings/api_2.0_sql_sessions-f9e6263a-5e73-4db3-a6db-4bf372687e43.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-cf5c-19a0-b709-2908cd02d91c\"}",
+    "body" : "{\"session_id\":\"01f10c18-cf5c-19a0-b709-2908cd02d91c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "75e66934-67ad-4552-b538-f1e560bb9e8f",
       "date" : "Tue, 17 Feb 2026 15:53:32 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetholdability/mappings/api_2.0_sql_sessions-52899c1d-e089-4991-a106-aeacbfb73312.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetholdability/mappings/api_2.0_sql_sessions-52899c1d-e089-4991-a106-aeacbfb73312.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-445f-152c-9a63-05a734c6c6a3\"}",
+    "body" : "{\"session_id\":\"01f10c86-445f-152c-9a63-05a734c6c6a3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4a004c30-b507-4839-b618-940c30774e38",
       "date" : "Wed, 18 Feb 2026 04:57:03 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetlong/mappings/api_2.0_sql_sessions-cfacca4a-f7a9-436b-ad19-c481a9317179.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetlong/mappings/api_2.0_sql_sessions-cfacca4a-f7a9-436b-ad19-c481a9317179.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-e13a-10f9-8c71-7aca09204e99\"}",
+    "body" : "{\"session_id\":\"01f10c18-e13a-10f9-8c71-7aca09204e99\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c6da91ad-70b1-421d-9f61-8fea6118d341",
       "date" : "Tue, 17 Feb 2026 15:54:02 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetobject_withtypeconversion/mappings/api_2.0_sql_sessions-bd8692e4-4efc-4e47-a277-5c9b65e26bfa.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetobject_withtypeconversion/mappings/api_2.0_sql_sessions-bd8692e4-4efc-4e47-a277-5c9b65e26bfa.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-e5ce-143d-828d-cf1a47198bd3\"}",
+    "body" : "{\"session_id\":\"01f10c18-e5ce-143d-828d-cf1a47198bd3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9a26a562-aee3-47a5-a41d-c7e48f522a48",
       "date" : "Tue, 17 Feb 2026 15:54:09 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetrow_tracksposition/mappings/api_2.0_sql_sessions-d132471c-49de-4911-b125-82aff022fd35.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetrow_tracksposition/mappings/api_2.0_sql_sessions-d132471c-49de-4911-b125-82aff022fd35.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-d21d-1610-ab93-dc7358504c2f\"}",
+    "body" : "{\"session_id\":\"01f10bdd-d21d-1610-ab93-dc7358504c2f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "a68374bf-9247-449c-bff8-bb1020696b6b",
       "date" : "Tue, 17 Feb 2026 08:51:16 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetshort/mappings/api_2.0_sql_sessions-d8427a45-e72c-4978-909c-19be3373bea3.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgetshort/mappings/api_2.0_sql_sessions-d8427a45-e72c-4978-909c-19be3373bea3.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-d3f3-1e52-a0e7-66e8abfc8c0b\"}",
+    "body" : "{\"session_id\":\"01f10c18-d3f3-1e52-a0e7-66e8abfc8c0b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "3d5807de-744c-4aed-9e97-83eb918a9ca0",
       "date" : "Tue, 17 Feb 2026 15:53:40 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testgettimestamp/mappings/api_2.0_sql_sessions-d2c50c49-8f75-4f4d-b007-57ee141658c1.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testgettimestamp/mappings/api_2.0_sql_sessions-d2c50c49-8f75-4f4d-b007-57ee141658c1.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c18-f89b-10c2-a6e6-00f02bb54772\"}",
+    "body" : "{\"session_id\":\"01f10c18-f89b-10c2-a6e6-00f02bb54772\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8a49c82a-93a3-410b-8ad9-027f02c4651b",
       "date" : "Tue, 17 Feb 2026 15:54:41 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testhandlingnullvalues/mappings/api_2.0_sql_sessions-ae41c8d0-b952-4185-a1c6-ee3612fe3bc2.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testhandlingnullvalues/mappings/api_2.0_sql_sessions-ae41c8d0-b952-4185-a1c6-ee3612fe3bc2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-c09a-1a24-b789-b3d87ab9456b\"}",
+    "body" : "{\"session_id\":\"01f099d9-c09a-1a24-b789-b3d87ab9456b\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "cc6729db-8ccd-42d7-a25b-e7e95a324245",
       "date" : "Thu, 25 Sep 2025 06:34:56 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testisbeforefirst_beforenavigation/mappings/api_2.0_sql_sessions-04f3e680-985c-4fe6-8bb0-19e0f64ae43e.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testisbeforefirst_beforenavigation/mappings/api_2.0_sql_sessions-04f3e680-985c-4fe6-8bb0-19e0f64ae43e.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-e212-15ab-bb1c-4eff55a648bc\"}",
+    "body" : "{\"session_id\":\"01f10bdd-e212-15ab-bb1c-4eff55a648bc\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "09a13a8b-78e2-45f7-a16a-a99417a5ec86",
       "date" : "Tue, 17 Feb 2026 08:51:43 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testisfirst_onfirstrow/mappings/api_2.0_sql_sessions-6f335002-976c-402c-bc6e-273aa3e554dd.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testisfirst_onfirstrow/mappings/api_2.0_sql_sessions-6f335002-976c-402c-bc6e-273aa3e554dd.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-0c92-1577-aeb2-4e276e20e51a\"}",
+    "body" : "{\"session_id\":\"01f10bde-0c92-1577-aeb2-4e276e20e51a\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "0b587758-3717-4a73-ae48-747826708673",
       "date" : "Tue, 17 Feb 2026 08:52:54 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testnavigationinsideresultset/mappings/api_2.0_sql_sessions-2ee826bb-2a09-4e72-9d26-0078d3484727.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testnavigationinsideresultset/mappings/api_2.0_sql_sessions-2ee826bb-2a09-4e72-9d26-0078d3484727.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-867c-1aac-af23-9265f5308dcb\"}",
+    "body" : "{\"session_id\":\"01f099d9-867c-1aac-af23-9265f5308dcb\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e1ef2f1b-b020-4cb1-9587-2cc97be8831e",
       "date" : "Thu, 25 Sep 2025 06:33:19 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testnextreturnsfalse_afterexhausted/mappings/api_2.0_sql_sessions-b1fe024a-75e2-416d-b91c-0d4dcc8fed47.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testnextreturnsfalse_afterexhausted/mappings/api_2.0_sql_sessions-b1fe024a-75e2-416d-b91c-0d4dcc8fed47.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-e620-1040-abc2-d3fdc53d69db\"}",
+    "body" : "{\"session_id\":\"01f10bdd-e620-1040-abc2-d3fdc53d69db\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "55b07ebb-693e-44a6-94a0-93cc3a30e83e",
       "date" : "Tue, 17 Feb 2026 08:51:50 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultset_getwarningsandclearwarnings/mappings/api_2.0_sql_sessions-cfd51f14-b085-4deb-9e70-21bf878e27cb.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultset_getwarningsandclearwarnings/mappings/api_2.0_sql_sessions-cfd51f14-b085-4deb-9e70-21bf878e27cb.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-4c89-17bb-b354-503503c3258c\"}",
+    "body" : "{\"session_id\":\"01f10c86-4c89-17bb-b354-503503c3258c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e860794c-0573-42a5-a8f4-6dbd6aa9d8db",
       "date" : "Wed, 18 Feb 2026 04:57:17 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetconcurrency_readonly/mappings/api_2.0_sql_sessions-9ccfb87d-9559-4b93-aca7-d74f8c77dd6d.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetconcurrency_readonly/mappings/api_2.0_sql_sessions-9ccfb87d-9559-4b93-aca7-d74f8c77dd6d.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-ce56-1aa6-bf00-05651b4fcb9f\"}",
+    "body" : "{\"session_id\":\"01f10bdd-ce56-1aa6-bf00-05651b4fcb9f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "59d250fc-4e8d-41d0-aed7-eba415e10741",
       "date" : "Tue, 17 Feb 2026 08:51:10 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetmetadata_getschemaandcatalogname/mappings/api_2.0_sql_sessions-fe757ec9-0df0-4871-b7f6-3b2819a502ea.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetmetadata_getschemaandcatalogname/mappings/api_2.0_sql_sessions-fe757ec9-0df0-4871-b7f6-3b2819a502ea.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-48d5-10df-b284-ae8911ec0cb0\"}",
+    "body" : "{\"session_id\":\"01f10c86-48d5-10df-b284-ae8911ec0cb0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "aec432fb-3f9d-4541-86a7-9607626c0c02",
       "date" : "Wed, 18 Feb 2026 04:57:11 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetmetadata_gettablename/mappings/api_2.0_sql_sessions-127ffa7a-6481-4713-acb1-10a907f7e74a.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsetmetadata_gettablename/mappings/api_2.0_sql_sessions-127ffa7a-6481-4713-acb1-10a907f7e74a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10c86-3c24-110c-bafa-5e26ceab9096\"}",
+    "body" : "{\"session_id\":\"01f10c86-3c24-110c-bafa-5e26ceab9096\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "9a2d311a-a376-4a83-a804-abd7d79d7d7b",
       "date" : "Wed, 18 Feb 2026 04:56:49 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsettype_forwardonly/mappings/api_2.0_sql_sessions-cb2c6da0-d30a-4216-b000-c26c9c72c852.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testresultsettype_forwardonly/mappings/api_2.0_sql_sessions-cb2c6da0-d30a-4216-b000-c26c9c72c852.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bdd-f11a-1f16-b80f-52a76f07520c\"}",
+    "body" : "{\"session_id\":\"01f10bdd-f11a-1f16-b80f-52a76f07520c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "fd23f86d-c1e2-4739-890a-d8408313d075",
       "date" : "Tue, 17 Feb 2026 08:52:08 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testretrievalofbasicdatatypes/mappings/api_2.0_sql_sessions-ebe550e5-9b1d-4027-b8a4-0089bfdd596f.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testretrievalofbasicdatatypes/mappings/api_2.0_sql_sessions-ebe550e5-9b1d-4027-b8a4-0089bfdd596f.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-b45f-1291-92a0-9a585519aff4\"}",
+    "body" : "{\"session_id\":\"01f099d9-b45f-1291-92a0-9a585519aff4\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "18bfadd0-354a-41f7-ae89-3ff82d6f2516",
       "date" : "Thu, 25 Sep 2025 06:34:36 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testretrievalofcomplexdatatypes/mappings/api_2.0_sql_sessions-ac182b94-c900-46c9-980d-2c763c370986.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testretrievalofcomplexdatatypes/mappings/api_2.0_sql_sessions-ac182b94-c900-46c9-980d-2c763c370986.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-a807-12a8-999b-15d7d62b4c63\"}",
+    "body" : "{\"session_id\":\"01f099d9-a807-12a8-999b-15d7d62b4c63\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "436ca2e9-6ba5-4d62-8b83-b82ec8519b60",
       "date" : "Thu, 25 Sep 2025 06:34:15 GMT",

--- a/src/test/resources/sqlexecapi/resultsetintegrationtests/testsetfetchsize_acceptedwithwarning/mappings/api_2.0_sql_sessions-06fb2b39-f597-449f-b164-299e31b5fb88.json
+++ b/src/test/resources/sqlexecapi/resultsetintegrationtests/testsetfetchsize_acceptedwithwarning/mappings/api_2.0_sql_sessions-06fb2b39-f597-449f-b164-299e31b5fb88.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f10bde-0909-1503-8ab4-ea4c357307b2\"}",
+    "body" : "{\"session_id\":\"01f10bde-0909-1503-8ab4-ea4c357307b2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2a7dcb4e-aeb2-4351-b494-8abbf713e000",
       "date" : "Tue, 17 Feb 2026 08:52:48 GMT",

--- a/src/test/resources/sqlexecapi/sqlexecapihybridresultsintegrationtests/testhybridlargequery/mappings/api_2.0_sql_sessions-19902762-1c46-4651-b76e-9d4953509dc8.json
+++ b/src/test/resources/sqlexecapi/sqlexecapihybridresultsintegrationtests/testhybridlargequery/mappings/api_2.0_sql_sessions-19902762-1c46-4651-b76e-9d4953509dc8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-d71a-1d5c-9521-5dd87826834e\"}",
+    "body" : "{\"session_id\":\"01f099d9-d71a-1d5c-9521-5dd87826834e\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ee8a868b-dd63-4221-af2d-ab28252e559f",
       "date" : "Thu, 25 Sep 2025 06:35:34 GMT",

--- a/src/test/resources/sqlexecapi/sqlexecapihybridresultsintegrationtests/testhybridsmallquery/mappings/api_2.0_sql_sessions-c5091ee1-fb3c-4e63-abf2-9171d0fb5259.json
+++ b/src/test/resources/sqlexecapi/sqlexecapihybridresultsintegrationtests/testhybridsmallquery/mappings/api_2.0_sql_sessions-c5091ee1-fb3c-4e63-abf2-9171d0fb5259.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-d37a-151f-b999-49e9226a5b69\"}",
+    "body" : "{\"session_id\":\"01f099d9-d37a-151f-b999-49e9226a5b69\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "73092024-b3dc-453f-b53e-f8b9687ef8ef",
       "date" : "Thu, 25 Sep 2025 06:35:28 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_casesensitivity_specialcharacters.invocation1/mappings/api_2.0_sql_sessions-666f6972-a384-44c5-9154-99cfb547d6ce.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_casesensitivity_specialcharacters.invocation1/mappings/api_2.0_sql_sessions-666f6972-a384-44c5-9154-99cfb547d6ce.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-7461-1793-b61c-d8b2e74da6a5\"}",
+    "body" : "{\"session_id\":\"01f099d9-7461-1793-b61c-d8b2e74da6a5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e6b1e61e-c0bd-4a5e-93a4-3094044089b7",
       "date" : "Thu, 25 Sep 2025 06:32:48 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_casesensitivity_specialcharacters.invocation2/mappings/api_2.0_sql_sessions-dc956a7a-226b-4fcf-aabd-619f973c7973.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_casesensitivity_specialcharacters.invocation2/mappings/api_2.0_sql_sessions-dc956a7a-226b-4fcf-aabd-619f973c7973.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-78ef-1279-892e-c9e485bcf254\"}",
+    "body" : "{\"session_id\":\"01f099d9-78ef-1279-892e-c9e485bcf254\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "bb1d2681-b5b5-4ddf-acbb-79d63835ce94",
       "date" : "Thu, 25 Sep 2025 06:32:56 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation1/mappings/api_2.0_sql_sessions-042bec5b-e5a0-47ce-a7cc-8610924491fb.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation1/mappings/api_2.0_sql_sessions-042bec5b-e5a0-47ce-a7cc-8610924491fb.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-3062-124f-9403-188cc1b6abb0\"}",
+    "body" : "{\"session_id\":\"01f099d9-3062-124f-9403-188cc1b6abb0\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "71a568ef-6d41-4b1a-8bd2-50a1eb21f8fc",
       "date" : "Thu, 25 Sep 2025 06:30:54 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation2/mappings/api_2.0_sql_sessions-1437c0a6-59ea-4d37-9e35-885aedb5dc0a.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation2/mappings/api_2.0_sql_sessions-1437c0a6-59ea-4d37-9e35-885aedb5dc0a.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-39c7-151d-9b35-cc1c805a3c6f\"}",
+    "body" : "{\"session_id\":\"01f099d9-39c7-151d-9b35-cc1c805a3c6f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "fa6f4210-863d-48a9-a625-f58ab5ffedc9",
       "date" : "Thu, 25 Sep 2025 06:31:10 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation3/mappings/api_2.0_sql_sessions-35247e4b-3721-445f-8bba-2f503245bc72.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_subfolders.invocation3/mappings/api_2.0_sql_sessions-35247e4b-3721-445f-8bba-2f503245bc72.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-3e7b-17cb-832e-b550e0a2d636\"}",
+    "body" : "{\"session_id\":\"01f099d9-3e7b-17cb-832e-b550e0a2d636\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "e4e6bdc1-cef7-430f-9125-867c121db682",
       "date" : "Thu, 25 Sep 2025 06:31:18 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_volumereferencing.invocation1/mappings/api_2.0_sql_sessions-bacdf8d6-5d5e-4c42-a2db-739fa44d1300.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_volumereferencing.invocation1/mappings/api_2.0_sql_sessions-bacdf8d6-5d5e-4c42-a2db-739fa44d1300.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-7d83-1b85-a3a8-a6f935440e82\"}",
+    "body" : "{\"session_id\":\"01f099d9-7d83-1b85-a3a8-a6f935440e82\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c8c01129-dfb0-40e4-8628-f43098916e63",
       "date" : "Thu, 25 Sep 2025 06:33:04 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_volumereferencing.invocation2/mappings/api_2.0_sql_sessions-aacf6cab-9b2b-4643-b3cd-fdce206d9343.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testlistobjects_volumereferencing.invocation2/mappings/api_2.0_sql_sessions-aacf6cab-9b2b-4643-b3cd-fdce206d9343.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-8200-1a09-b1dd-e27b90839740\"}",
+    "body" : "{\"session_id\":\"01f099d9-8200-1a09-b1dd-e27b90839740\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "6eed0040-0305-40f4-8210-a99d3b60acd8",
       "date" : "Thu, 25 Sep 2025 06:33:11 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistscasesensitivity.invocation1/mappings/api_2.0_sql_sessions-4f59eec8-ccbb-4492-95e7-d25442960e31.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistscasesensitivity.invocation1/mappings/api_2.0_sql_sessions-4f59eec8-ccbb-4492-95e7-d25442960e31.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-5909-1c4f-8de1-c110f0d6eba3\"}",
+    "body" : "{\"session_id\":\"01f099d9-5909-1c4f-8de1-c110f0d6eba3\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "8be371a2-1352-4e52-b0dc-3859ea9eca1e",
       "date" : "Thu, 25 Sep 2025 06:32:02 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistscasesensitivity.invocation2/mappings/api_2.0_sql_sessions-7127cf4a-2f47-498a-8072-24da96aaf5dd.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistscasesensitivity.invocation2/mappings/api_2.0_sql_sessions-7127cf4a-2f47-498a-8072-24da96aaf5dd.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-5d88-1ab3-af96-2f246a811e11\"}",
+    "body" : "{\"session_id\":\"01f099d9-5d88-1ab3-af96-2f246a811e11\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "c18ed655-a3f5-4450-8b6d-82fcfba5c61e",
       "date" : "Thu, 25 Sep 2025 06:32:10 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsspecialcharacters.invocation1/mappings/api_2.0_sql_sessions-73fe0ffc-cfd5-478f-bb81-59377c5bbfc8.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsspecialcharacters.invocation1/mappings/api_2.0_sql_sessions-73fe0ffc-cfd5-478f-bb81-59377c5bbfc8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-5022-1ce9-ba98-b19b8b113417\"}",
+    "body" : "{\"session_id\":\"01f099d9-5022-1ce9-ba98-b19b8b113417\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "921f4aff-92d2-4168-b57c-086d912fa267",
       "date" : "Thu, 25 Sep 2025 06:31:48 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsspecialcharacters.invocation2/mappings/api_2.0_sql_sessions-c49182b3-434a-4ebb-aa44-64f7d3204ca9.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsspecialcharacters.invocation2/mappings/api_2.0_sql_sessions-c49182b3-434a-4ebb-aa44-64f7d3204ca9.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-54a4-164e-82c9-29b1683458a5\"}",
+    "body" : "{\"session_id\":\"01f099d9-54a4-164e-82c9-29b1683458a5\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "d40a51b0-3c40-44b4-8fae-0cc803cfd8a0",
       "date" : "Thu, 25 Sep 2025 06:31:55 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsvolumereferencing.invocation1/mappings/api_2.0_sql_sessions-1a465486-1687-4a91-b01d-85edb26a38a8.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsvolumereferencing.invocation1/mappings/api_2.0_sql_sessions-1a465486-1687-4a91-b01d-85edb26a38a8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-6217-1c2e-95db-6e935d1bb1f2\"}",
+    "body" : "{\"session_id\":\"01f099d9-6217-1c2e-95db-6e935d1bb1f2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "caba863a-c248-4574-a7f7-e17ea20fd0da",
       "date" : "Thu, 25 Sep 2025 06:32:18 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsvolumereferencing.invocation2/mappings/api_2.0_sql_sessions-8250bf8a-516e-43ff-bf32-bdb6b51d9bf2.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testobjectexistsvolumereferencing.invocation2/mappings/api_2.0_sql_sessions-8250bf8a-516e-43ff-bf32-bdb6b51d9bf2.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-66b0-18f1-83cb-934fbff6a0b2\"}",
+    "body" : "{\"session_id\":\"01f099d9-66b0-18f1-83cb-934fbff6a0b2\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "ee95a0b5-f3c3-4181-a9cd-d3cef25b02c7",
       "date" : "Thu, 25 Sep 2025 06:32:25 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testprefixexists.invocation1/mappings/api_2.0_sql_sessions-021a7911-4c1e-4e84-81fe-9a880fcb99e7.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testprefixexists.invocation1/mappings/api_2.0_sql_sessions-021a7911-4c1e-4e84-81fe-9a880fcb99e7.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-6b4a-1ecd-8d14-41211bddfd27\"}",
+    "body" : "{\"session_id\":\"01f099d9-6b4a-1ecd-8d14-41211bddfd27\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "99c10a99-e9eb-4413-bcef-284aa1fbc40c",
       "date" : "Thu, 25 Sep 2025 06:32:33 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testprefixexists.invocation2/mappings/api_2.0_sql_sessions-4cb61601-e91a-4ce9-9cb6-1ba9ad8f0391.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testprefixexists.invocation2/mappings/api_2.0_sql_sessions-4cb61601-e91a-4ce9-9cb6-1ba9ad8f0391.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-6fc0-1808-aca8-2efb3c57e23f\"}",
+    "body" : "{\"session_id\":\"01f099d9-6fc0-1808-aca8-2efb3c57e23f\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "2ccee93a-6b1b-485d-80cd-432fa614ab1c",
       "date" : "Thu, 25 Sep 2025 06:32:41 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation1/mappings/api_2.0_sql_sessions-0abc0530-d281-4213-8295-76ecb45159e8.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation1/mappings/api_2.0_sql_sessions-0abc0530-d281-4213-8295-76ecb45159e8.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-430b-1036-92a0-8c9029fa0546\"}",
+    "body" : "{\"session_id\":\"01f099d9-430b-1036-92a0-8c9029fa0546\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "59bd9aa0-9eeb-44fc-a05b-d1842a1ad35e",
       "date" : "Thu, 25 Sep 2025 06:31:26 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation2/mappings/api_2.0_sql_sessions-6207f195-f13a-4e07-b3c4-38f7898f62a7.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation2/mappings/api_2.0_sql_sessions-6207f195-f13a-4e07-b3c4-38f7898f62a7.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-4761-1f21-a430-2af858fdd93c\"}",
+    "body" : "{\"session_id\":\"01f099d9-4761-1f21-a430-2af858fdd93c\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "517b1620-0061-4d64-bb89-6e1cc34a0235",
       "date" : "Thu, 25 Sep 2025 06:31:33 GMT",

--- a/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation3/mappings/api_2.0_sql_sessions-72103f39-0bb0-4024-bca7-d49e98e37d2c.json
+++ b/src/test/resources/sqlexecapi/ucvolumeintegrationtests/testvolumeexists.invocation3/mappings/api_2.0_sql_sessions-72103f39-0bb0-4024-bca7-d49e98e37d2c.json
@@ -12,7 +12,7 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"session_id\":\"01f099d9-4bc5-1192-88f4-0a6ef6964c97\"}",
+    "body" : "{\"session_id\":\"01f099d9-4bc5-1192-88f4-0a6ef6964c97\",\"session_version\":{\"version_id\":1}}",
     "headers" : {
       "x-request-id" : "4235a1b2-8e72-4d5a-bb32-b3d59b88266c",
       "date" : "Thu, 25 Sep 2025 06:31:40 GMT",


### PR DESCRIPTION
## Description

Add the SEA client-token/session-version contract required for Fast Path explicit sessions:

- Create SEA sessions with `execution_mode=FAST` and seed session-local state from `CreateSessionResponse.session_version.version_id`.
- Send the highest observed session version on every execute and fold versions from execute, polling, result, and heartbeat responses.
- Guard updates by session identity and exclude reattached statement IDs so delayed or foreign responses cannot contaminate the current session.
- Validate FAST create responses and best-effort delete a created server session when its initial version is missing.

Thrift behavior is unchanged.

## Testing

- `mvn -q -DskipTests compile`
- `mvn -q spotless:check`
- `mvn -q -pl jdbc-core -Dtest=DatabricksSessionTest,DatabricksSdkClientTest,DatabricksStatementTest,DatabricksResultSetTest test`
- Full `databricks-jdbc-core` local-profile test suite

## Additional Notes to the Reviewer

The implementation tracks the maximum version because statement completions may be observed out of order. Live endpoint validation remains pending availability of a Fast Path-capable SEA endpoint.