### PR TITLE
Fix duplicate JDBC connection parameters

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 
 ### Fixed
-- Fixed connections failing when the same parameter is provided in both the JDBC URL and the connection properties.
+- Fixed connections failing when the same parameter is provided in both the JDBC URL and the connection properties, with the JDBC URL taking precedence.
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 
 - Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 
 ### Fixed
+- Fixed connections failing when the same parameter is provided in both the JDBC URL and the connection properties.
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 
 - Throw `DatabricksSQLException` instead of an unchecked `ClassCastException` when a complex-type getter (`getArray`, `getStruct`, `getMap`) is called on a column of a different complex type.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -105,6 +105,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   /**
    * Builds a map of properties from the given connection parameter string and properties object.
+   * Connection URL parameters take precedence over entries in the properties object.
    *
    * @param connectionParamString the connection parameter string
    * @param properties the properties object
@@ -113,6 +114,9 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   public static ImmutableMap<String, String> buildPropertiesMap(
       String connectionParamString, Properties properties) {
     ImmutableMap.Builder<String, String> parametersBuilder = ImmutableMap.builder();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      parametersBuilder.put(entry.getKey().toString().toLowerCase(), entry.getValue().toString());
+    }
     // check if connectionParamString is empty or null
     if (!isNullOrEmpty(connectionParamString)) {
       String[] urlParts = connectionParamString.split(DatabricksJdbcConstants.URL_DELIMITER);
@@ -128,10 +132,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
         }
       }
     }
-    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-      parametersBuilder.put(entry.getKey().toString().toLowerCase(), entry.getValue().toString());
-    }
-    return parametersBuilder.build();
+    return parametersBuilder.buildKeepingLast();
   }
 
   static IDatabricksConnectionContext parseWithoutError(String url, Properties properties) {

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -60,6 +60,20 @@ class DatabricksConnectionContextTest {
     assertEquals("value3", propertiesMap.get("param3"));
   }
 
+  @ParameterizedTest
+  @CsvSource({"url-value, url-value", "url-value, properties-value"})
+  public void testBuildPropertiesMapUrlOverridesProperties(
+      String urlValue, String propertiesValue) {
+    Properties properties = new Properties();
+    properties.setProperty("HTTPPATH", propertiesValue);
+
+    ImmutableMap<String, String> propertiesMap =
+        buildPropertiesMap("httpPath=" + urlValue, properties);
+
+    assertEquals(1, propertiesMap.size());
+    assertEquals(urlValue, propertiesMap.get("httppath"));
+  }
+
   @Test
   public void testTelemetrySocketTimeoutDefault() throws DatabricksSQLException {
     DatabricksConnectionContext context =


### PR DESCRIPTION
## Description
- Allow a connection parameter to be supplied in both the JDBC URL and `Properties` without failing on a duplicate map key.
- Preserve JDBC URL precedence when duplicate values differ.
- Add regression coverage for identical and conflicting values with case-insensitive parameter names.

Fixes #1648

## Testing
- `DatabricksConnectionContextTest`: 147 tests passed.
- Live warehouse repro confirmed that duplicate parameters connect successfully and the JDBC URL value takes precedence.
- `isaac review --uncommitted`: 0 final findings.

## Telemetry Errors
- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is requested because the author cannot access the classification.

## Additional Notes to the Reviewer
The precedence behavior is documented in the helper method and the changelog.