### PR TITLE
Avoid false unsupported-operation telemetry for nested timestamps

### DIFF
--- a/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/ComplexDataTypeParser.java
@@ -233,22 +233,18 @@ public class ComplexDataTypeParser {
       case DatabricksTypeUtil.TIMESTAMP:
       case DatabricksTypeUtil.TIMESTAMP_NTZ:
         try {
-          return parseTimestamp(text);
-        } catch (IllegalArgumentException e) {
+          // Parse Arrow's expected numeric format before TimestampConverter logs a failed attempt.
           // Arrow serializes TIMESTAMP/TIMESTAMP_NTZ inside nested types as epoch microseconds.
           // e.g., {"ts":1696519230000000} for 2023-10-05 15:20:30 UTC
-          try {
-            long micros = Long.parseLong(text);
-            long seconds = Math.floorDiv(micros, 1_000_000L);
-            long microsRemainder = Math.floorMod(micros, 1_000_000L);
-            Instant instant = Instant.ofEpochSecond(seconds, microsRemainder * 1_000);
-            // Build from the UTC wall-clock; Timestamp.from(instant) gets re-rendered in the JVM
-            // default timezone, shifting nested TIMESTAMP fields (ES-1978662).
-            return Timestamp.valueOf(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
-          } catch (NumberFormatException nfe) {
-            LOGGER.error(e, "Failed to parse TIMESTAMP value '{}' as epoch microseconds", text);
-            throw e;
-          }
+          long micros = Long.parseLong(text);
+          long seconds = Math.floorDiv(micros, 1_000_000L);
+          long microsRemainder = Math.floorMod(micros, 1_000_000L);
+          Instant instant = Instant.ofEpochSecond(seconds, microsRemainder * 1_000);
+          // Build from the UTC wall-clock; Timestamp.from(instant) gets re-rendered in the JVM
+          // default timezone, shifting nested TIMESTAMP fields (ES-1978662).
+          return Timestamp.valueOf(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
+        } catch (NumberFormatException e) {
+          return parseTimestamp(text);
         }
       case DatabricksTypeUtil.TIME:
         return Time.valueOf(text);

--- a/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeParserTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ComplexDataTypeParserTest.java
@@ -1,13 +1,24 @@
 package com.databricks.jdbc.api.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.DatabricksClientType;
+import com.databricks.jdbc.common.TelemetryLogLevel;
+import com.databricks.jdbc.common.util.DatabricksThreadContextHolder;
 import com.databricks.jdbc.exception.DatabricksParsingException;
+import com.databricks.jdbc.telemetry.ITelemetryClient;
+import com.databricks.jdbc.telemetry.TelemetryClientFactory;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ComplexDataTypeParserTest {
 
@@ -254,6 +265,35 @@ public class ComplexDataTypeParserTest {
       assertEquals(0, ts.getNanos() % 1_000_000); // no sub-millisecond component
     } catch (Exception e) {
       fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test
+  void testTimestampAsEpochMicrosDoesNotEmitFailureTelemetry() throws Exception {
+    String json = "{\"before_epoch\":-1,\"fractional\":1696519230123456}";
+    IDatabricksConnectionContext connectionContext = mock(IDatabricksConnectionContext.class);
+    when(connectionContext.getTelemetryLogLevel()).thenReturn(TelemetryLogLevel.DEBUG);
+    when(connectionContext.getConnectionUuid()).thenReturn("epoch-micros-test");
+    when(connectionContext.getClientType()).thenReturn(DatabricksClientType.THRIFT);
+    DatabricksThreadContextHolder.setConnectionContext(connectionContext);
+
+    TelemetryClientFactory factory = mock(TelemetryClientFactory.class);
+    ITelemetryClient client = mock(ITelemetryClient.class);
+
+    try (MockedStatic<TelemetryClientFactory> telemetryFactory =
+        Mockito.mockStatic(TelemetryClientFactory.class)) {
+      telemetryFactory.when(TelemetryClientFactory::getInstance).thenReturn(factory);
+      when(factory.getTelemetryClient(connectionContext)).thenReturn(client);
+      DatabricksStruct dbStruct =
+          parser.parseJsonStringToDbStruct(
+              json, "STRUCT<before_epoch:TIMESTAMP_NTZ,fractional:TIMESTAMP>");
+      Object[] attrs = dbStruct.getAttributes();
+
+      assertEquals(Timestamp.valueOf("1969-12-31 23:59:59.999999"), attrs[0]);
+      assertEquals(Timestamp.valueOf("2023-10-05 15:20:30.123456"), attrs[1]);
+      telemetryFactory.verify(TelemetryClientFactory::getInstance, never());
+    } finally {
+      DatabricksThreadContextHolder.clearAllContext();
     }
   }
 


### PR DESCRIPTION
## Description

Parses Arrow's epoch-microsecond representation for nested `TIMESTAMP` and `TIMESTAMP_NTZ` values before trying the formatted-string converter. Successful numeric values therefore no longer construct and export a false `UNSUPPORTED_OPERATION` error. Formatted timestamp strings and returned timestamp values are unchanged.

## Testing

The regression test covers both timestamp types, a pre-1970 value, microsecond precision, and verifies that successful numeric parsing never initializes the telemetry client.

- `mvn spotless:apply`: passed
- Focused Maven tests were attempted after rebasing, but current `main` dependencies were unavailable because Maven Central DNS resolution failed locally. CI remains the current test gate.

## Telemetry Errors

- [ ] Not applicable — this PR does not add or change a telemetry-visible error.
- [x] Applicable — this removes an incorrect `UNSUPPORTED_OPERATION` emission; it adds no error code or numeric value.
- [x] Applicable — the existing classification is unchanged; maintainer confirmation is requested that no dashboard or taxonomy update is needed.

## Additional Notes to the Reviewer

Review focus: numeric-first fallback behavior and the no-telemetry regression assertion.

NO_CHANGELOG=true
