### PR TITLE
[PECOBLR-3982] Use JDBC-standard exception for unimplemented features

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 
 ### Fixed
+- `DatabricksSQLFeatureNotImplementedException` now follows the JDBC contract by extending
+  `SQLFeatureNotSupportedException`, while continuing to emit the existing
+  `NOT_IMPLEMENTED_OPERATION` telemetry error.
+
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 
 - Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksSQLFeatureNotImplementedException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksSQLFeatureNotImplementedException.java
@@ -1,10 +1,19 @@
 package com.databricks.jdbc.exception;
 
+import com.databricks.jdbc.common.TelemetryLogLevel;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import com.databricks.jdbc.telemetry.TelemetryHelper;
+import java.sql.SQLFeatureNotSupportedException;
 
-public class DatabricksSQLFeatureNotImplementedException extends DatabricksSQLException {
+public class DatabricksSQLFeatureNotImplementedException extends SQLFeatureNotSupportedException {
 
   public DatabricksSQLFeatureNotImplementedException(String reason) {
-    super(reason, DatabricksDriverErrorCode.NOT_IMPLEMENTED_OPERATION);
+    super(reason, DatabricksDriverErrorCode.NOT_IMPLEMENTED_OPERATION.name());
+    TelemetryHelper.exportFailureLog(
+        DatabricksThreadContextHolder.getConnectionContext(),
+        DatabricksDriverErrorCode.NOT_IMPLEMENTED_OPERATION.name(),
+        reason,
+        TelemetryLogLevel.ERROR);
   }
 }

--- a/src/test/java/com/databricks/jdbc/exception/DatabricksSQLFeatureNotImplementedExceptionTest.java
+++ b/src/test/java/com/databricks/jdbc/exception/DatabricksSQLFeatureNotImplementedExceptionTest.java
@@ -1,0 +1,38 @@
+package com.databricks.jdbc.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mockStatic;
+
+import com.databricks.jdbc.common.TelemetryLogLevel;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import com.databricks.jdbc.telemetry.TelemetryHelper;
+import java.sql.SQLFeatureNotSupportedException;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class DatabricksSQLFeatureNotImplementedExceptionTest {
+
+  @Test
+  void followsJdbcContractAndPreservesTelemetry() {
+    String reason = "Not implemented";
+    DatabricksSQLFeatureNotImplementedException exception;
+    try (MockedStatic<TelemetryHelper> telemetryHelper = mockStatic(TelemetryHelper.class)) {
+      exception = new DatabricksSQLFeatureNotImplementedException(reason);
+
+      telemetryHelper.verify(
+          () ->
+              TelemetryHelper.exportFailureLog(
+                  DatabricksThreadContextHolder.getConnectionContext(),
+                  DatabricksDriverErrorCode.NOT_IMPLEMENTED_OPERATION.name(),
+                  reason,
+                  TelemetryLogLevel.ERROR));
+    }
+
+    assertInstanceOf(SQLFeatureNotSupportedException.class, exception);
+    assertEquals(
+        DatabricksDriverErrorCode.NOT_IMPLEMENTED_OPERATION.name(), exception.getSQLState());
+    assertEquals(0, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
## Description

Brickyard’s driver-error alert for 3.0.1 surfaced a large volume of unsupported-operation failures. Transactions and callable statements were implemented in later driver releases, but the current driver still reports genuinely unsupported JDBC methods through an exception that does not implement the standard `SQLFeatureNotSupportedException` contract.

This change makes `DatabricksSQLFeatureNotImplementedException` extend `SQLFeatureNotSupportedException` while preserving the existing `NOT_IMPLEMENTED_OPERATION` telemetry export and vendor code `0`.

## Testing

The new focused test verifies the JDBC exception type, SQL state, vendor code, and telemetry export. All 46 `DatabricksConnectionTest` cases pass, and Spotless passes.

## Telemetry Errors

- [ ] Not applicable — this PR does not add or change a telemetry-visible error.
- [x] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any new code is uniquely numbered and tested.
- [x] Applicable — maintainer help is requested to confirm that the existing `NOT_IMPLEMENTED_OPERATION` classification remains driver-owned.

## Additional Notes to the Reviewer

This reuses the existing error enum; no new telemetry code is added.

Compatibility tradeoff: code that catches only `DatabricksSQLException` will no longer catch this exception. Code catching `SQLException`, `SQLFeatureNotSupportedException`, or the concrete exception continues to work. Please review whether adopting the JDBC-standard hierarchy justifies that source-level behavior change.

Jira: PECOBLR-3982