### PR TITLE
Fix NPE for incomplete JDBC URLs

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,9 @@
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 
 ### Fixed
+- Invalid or incomplete Databricks JDBC URLs now fail with a descriptive `DatabricksSQLException`
+  instead of leaking a `NullPointerException` when required connection parameters are missing.
+
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 
 - Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.

--- a/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
@@ -20,6 +20,7 @@ import org.apache.http.util.EntityUtils;
 public class ValidationUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ValidationUtil.class);
+
   public static <T extends Number> void checkIfNonNegative(T number, String fieldName)
       throws DatabricksValidationException {
     if (number.longValue() < 0) {

--- a/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
@@ -11,7 +11,6 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -21,9 +20,6 @@ import org.apache.http.util.EntityUtils;
 public class ValidationUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ValidationUtil.class);
-  private static final List<DatabricksJdbcUrlParams>
-      UNCONDITIONALLY_REQUIRED_CONNECTION_PARAMETERS = List.of(DatabricksJdbcUrlParams.HTTP_PATH);
-
   public static <T extends Number> void checkIfNonNegative(T number, String fieldName)
       throws DatabricksValidationException {
     if (number.longValue() < 0) {
@@ -199,21 +195,11 @@ public class ValidationUtil {
    */
   private static void validateRequiredConnectionParameters(Map<String, String> parameters)
       throws DatabricksValidationException {
-    List<String> missingParameters = new ArrayList<>();
-    for (DatabricksJdbcUrlParams requiredParameter :
-        UNCONDITIONALLY_REQUIRED_CONNECTION_PARAMETERS) {
-      String parameterName = requiredParameter.getParamName().toLowerCase();
-      String value = parameters.get(parameterName);
-      if (value == null || value.isBlank()) {
-        missingParameters.add(parameterName);
-      }
-    }
-    if (!missingParameters.isEmpty()) {
-      String parameterLabel = missingParameters.size() == 1 ? "parameter" : "parameters";
+    String parameterName = DatabricksJdbcUrlParams.HTTP_PATH.getParamName().toLowerCase();
+    String httpPath = parameters.get(parameterName);
+    if (httpPath == null || httpPath.isBlank()) {
       throw new DatabricksValidationException(
-          String.format(
-              "Missing required connection %s: %s",
-              parameterLabel, String.join(", ", missingParameters)));
+          "Missing required connection parameter: " + parameterName);
     }
   }
 

--- a/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ValidationUtil.java
@@ -11,6 +11,7 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -20,6 +21,8 @@ import org.apache.http.util.EntityUtils;
 public class ValidationUtil {
 
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ValidationUtil.class);
+  private static final List<DatabricksJdbcUrlParams>
+      UNCONDITIONALLY_REQUIRED_CONNECTION_PARAMETERS = List.of(DatabricksJdbcUrlParams.HTTP_PATH);
 
   public static <T extends Number> void checkIfNonNegative(T number, String fieldName)
       throws DatabricksValidationException {
@@ -148,6 +151,10 @@ public class ValidationUtil {
    * @return true if the URL is valid, false otherwise
    */
   public static boolean isValidJdbcUrl(String url) {
+    if (url == null) {
+      return false;
+    }
+
     final List<Pattern> PATH_PATTERNS =
         List.of(
             HTTP_CLUSTER_PATH_PATTERN,
@@ -176,9 +183,38 @@ public class ValidationUtil {
    */
   public static void validateInputProperties(Map<String, String> parameters)
       throws DatabricksValidationException {
+    validateRequiredConnectionParameters(parameters);
     // Fail fast on an unsupported AuthMech before the client-configurator machinery runs.
     validateAuthMech(parameters);
     validateUidParameter(parameters);
+  }
+
+  /**
+   * Validates parameters that must be present in every connection configuration. URL parameters and
+   * {@link java.util.Properties} are merged before this method is called, so required values may be
+   * supplied through either mechanism.
+   *
+   * @param parameters merged JDBC connection parameters
+   * @throws DatabricksValidationException if any required parameter is missing or blank
+   */
+  private static void validateRequiredConnectionParameters(Map<String, String> parameters)
+      throws DatabricksValidationException {
+    List<String> missingParameters = new ArrayList<>();
+    for (DatabricksJdbcUrlParams requiredParameter :
+        UNCONDITIONALLY_REQUIRED_CONNECTION_PARAMETERS) {
+      String parameterName = requiredParameter.getParamName().toLowerCase();
+      String value = parameters.get(parameterName);
+      if (value == null || value.isBlank()) {
+        missingParameters.add(parameterName);
+      }
+    }
+    if (!missingParameters.isEmpty()) {
+      String parameterLabel = missingParameters.size() == 1 ? "parameter" : "parameters";
+      throw new DatabricksValidationException(
+          String.format(
+              "Missing required connection %s: %s",
+              parameterLabel, String.join(", ", missingParameters)));
+    }
   }
 
   /**

--- a/src/test/java/com/databricks/client/jdbc/DriverTest.java
+++ b/src/test/java/com/databricks/client/jdbc/DriverTest.java
@@ -1,0 +1,24 @@
+package com.databricks.client.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.databricks.jdbc.exception.DatabricksSQLException;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class DriverTest {
+
+  @Test
+  void connectRejectsMissingRequiredConnectionParameters() {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () ->
+                Driver.getInstance().connect("jdbc:databricks://localhost:8080", new Properties()));
+
+    assertEquals("INPUT_VALIDATION_ERROR", exception.getSQLState());
+    assertTrue(exception.getMessage().contains("httppath"));
+  }
+}

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DatabricksConnectionContextTest {
 
@@ -85,6 +86,26 @@ class DatabricksConnectionContextTest {
     assertThrows(
         DatabricksParsingException.class,
         () -> DatabricksConnectionContext.parse(TestConstants.INVALID_URL_2, properties));
+    assertThrows(
+        DatabricksParsingException.class,
+        () -> DatabricksConnectionContext.parse(null, properties));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:databricks://localhost:8080",
+        "jdbc:databricks://localhost:8080;httpPath=",
+        "jdbc:databricks://localhost:8080;httpPath= "
+      })
+  public void testParseRejectsMissingRequiredConnectionParameters(String url) {
+    DatabricksSQLException exception =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> DatabricksConnectionContext.parse(url, new Properties()));
+
+    assertEquals("INPUT_VALIDATION_ERROR", exception.getSQLState());
+    assertTrue(exception.getMessage().contains("httppath"));
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes #1630.

- Validates unconditionally required connection parameters.
- Returns a `DatabricksValidationException` with `INPUT_VALIDATION_ERROR` when a required parameter is missing or blank, preventing the `NullPointerException`.
- Handles null JDBC URLs safely during URL validation.

## Testing

- Added parser coverage for null URLs and missing, empty, and blank required parameters.
- Added a public `Driver.connect()` regression test for the issue reproduction.
- Verified the existing valid base-URL flow where `httpPath` is supplied through `Properties`.

## Additional Notes to the Reviewer

`httpPath` is currently the only parameter required unconditionally to construct a connection context. Authentication requirements remain validated according to their existing mode-specific rules.
