### PR TITLE
Fix NPE on materialising nested arrays or arrays of maps with `NULL` elements.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed connecting with an unsupported `AuthMech` (e.g. `AuthMech=99`) intermittently failing with an internal `IllegalStateException: Recursive update` or `StackOverflowError` on both the SEA and Thrift paths. The value is now validated at connect time and rejected deterministically with a `SQLException` (`SQLState=INPUT_VALIDATION_ERROR`).
 
 - Improved SEA connection-failure error messages.
+
+- Fixed `NullPointerException` being thrown when materializing an array containing nested object types (other arrays, structs or maps) as `DatabricksArray` when some or all elements are literal `null`. 
 ---
 *Note: When making changes, please add your change under the appropriate section
 with a brief description.*

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksArray.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksArray.java
@@ -54,6 +54,8 @@ public class DatabricksArray implements Array {
             convertedElements[i] = new DatabricksStruct((Map<String, Object>) element, elementType);
           } else if (element instanceof DatabricksStruct) {
             convertedElements[i] = element;
+          } else if (element == null) {
+            convertedElements[i] = null;
           } else {
             throw new DatabricksDriverException(
                 "Expected a Map for STRUCT but found: " + element.getClass().getSimpleName(),
@@ -64,6 +66,8 @@ public class DatabricksArray implements Array {
             convertedElements[i] = new DatabricksArray((List<Object>) element, elementType);
           } else if (element instanceof DatabricksArray) {
             convertedElements[i] = element;
+          } else if (element == null) {
+            convertedElements[i] = null;
           } else {
             throw new DatabricksDriverException(
                 "Expected a List for ARRAY but found: " + element.getClass().getSimpleName(),
@@ -74,6 +78,8 @@ public class DatabricksArray implements Array {
             convertedElements[i] = new DatabricksMap<>((Map<String, Object>) element, elementType);
           } else if (element instanceof DatabricksMap) {
             convertedElements[i] = element;
+          } else if (element == null) {
+            convertedElements[i] = null;
           } else {
             throw new DatabricksDriverException(
                 "Expected a Map for MAP but found: " + element.getClass().getSimpleName(),

--- a/src/test/java/com/databricks/jdbc/integration/e2e/ComplexTypeQueryTests.java
+++ b/src/test/java/com/databricks/jdbc/integration/e2e/ComplexTypeQueryTests.java
@@ -192,6 +192,89 @@ public class ComplexTypeQueryTests {
 
   @ParameterizedTest
   @CsvSource({"0,0", "1,0", "0,1", "1,1"})
+  void testNestedArrayWithNullElement(int thriftVal, int complexSupport) throws SQLException {
+    setupConnection(thriftVal, complexSupport);
+
+    String sql = "SELECT array(null, array('Hello'))::ARRAY<ARRAY<VARCHAR(32)>> AS arr";
+    ResultSet rs = executeQuery(connection, sql);
+    assertNotNull(rs);
+    while (rs.next()) {
+      if (complexSupport == 1) {
+        Array arr = rs.getArray("arr");
+        assertNotNull(arr);
+        Object[] elements = (Object[]) arr.getArray();
+        assertEquals(2, elements.length);
+        assertNull(elements[0]);
+        assertInstanceOf(Array.class, elements[1]);
+        Object[] innerElements = (Object[]) ((Array) elements[1]).getArray();
+        assertEquals(1, innerElements.length);
+        assertEquals("Hello", innerElements[0]);
+      } else {
+        assertThrows(SQLException.class, () -> rs.getArray("arr"));
+        Object obj = rs.getObject("arr");
+        assertInstanceOf(String.class, obj);
+        String text = (String) obj;
+        assertFalse(text.isEmpty());
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0,0", "1,0", "0,1", "1,1"})
+  void testArrayOfMapsWithNullElement(int thriftVal, int complexSupport) throws SQLException {
+    setupConnection(thriftVal, complexSupport);
+
+    String sql =
+        "SELECT array(null, map('red', 1, 'green', 2))::ARRAY<MAP<VARCHAR(8), INT>> AS arr";
+    ResultSet rs = executeQuery(connection, sql);
+    assertNotNull(rs);
+    while (rs.next()) {
+      if (complexSupport == 1) {
+        Array arr = rs.getArray("arr");
+        assertNotNull(arr);
+        Object[] elements = (Object[]) arr.getArray();
+        assertEquals(2, elements.length);
+        assertNull(elements[0]);
+        assertInstanceOf(Map.class, elements[1]);
+      } else {
+        assertThrows(SQLException.class, () -> rs.getArray("arr"));
+        Object obj = rs.getObject("arr");
+        assertInstanceOf(String.class, obj);
+        String text = (String) obj;
+        assertFalse(text.isEmpty());
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0,0", "1,0", "0,1", "1,1"})
+  void testArrayOfStructsWithNullElement(int thriftVal, int complexSupport) throws SQLException {
+    setupConnection(thriftVal, complexSupport);
+
+    String sql =
+        "SELECT array(null, struct('Spark', 5))::ARRAY<STRUCT<col1:string,col2:int>> AS arr";
+    ResultSet rs = executeQuery(connection, sql);
+    assertNotNull(rs);
+    while (rs.next()) {
+      if (complexSupport == 1) {
+        Array arr = rs.getArray("arr");
+        assertNotNull(arr);
+        Object[] elements = (Object[]) arr.getArray();
+        assertEquals(2, elements.length);
+        assertNull(elements[0]);
+        assertInstanceOf(Struct.class, elements[1]);
+      } else {
+        assertThrows(SQLException.class, () -> rs.getArray("arr"));
+        Object obj = rs.getObject("arr");
+        assertInstanceOf(String.class, obj);
+        String text = (String) obj;
+        assertFalse(text.isEmpty());
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0,0", "1,0", "0,1", "1,1"})
   void testNullArray(int thriftVal, int complexSupport) throws SQLException {
     setupConnection(thriftVal, complexSupport);
 


### PR DESCRIPTION
Null elements in strongly typed nested arrays are valid elements and must be returned as such. This fixes the instance of checking by adding a null-check on both nested branches (arrays of arrays and arrays of maps).

No AI used.

This closes #1658.

## Testing

End to end tested in `ComplexTypeQueryTests`, three new test methods.

## Telemetry Errors

- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any
      new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is
      requested because the author cannot access the classification.

## Additional Notes to the Reviewer

Contributed as part of my work at Neo4j on our Databricks integration. No licence or usage restriction / source restriction on my contribution, also no AI used. Do whatever you want with the code.