### PR TITLE
[PECOBLR-4216] Cache inline Arrow compression metadata

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Fixed
 - Invalid or incomplete Databricks JDBC URLs now fail with a descriptive `DatabricksSQLException`
   instead of leaking a `NullPointerException` when required connection parameters are missing.
-
+- Fixed inline Arrow result processing when later Thrift batches omit compression metadata.
 - Fixed connections failing when the same parameter is provided in both the JDBC URL and the connection properties, with the JDBC URL taking precedence.
 - Fixed `IdleConnectionEvictor` thread leak in long-running applications. Driver-side resources (HTTP client, background threads) are now always released when `Connection.close()` is called, even if statement cleanup or server-side session termination fails.
 

--- a/src/main/java/com/databricks/jdbc/api/impl/ExecutionResultFactory.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/ExecutionResultFactory.java
@@ -14,6 +14,7 @@ import com.databricks.jdbc.exception.*;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.client.thrift.generated.TFetchResultsResp;
+import com.databricks.jdbc.model.client.thrift.generated.TGetResultSetMetadataResp;
 import com.databricks.jdbc.model.client.thrift.generated.TSparkRowSetType;
 import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
@@ -94,7 +95,14 @@ class ExecutionResultFactory {
       IDatabricksStatementInternal parentStatement,
       IDatabricksSession session)
       throws SQLException {
-    TSparkRowSetType resultFormat = resultsResp.getResultSetMetadata().getResultFormat();
+    TGetResultSetMetadataResp metadata = resultsResp.getResultSetMetadata();
+    if (metadata == null) {
+      throw new DatabricksSQLException(
+          "Missing result set metadata",
+          DatabricksDriverErrorCode.INVALID_STATE.name(),
+          DatabricksDriverErrorCode.INVALID_STATE);
+    }
+    TSparkRowSetType resultFormat = metadata.getResultFormat();
     TelemetryHelper.setResultFormat(session.getConnectionContext(), parentStatement, resultFormat);
     LOGGER.info("Processing result of format {} from Thrift server", resultFormat);
     switch (resultFormat) {

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/LazyThriftInlineArrowResult.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/LazyThriftInlineArrowResult.java
@@ -8,11 +8,13 @@ import static com.databricks.jdbc.common.util.ArrowUtil.getTotalRowsInResponse;
 import com.databricks.jdbc.api.impl.IExecutionResult;
 import com.databricks.jdbc.api.internal.IDatabricksSession;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
+import com.databricks.jdbc.common.CompressionCodec;
 import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.client.thrift.generated.TFetchResultsResp;
+import com.databricks.jdbc.model.client.thrift.generated.TGetResultSetMetadataResp;
 import com.databricks.jdbc.model.core.ColumnInfo;
 import com.databricks.jdbc.model.core.ColumnInfoTypeName;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
@@ -39,6 +41,7 @@ public class LazyThriftInlineArrowResult implements IExecutionResult {
   private long totalRowsFetched;
   private List<ColumnInfo> columnInfos;
   private byte[] cachedSchema; // Cache schema from first response for subsequent batches
+  private final CompressionCodec cachedCompressionCodec;
 
   /**
    * Creates a new LazyThriftInlineArrowResult that lazily fetches arrow data on demand.
@@ -61,12 +64,19 @@ public class LazyThriftInlineArrowResult implements IExecutionResult {
     this.isClosed = false;
     this.totalRowsFetched = 0;
 
-    // Initialize column info from metadata
-    this.columnInfos = getColumnInfoList(initialResponse.getResultSetMetadata());
+    TGetResultSetMetadataResp metadata = initialResponse.getResultSetMetadata();
+    if (metadata == null) {
+      throw new DatabricksSQLException(
+          "Initial inline Arrow response is missing result set metadata",
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(),
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR);
+    }
+    this.columnInfos = getColumnInfoList(metadata);
+    this.cachedCompressionCodec = CompressionCodec.getCompressionMapping(metadata);
 
     // Cache the schema from the first response for use in subsequent batches
     try {
-      this.cachedSchema = getSerializedSchema(initialResponse.getResultSetMetadata());
+      this.cachedSchema = getSerializedSchema(metadata);
     } catch (DatabricksParsingException e) {
       LOGGER.error("Failed to cache Arrow schema: {}", e.getMessage(), e);
       throw new DatabricksSQLException(
@@ -258,7 +268,7 @@ public class LazyThriftInlineArrowResult implements IExecutionResult {
   private void loadCurrentChunk() throws DatabricksSQLException {
     try {
       ByteArrayInputStream byteStream =
-          createArrowByteStream(cachedSchema, currentResponse, getClass());
+          createArrowByteStream(cachedSchema, currentResponse, cachedCompressionCodec, getClass());
       long rowCount = getTotalRowsInResponse(currentResponse);
 
       ArrowResultChunk.Builder builder =

--- a/src/main/java/com/databricks/jdbc/api/impl/arrow/StreamingInlineArrowResult.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/arrow/StreamingInlineArrowResult.java
@@ -14,6 +14,7 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.client.thrift.generated.TFetchResultsResp;
+import com.databricks.jdbc.model.client.thrift.generated.TGetResultSetMetadataResp;
 import com.databricks.jdbc.model.core.ColumnInfo;
 import com.databricks.jdbc.model.core.ColumnInfoTypeName;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
@@ -80,8 +81,14 @@ public class StreamingInlineArrowResult implements IExecutionResult {
     this.hasReachedEnd = false;
     this.isClosed = false;
 
-    // Initialize column info from metadata
-    this.columnInfos = getColumnInfoList(initialResponse.getResultSetMetadata());
+    TGetResultSetMetadataResp metadata = initialResponse.getResultSetMetadata();
+    if (metadata == null) {
+      throw new DatabricksSQLException(
+          "Initial inline Arrow response is missing result set metadata",
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(),
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR);
+    }
+    this.columnInfos = getColumnInfoList(metadata);
 
     // Create batch fetcher and type-safe generic provider for Arrow
     ThriftBatchFetcher fetcher = new ThriftBatchFetcherImpl(session, statement);

--- a/src/main/java/com/databricks/jdbc/api/impl/streaming/InlineArrowResponseProcessor.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/streaming/InlineArrowResponseProcessor.java
@@ -5,12 +5,14 @@ import static com.databricks.jdbc.common.util.ArrowUtil.getSerializedSchema;
 import static com.databricks.jdbc.common.util.ArrowUtil.getTotalRowsInResponse;
 
 import com.databricks.jdbc.api.impl.arrow.ArrowResultChunk;
+import com.databricks.jdbc.common.CompressionCodec;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.exception.DatabricksParsingException;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import com.databricks.jdbc.model.client.thrift.generated.TFetchResultsResp;
+import com.databricks.jdbc.model.client.thrift.generated.TGetResultSetMetadataResp;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import java.io.ByteArrayInputStream;
 import java.util.function.Consumer;
@@ -20,7 +22,8 @@ import java.util.function.Consumer;
  *
  * <p>This processor converts {@link TFetchResultsResp} into {@link ArrowResultChunk} for inline
  * Arrow result handling. It caches the Arrow schema from the first response for use in subsequent
- * batches.
+ * batches. The compression codec is also cached because later Thrift responses may omit result set
+ * metadata.
  */
 public class InlineArrowResponseProcessor implements ThriftResponseProcessor<ArrowResultChunk> {
 
@@ -30,6 +33,7 @@ public class InlineArrowResponseProcessor implements ThriftResponseProcessor<Arr
   private final StatementId statementId;
   private volatile byte[]
       cachedSchema; // Cache schema from first response, volatile for visibility across threads
+  private volatile CompressionCodec cachedCompressionCodec;
 
   /**
    * Creates a new inline Arrow response processor.
@@ -44,9 +48,17 @@ public class InlineArrowResponseProcessor implements ThriftResponseProcessor<Arr
   public StreamingBatch<ArrowResultChunk> processInitialResponse(TFetchResultsResp response)
       throws DatabricksSQLException {
     LOGGER.debug("Processing initial inline Arrow response");
-    // Cache the schema for subsequent batches
+    TGetResultSetMetadataResp metadata = response.getResultSetMetadata();
+    if (metadata == null) {
+      throw new DatabricksSQLException(
+          "Initial inline Arrow response is missing result set metadata",
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(),
+          DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR);
+    }
+
     try {
-      this.cachedSchema = getSerializedSchema(response.getResultSetMetadata());
+      this.cachedSchema = getSerializedSchema(metadata);
+      this.cachedCompressionCodec = CompressionCodec.getCompressionMapping(metadata);
     } catch (DatabricksParsingException e) {
       LOGGER.error("Failed to serialize Arrow schema: {}", e.getMessage(), e);
       throw new DatabricksSQLException(
@@ -65,7 +77,8 @@ public class InlineArrowResponseProcessor implements ThriftResponseProcessor<Arr
         new StreamingBatch<>(batchIndex, rowOffset, getReleaseAction());
 
     try {
-      ByteArrayInputStream byteStream = createArrowByteStream(cachedSchema, response, getClass());
+      ByteArrayInputStream byteStream =
+          createArrowByteStream(cachedSchema, response, cachedCompressionCodec, getClass());
       long rowCount = getTotalRowsInResponse(response);
 
       ArrowResultChunk.Builder builder =

--- a/src/main/java/com/databricks/jdbc/common/CompressionCodec.java
+++ b/src/main/java/com/databricks/jdbc/common/CompressionCodec.java
@@ -31,6 +31,9 @@ public enum CompressionCodec {
   }
 
   public static CompressionCodec getCompressionMapping(TGetResultSetMetadataResp metadataResp) {
+    if (metadataResp == null) {
+      return CompressionCodec.NONE;
+    }
     if (!metadataResp.isSetLz4Compressed()) {
       return CompressionCodec.NONE;
     }

--- a/src/main/java/com/databricks/jdbc/common/util/ArrowUtil.java
+++ b/src/main/java/com/databricks/jdbc/common/util/ArrowUtil.java
@@ -151,10 +151,31 @@ public final class ArrowUtil {
   public static ByteArrayInputStream createArrowByteStream(
       byte[] cachedSchema, TFetchResultsResp response, Class<?> callerClass)
       throws DatabricksParsingException {
+    return createArrowByteStream(
+        cachedSchema,
+        response,
+        CompressionCodec.getCompressionMapping(response.getResultSetMetadata()),
+        callerClass);
+  }
+
+  /**
+   * Creates an Arrow IPC byte stream using a previously resolved compression codec.
+   *
+   * @param cachedSchema The serialized Arrow schema bytes
+   * @param response The Thrift fetch response containing Arrow batches
+   * @param compressionCodec The compression codec resolved from the initial response
+   * @param callerClass The calling class for logging context
+   * @return ByteArrayInputStream containing the Arrow IPC data
+   * @throws DatabricksParsingException if processing fails
+   */
+  public static ByteArrayInputStream createArrowByteStream(
+      byte[] cachedSchema,
+      TFetchResultsResp response,
+      CompressionCodec compressionCodec,
+      Class<?> callerClass)
+      throws DatabricksParsingException {
     String context = callerClass.getSimpleName();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    CompressionCodec compressionCodec =
-        CompressionCodec.getCompressionMapping(response.getResultSetMetadata());
 
     try {
       // Write schema if available

--- a/src/test/java/com/databricks/jdbc/api/impl/ExecutionResultFactoryTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ExecutionResultFactoryTest.java
@@ -12,11 +12,13 @@ import com.databricks.jdbc.api.impl.volume.VolumeOperationResult;
 import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
 import com.databricks.jdbc.api.internal.IDatabricksStatementInternal;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
+import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksSQLFeatureNotSupportedException;
 import com.databricks.jdbc.model.client.thrift.generated.*;
 import com.databricks.jdbc.model.core.ResultData;
 import com.databricks.jdbc.model.core.ResultManifest;
 import com.databricks.jdbc.model.core.ResultSchema;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import com.databricks.sdk.service.sql.Format;
 import java.io.ByteArrayOutputStream;
 import java.sql.SQLException;
@@ -125,6 +127,17 @@ public class ExecutionResultFactoryTest {
     assertThrows(
         DatabricksSQLFeatureNotSupportedException.class,
         () -> ExecutionResultFactory.getResultSet(fetchResultsResp, session, parentStatement));
+  }
+
+  @Test
+  public void testGetResultSet_thriftMissingMetadata() {
+    DatabricksSQLException thrown =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> ExecutionResultFactory.getResultSet(fetchResultsResp, session, parentStatement));
+
+    assertEquals(DatabricksDriverErrorCode.INVALID_STATE.name(), thrown.getSQLState());
+    assertEquals(DatabricksDriverErrorCode.INVALID_STATE.getCode(), thrown.getErrorCode());
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/LazyThriftInlineArrowResultTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/LazyThriftInlineArrowResultTest.java
@@ -13,11 +13,13 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.model.client.thrift.generated.*;
 import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -138,6 +140,39 @@ public class LazyThriftInlineArrowResultTest {
     response.hasMoreRows = hasMoreRows;
 
     return response;
+  }
+
+  private TFetchResultsResp createFetchResultsRespWithoutMetadata(
+      byte[] arrowData, int rowCount, boolean hasMoreRows) {
+    TSparkArrowBatch arrowBatch = new TSparkArrowBatch().setRowCount(rowCount).setBatch(arrowData);
+    TRowSet rowSet = new TRowSet().setArrowBatches(Collections.singletonList(arrowBatch));
+    TFetchResultsResp response = new TFetchResultsResp().setResults(rowSet);
+    response.hasMoreRows = hasMoreRows;
+    return response;
+  }
+
+  private static byte[] compressLz4(byte[] data) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (LZ4FrameOutputStream lz4 = new LZ4FrameOutputStream(out)) {
+      lz4.write(data);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create compressed Arrow data", e);
+    }
+    return out.toByteArray();
+  }
+
+  @Test
+  void testMissingInitialMetadataThrowsTypedParsingError() {
+    TFetchResultsResp response = new TFetchResultsResp();
+
+    DatabricksSQLException thrown =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new LazyThriftInlineArrowResult(response, statement, session));
+
+    assertEquals(DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(), thrown.getSQLState());
+    assertEquals(
+        DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.getCode(), thrown.getErrorCode());
   }
 
   @Test
@@ -376,6 +411,31 @@ public class LazyThriftInlineArrowResultTest {
 
     // Verify that getMoreResults was called
     verify(databricksClient).getMoreResults(statement);
+  }
+
+  @Test
+  void testCompressedNextChunkWithoutMetadataUsesInitialCompression() throws SQLException {
+    int rowsPerChunk = 2;
+    byte[] firstArrowData = compressLz4(createValidArrowData(1, rowsPerChunk));
+    byte[] secondArrowData = compressLz4(createValidArrowData(1, rowsPerChunk));
+    TFetchResultsResp initialResponse = createFetchResultsResp(firstArrowData, rowsPerChunk, true);
+    initialResponse.getResultSetMetadata().setLz4Compressed(true);
+    TFetchResultsResp secondResponse =
+        createFetchResultsRespWithoutMetadata(secondArrowData, rowsPerChunk, false);
+
+    when(statement.getStatementId()).thenReturn(STATEMENT_ID);
+    when(session.getDatabricksClient()).thenReturn(databricksClient);
+    when(databricksClient.getMoreResults(statement)).thenReturn(secondResponse);
+
+    LazyThriftInlineArrowResult result =
+        new LazyThriftInlineArrowResult(initialResponse, statement, session);
+
+    assertTrue(result.next());
+    assertTrue(result.next());
+    assertTrue(result.next());
+    assertTrue(result.next());
+    assertFalse(result.next());
+    assertEquals(rowsPerChunk * 2, result.getTotalRowsFetched());
   }
 
   @Test

--- a/src/test/java/com/databricks/jdbc/api/impl/arrow/StreamingInlineArrowResultTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/arrow/StreamingInlineArrowResultTest.java
@@ -60,6 +60,20 @@ public class StreamingInlineArrowResultTest {
   }
 
   @Test
+  void testMissingInitialMetadataThrowsTypedParsingError() {
+    TFetchResultsResp response = new TFetchResultsResp();
+
+    DatabricksSQLException thrown =
+        assertThrows(
+            DatabricksSQLException.class,
+            () -> new StreamingInlineArrowResult(response, statement, session));
+
+    assertEquals(DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(), thrown.getSQLState());
+    assertEquals(
+        DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.getCode(), thrown.getErrorCode());
+  }
+
+  @Test
   void testBasicIteration() throws SQLException {
     int rowCount = 5;
     byte[] arrowData = createValidArrowData(1, rowCount);

--- a/src/test/java/com/databricks/jdbc/api/impl/streaming/InlineArrowResponseProcessorTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/streaming/InlineArrowResponseProcessorTest.java
@@ -6,10 +6,13 @@ import com.databricks.jdbc.api.impl.arrow.ArrowResultChunk;
 import com.databricks.jdbc.dbclient.impl.common.StatementId;
 import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.model.client.thrift.generated.*;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -53,7 +56,7 @@ public class InlineArrowResponseProcessorTest {
 
     // Now process a subsequent response (simulating second batch)
     // The schema should be cached from the initial response
-    TFetchResultsResp subsequentResponse = createArrowFetchResponseNoSchema(3, false);
+    TFetchResultsResp subsequentResponse = createArrowFetchResponseWithoutMetadata(3, false, false);
     StreamingBatch<ArrowResultChunk> batch2 = processor.processResponse(subsequentResponse, 1, 100);
 
     assertNotNull(batch2);
@@ -65,6 +68,38 @@ public class InlineArrowResponseProcessorTest {
     // Clean up native memory
     batch1.release();
     batch2.release();
+  }
+
+  @Test
+  void testCompressedSubsequentResponseWithoutMetadataUsesInitialCompression()
+      throws DatabricksSQLException {
+    InlineArrowResponseProcessor processor = new InlineArrowResponseProcessor(STATEMENT_ID);
+
+    StreamingBatch<ArrowResultChunk> initialBatch =
+        processor.processInitialResponse(createArrowFetchResponse(2, true, true));
+    StreamingBatch<ArrowResultChunk> subsequentBatch =
+        processor.processResponse(createArrowFetchResponseWithoutMetadata(3, false, true), 1, 2);
+
+    assertTrue(initialBatch.isReady());
+    assertTrue(subsequentBatch.isReady());
+    assertEquals(3, subsequentBatch.getRowCount());
+
+    initialBatch.release();
+    subsequentBatch.release();
+  }
+
+  @Test
+  void testInitialResponseWithoutMetadataThrowsTypedParsingError() {
+    InlineArrowResponseProcessor processor = new InlineArrowResponseProcessor(STATEMENT_ID);
+    TFetchResultsResp response = createArrowFetchResponseWithoutMetadata(1, false, false);
+
+    DatabricksSQLException thrown =
+        assertThrows(
+            DatabricksSQLException.class, () -> processor.processInitialResponse(response));
+
+    assertEquals(DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.name(), thrown.getSQLState());
+    assertEquals(
+        DatabricksDriverErrorCode.INLINE_CHUNK_PARSING_ERROR.getCode(), thrown.getErrorCode());
   }
 
   @Test
@@ -141,15 +176,24 @@ public class InlineArrowResponseProcessorTest {
 
   /** Creates an Arrow response with full schema (for initial response). */
   private TFetchResultsResp createArrowFetchResponse(int rowCount, boolean hasMoreRows) {
+    return createArrowFetchResponse(rowCount, hasMoreRows, false);
+  }
+
+  private TFetchResultsResp createArrowFetchResponse(
+      int rowCount, boolean hasMoreRows, boolean lz4Compressed) {
     TFetchResultsResp response = new TFetchResultsResp();
     response.hasMoreRows = hasMoreRows;
 
     byte[] arrowData = createArrowBytes(rowCount);
+    if (lz4Compressed) {
+      arrowData = compressLz4(arrowData);
+    }
 
     TGetResultSetMetadataResp metadata = new TGetResultSetMetadataResp();
     metadata.setResultFormat(TSparkRowSetType.ARROW_BASED_SET);
     metadata.setArrowSchema(new byte[0]); // Empty - schema is in the IPC stream
     metadata.setSchema(createTableSchema());
+    metadata.setLz4Compressed(lz4Compressed);
     response.setResultSetMetadata(metadata);
 
     TSparkArrowBatch arrowBatch = new TSparkArrowBatch();
@@ -160,6 +204,26 @@ public class InlineArrowResponseProcessorTest {
     rowSet.setArrowBatches(Collections.singletonList(arrowBatch));
     response.setResults(rowSet);
 
+    return response;
+  }
+
+  private TFetchResultsResp createArrowFetchResponseWithoutMetadata(
+      int rowCount, boolean hasMoreRows, boolean lz4Compressed) {
+    TFetchResultsResp response = new TFetchResultsResp();
+    response.hasMoreRows = hasMoreRows;
+
+    byte[] arrowData = createArrowBytes(rowCount);
+    if (lz4Compressed) {
+      arrowData = compressLz4(arrowData);
+    }
+
+    TSparkArrowBatch arrowBatch = new TSparkArrowBatch();
+    arrowBatch.setRowCount(rowCount);
+    arrowBatch.setBatch(arrowData);
+
+    TRowSet rowSet = new TRowSet();
+    rowSet.setArrowBatches(Collections.singletonList(arrowBatch));
+    response.setResults(rowSet);
     return response;
   }
 
@@ -213,6 +277,16 @@ public class InlineArrowResponseProcessorTest {
     } catch (Exception e) {
       throw new RuntimeException("Failed to create Arrow data", e);
     }
+  }
+
+  private byte[] compressLz4(byte[] data) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (LZ4FrameOutputStream lz4 = new LZ4FrameOutputStream(out)) {
+      lz4.write(data);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create compressed Arrow data", e);
+    }
+    return out.toByteArray();
   }
 
   /** Creates a TTableSchema with a single INT column. */

--- a/src/test/java/com/databricks/jdbc/common/util/ArrowUtilTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/ArrowUtilTest.java
@@ -93,17 +93,14 @@ public class ArrowUtilTest {
   }
 
   @Test
-  void testCreateArrowByteStream() throws DatabricksParsingException {
+  void testCreateArrowByteStreamWithoutMetadataDefaultsToUncompressed()
+      throws DatabricksParsingException {
     byte[] schema = new byte[] {1, 2, 3};
 
     TFetchResultsResp response = new TFetchResultsResp();
     TRowSet rowSet = new TRowSet();
     rowSet.setArrowBatches(Collections.emptyList());
     response.setResults(rowSet);
-
-    // Set up metadata with no compression
-    TGetResultSetMetadataResp metadata = new TGetResultSetMetadataResp();
-    response.setResultSetMetadata(metadata);
 
     ByteArrayInputStream result = ArrowUtil.createArrowByteStream(schema, response, getClass());
 


### PR DESCRIPTION
## Description

Caches the compression codec from the initial Thrift inline response alongside the Arrow schema, so later result batches can omit optional result-set metadata without failing in compression detection.

If an initial Thrift response omits required metadata, the result factory now rejects it with typed `INVALID_STATE` name and numeric code before dereferencing it. Inline Arrow components continue to use `INLINE_CHUNK_PARSING_ERROR` once the Arrow format is known.

## Testing

Focused coverage includes 63 tests across the result factory, streaming and lazy inline Arrow paths, response processor, and Arrow utilities. It covers compressed and uncompressed later batches without repeated metadata and verifies the error name and numeric code for missing initial metadata.

The focused suite passed locally before the rebase, and Spotless passed on the rebased branch. CI is validating the rebased head because the local environment could not resolve dependency versions newly added on `main`.

## Telemetry Errors

- [ ] Not applicable — this PR does not add or change a telemetry-visible error.
- [x] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any
      new code is uniquely numbered and tested.
- [x] Applicable — its driver/server/user classification is linked, or maintainer help is
      requested because the author cannot access the classification.

## Additional Notes to the Reviewer

Please confirm that `INLINE_CHUNK_PARSING_ERROR` remains appropriate once the response is known to be inline Arrow, and that `INVALID_STATE` is appropriate when metadata is absent before the format can be determined. Retry and download behavior are unchanged.
