### PR TITLE
Fix blocking security scan findings on main

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Updated
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
-- Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions.
+- Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions to address security findings.
 
 ### Fixed
 - Invalid or incomplete Databricks JDBC URLs now fail with a descriptive `DatabricksSQLException`

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,10 +6,7 @@
 
 ### Updated
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
-- Bumped `jackson-databind` (and `jackson-core`/`jackson-annotations`) from 2.18.8 to 2.18.9 to resolve CVE-2026-54515, CVE-2026-59889, and GHSA-mhm7-754m-9p8w (`@JsonView`/`@JsonIgnoreProperties` deserialization bypasses).
-- Bumped `lz4-java` from 1.10.1 to 1.11.1 to resolve CVE-2026-59949 (native XXHash JVM crash on invalid byte-array ranges).
-- Bumped shaded `netty-buffer`/`netty-common` from 4.2.13.Final to 4.2.15.Final (Netty security release). Addresses issue #1584.
-- Bumped Apache `httpcore5` from 5.3.6 to 5.4.3 and pinned the transitive `httpcore5-h2` (HTTP/2 HPACK decoder) to 5.4.3 to resolve CVE-2026-54399 (HTTP/1.1 parser DoS) and CVE-2026-54428 (HPACK header-list-size enforcement). `httpclient5` stays at 5.5.2, which is compatible with the httpcore5 5.4.x branch. Addresses issue #1584.
+- Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions.
 
 ### Fixed
 - Invalid or incomplete Databricks JDBC URLs now fail with a descriptive `DatabricksSQLException`

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Updated
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
+- Bumped `jackson-databind` (and `jackson-core`/`jackson-annotations`) from 2.18.8 to 2.18.9 to resolve CVE-2026-54515, CVE-2026-59889, and GHSA-mhm7-754m-9p8w (`@JsonView`/`@JsonIgnoreProperties` deserialization bypasses).
+- Bumped `lz4-java` from 1.10.1 to 1.11.1 to resolve CVE-2026-59949 (native XXHash JVM crash on invalid byte-array ranges).
+- Bumped shaded `netty-buffer`/`netty-common` from 4.2.13.Final to 4.2.15.Final (Netty security release). Addresses issue #1584.
+- Bumped Apache `httpcore5` from 5.3.6 to 5.4.3 and pinned the transitive `httpcore5-h2` (HTTP/2 HPACK decoder) to 5.4.3 to resolve CVE-2026-54399 (HTTP/1.1 parser DoS) and CVE-2026-54428 (HPACK header-list-size enforcement). `httpclient5` stays at 5.5.2, which is compatible with the httpcore5 5.4.x branch. Addresses issue #1584.
 
 ### Fixed
 - Invalid or incomplete Databricks JDBC URLs now fail with a descriptive `DatabricksSQLException`

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <commons-io.version>2.14.0</commons-io.version>
     <databricks-sdk.version>0.118.0</databricks-sdk.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <async-httpclient.version>5.5.2</async-httpclient.version>
+    <async-httpclient.version>5.6.3</async-httpclient.version>
     <httpcore5.version>5.4.3</httpcore5.version>
     <thrift.version>0.23.0</thrift.version>
     <slf4j.version>2.0.13</slf4j.version>
@@ -120,15 +120,6 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
-      </dependency>
-      <!-- Force safe version of httpcore5-h2 (HTTP/2 HPACK decoder) across all
-           modules, including the uber jar, to resolve CVE-2026-54428. It is a
-           transitive dep of httpclient5 (which otherwise drags in 5.3.6); pin it
-           to the same 5.4.3 as the directly-declared httpcore5. See issue #1584. -->
-      <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5-h2</artifactId>
-        <version>${httpcore5.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,17 +72,17 @@
     <databricks-sdk.version>0.118.0</databricks-sdk.version>
     <httpclient.version>4.5.14</httpclient.version>
     <async-httpclient.version>5.5.2</async-httpclient.version>
-    <httpcore5.version>5.3.6</httpcore5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
     <thrift.version>0.23.0</thrift.version>
     <slf4j.version>2.0.13</slf4j.version>
-    <jackson.version>2.18.8</jackson.version>
+    <jackson.version>2.18.9</jackson.version>
     <gson.version>2.13.2</gson.version>
     <google.guava.version>33.0.0-jre</google.guava.version>
     <google.findbugs.annotations.version>3.0.1</google.findbugs.annotations.version>
     <immutables.value.version>2.9.2</immutables.value.version>
-    <lz4-compression.version>1.10.1</lz4-compression.version>
+    <lz4-compression.version>1.11.1</lz4-compression.version>
     <annotation.version>1.3.5</annotation.version>
-    <netty.version>4.2.13.Final</netty.version>
+    <netty.version>4.2.15.Final</netty.version>
     <grpc.version>1.71.0</grpc.version>
     <jts-core.version>1.20.0</jts-core.version>
     <resilience4j.version>1.7.0</resilience4j.version>
@@ -120,6 +120,15 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
+      </dependency>
+      <!-- Force safe version of httpcore5-h2 (HTTP/2 HPACK decoder) across all
+           modules, including the uber jar, to resolve CVE-2026-54428. It is a
+           transitive dep of httpclient5 (which otherwise drags in 5.3.6); pin it
+           to the same 5.4.3 as the directly-declared httpcore5. See issue #1584. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcore5.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Summary
- upgrade Apache HttpClient to 5.6.3, which officially resolves both `httpcore5` and `httpcore5-h2` to patched version 5.4.3
- update Jackson, lz4-java, and shaded Netty dependencies to clear the remaining current OSV findings
- document the user-visible dependency updates in `NEXT_CHANGELOG.md`

Closes #1584.

## Test plan
- [x] `mvn clean package -Dmaven.test.skip=true -Ddependency-check.skip=true -B`
- [x] Maven dependency tree resolves `httpclient5:5.6.3`, `httpcore5:5.4.3`, and `httpcore5-h2:5.4.3`
- [x] verified the uber JAR embeds those versions plus Jackson 2.18.9, lz4-java 1.11.1, and Netty 4.2.15.Final
- [x] GitHub Security Scan
- [x] local PR integration tests
- [x] external JDBC integration tests

## Telemetry Errors
- [x] Not applicable — this change does not add or change a telemetry-visible error.