### PR TITLE
Enable native SEA metadata defaults behind server flag

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `EnableThriftNativeMetadata` to request and consume supported Thrift-native SEA metadata results.
 
 ### Updated
+- `UseBoundedSeaApi` and `EnableThriftNativeMetadata` now default to `1`; when unset, activation is controlled by the server-side `enableNativeMetadataViaSEA` rollout flag.
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 - Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions to address security findings.
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `EnableThriftNativeMetadata` to request and consume supported Thrift-native SEA metadata results.
 
 ### Updated
-- `UseBoundedSeaApi` and `EnableThriftNativeMetadata` now default to `1`; when unset, activation is controlled by the server-side `enableNativeMetadataViaSEA` rollout flag.
+- `UseBoundedSeaApi` and `EnableThriftNativeMetadata` now default to `1`; when unset, activation is controlled by the server-side `enableSqlExecForJdbc` rollout flag.
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 - Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions to address security findings.
 

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -49,6 +49,9 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   private static final String USE_QUERY_FOR_THRIFT_FLAG_NAME =
       "databricks.partnerplatform.clientConfigsFeatureFlags.enableUseQueryForThriftJdbc";
 
+  private static final String NATIVE_METADATA_VIA_SEA_FLAG_NAME =
+      "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA";
+
   private final String host;
   @VisibleForTesting final int port;
   private final String schema;
@@ -1519,7 +1522,8 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   @Override
   public boolean isThriftNativeMetadataEnabled() {
-    return getParameter(DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA).equals("1");
+    return resolveFeatureFlag(
+        DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA, NATIVE_METADATA_VIA_SEA_FLAG_NAME);
   }
 
   @Override
@@ -1549,7 +1553,8 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   @Override
   public boolean isBoundedSeaApiEnabled() {
-    return getParameter(DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API).equals("1");
+    return resolveFeatureFlag(
+        DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API, NATIVE_METADATA_VIA_SEA_FLAG_NAME);
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksConnectionContext.java
@@ -49,9 +49,6 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   private static final String USE_QUERY_FOR_THRIFT_FLAG_NAME =
       "databricks.partnerplatform.clientConfigsFeatureFlags.enableUseQueryForThriftJdbc";
 
-  private static final String NATIVE_METADATA_VIA_SEA_FLAG_NAME =
-      "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA";
-
   private final String host;
   @VisibleForTesting final int port;
   private final String schema;
@@ -1523,7 +1520,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
   @Override
   public boolean isThriftNativeMetadataEnabled() {
     return resolveFeatureFlag(
-        DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA, NATIVE_METADATA_VIA_SEA_FLAG_NAME);
+        DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA, SQL_EXEC_FLAG_NAME);
   }
 
   @Override
@@ -1553,8 +1550,7 @@ public class DatabricksConnectionContext implements IDatabricksConnectionContext
 
   @Override
   public boolean isBoundedSeaApiEnabled() {
-    return resolveFeatureFlag(
-        DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API, NATIVE_METADATA_VIA_SEA_FLAG_NAME);
+    return resolveFeatureFlag(DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API, SQL_EXEC_FLAG_NAME);
   }
 
   @Override

--- a/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
+++ b/src/main/java/com/databricks/jdbc/common/DatabricksJdbcUrlParams.java
@@ -215,11 +215,11 @@ public enum DatabricksJdbcUrlParams {
   USE_BOUNDED_SEA_API(
       "UseBoundedSeaApi",
       "Use bounded SEA API for CloudFetch: send row_offset on GetResultData, force StreamingChunkProvider, stop relying on total_chunk_count. Requires server support.",
-      "0"),
+      "1"),
   ENABLE_THRIFT_NATIVE_METADATA(
       "EnableThriftNativeMetadata",
       "Request Thrift-native SEA results for catalogs, schemas, tables, columns, functions, primary keys, imported keys, and cross references",
-      "0"),
+      "1"),
   DISABLE_OAUTH_REFRESH_TOKEN(
       "DisableOauthRefreshToken",
       "Disable requesting OAuth refresh tokens (omit offline_access unless explicitly provided)",

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -1685,8 +1685,7 @@ class DatabricksConnectionContextTest {
             DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
 
     Map<String, String> flags = new HashMap<>();
-    flags.put(
-        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+    flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
     DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
 
     assertEquals("1", DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API.getDefaultValue());
@@ -1703,8 +1702,7 @@ class DatabricksConnectionContextTest {
             DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
 
     Map<String, String> flags = new HashMap<>();
-    flags.put(
-        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "false");
+    flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "false");
     DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
 
     assertFalse(ctx.isBoundedSeaApiEnabled());
@@ -1719,8 +1717,7 @@ class DatabricksConnectionContextTest {
             DatabricksConnectionContext.parse(TestConstants.VALID_CLUSTER_URL, properties);
 
     Map<String, String> flags = new HashMap<>();
-    flags.put(
-        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+    flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
     DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
 
     assertFalse(ctx.isBoundedSeaApiEnabled());
@@ -1743,11 +1740,11 @@ class DatabricksConnectionContextTest {
 
     Map<String, String> disabledFlag = new HashMap<>();
     disabledFlag.put(
-        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "false");
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "false");
     DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(enabledCtx, disabledFlag);
     Map<String, String> enabledFlag = new HashMap<>();
     enabledFlag.put(
-        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
     DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(disabledCtx, enabledFlag);
 
     assertTrue(enabledCtx.isBoundedSeaApiEnabled());

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -20,6 +20,7 @@ import com.databricks.jdbc.exception.DatabricksSQLException;
 import com.databricks.jdbc.exception.DatabricksVendorCode;
 import com.databricks.sdk.core.ProxyConfig;
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,11 +41,24 @@ class DatabricksConnectionContextTest {
 
   private static final Properties properties = new Properties();
   private static final Properties properties_with_pwd = new Properties();
+  private final List<IDatabricksConnectionContext> featureFlagContextsToCleanUp = new ArrayList<>();
 
   @BeforeAll
   public static void setUp() {
     properties.setProperty("password", "passwd");
     properties_with_pwd.setProperty("pwd", "passwd2");
+  }
+
+  @AfterEach
+  public void cleanUpFeatureFlagContexts() {
+    featureFlagContextsToCleanUp.forEach(
+        DatabricksDriverFeatureFlagsContextFactory::removeInstance);
+  }
+
+  private void setFeatureFlagsContext(
+      IDatabricksConnectionContext context, Map<String, String> flags) {
+    featureFlagContextsToCleanUp.add(context);
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(context, flags);
   }
 
   @Test
@@ -1686,7 +1701,7 @@ class DatabricksConnectionContextTest {
 
     Map<String, String> flags = new HashMap<>();
     flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
-    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+    setFeatureFlagsContext(ctx, flags);
 
     assertEquals("1", DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API.getDefaultValue());
     assertEquals("1", DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA.getDefaultValue());
@@ -1703,7 +1718,7 @@ class DatabricksConnectionContextTest {
 
     Map<String, String> flags = new HashMap<>();
     flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "false");
-    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+    setFeatureFlagsContext(ctx, flags);
 
     assertFalse(ctx.isBoundedSeaApiEnabled());
     assertFalse(ctx.isThriftNativeMetadataEnabled());
@@ -1718,7 +1733,7 @@ class DatabricksConnectionContextTest {
 
     Map<String, String> flags = new HashMap<>();
     flags.put("databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
-    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+    setFeatureFlagsContext(ctx, flags);
 
     assertFalse(ctx.isBoundedSeaApiEnabled());
     assertFalse(ctx.isThriftNativeMetadataEnabled());
@@ -1741,11 +1756,11 @@ class DatabricksConnectionContextTest {
     Map<String, String> disabledFlag = new HashMap<>();
     disabledFlag.put(
         "databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "false");
-    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(enabledCtx, disabledFlag);
+    setFeatureFlagsContext(enabledCtx, disabledFlag);
     Map<String, String> enabledFlag = new HashMap<>();
     enabledFlag.put(
         "databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc", "true");
-    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(disabledCtx, enabledFlag);
+    setFeatureFlagsContext(disabledCtx, enabledFlag);
 
     assertTrue(enabledCtx.isBoundedSeaApiEnabled());
     assertTrue(enabledCtx.isThriftNativeMetadataEnabled());

--- a/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/DatabricksConnectionContextTest.java
@@ -1677,6 +1677,85 @@ class DatabricksConnectionContextTest {
     assertFalse(ctx.useQueryForMetadata());
   }
 
+  @Test
+  public void testNativeMetadataViaSea_serverFlagEnabled_warehouseReturnsTrue()
+      throws DatabricksSQLException {
+    DatabricksConnectionContext ctx =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
+
+    Map<String, String> flags = new HashMap<>();
+    flags.put(
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+
+    assertEquals("1", DatabricksJdbcUrlParams.USE_BOUNDED_SEA_API.getDefaultValue());
+    assertEquals("1", DatabricksJdbcUrlParams.ENABLE_THRIFT_NATIVE_METADATA.getDefaultValue());
+    assertTrue(ctx.isBoundedSeaApiEnabled());
+    assertTrue(ctx.isThriftNativeMetadataEnabled());
+  }
+
+  @Test
+  public void testNativeMetadataViaSea_serverFlagDisabled_warehouseReturnsFalse()
+      throws DatabricksSQLException {
+    DatabricksConnectionContext ctx =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(TestConstants.VALID_URL_1, properties);
+
+    Map<String, String> flags = new HashMap<>();
+    flags.put(
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "false");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+
+    assertFalse(ctx.isBoundedSeaApiEnabled());
+    assertFalse(ctx.isThriftNativeMetadataEnabled());
+  }
+
+  @Test
+  public void testNativeMetadataViaSea_serverFlagEnabled_clusterIgnored()
+      throws DatabricksSQLException {
+    DatabricksConnectionContext ctx =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(TestConstants.VALID_CLUSTER_URL, properties);
+
+    Map<String, String> flags = new HashMap<>();
+    flags.put(
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(ctx, flags);
+
+    assertFalse(ctx.isBoundedSeaApiEnabled());
+    assertFalse(ctx.isThriftNativeMetadataEnabled());
+  }
+
+  @Test
+  public void testNativeMetadataViaSea_explicitParamsOverrideServerFlag()
+      throws DatabricksSQLException {
+    DatabricksConnectionContext enabledCtx =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(
+                TestConstants.VALID_URL_1 + ";UseBoundedSeaApi=1;EnableThriftNativeMetadata=1",
+                properties);
+    DatabricksConnectionContext disabledCtx =
+        (DatabricksConnectionContext)
+            DatabricksConnectionContext.parse(
+                TestConstants.VALID_URL_1 + ";UseBoundedSeaApi=0;EnableThriftNativeMetadata=0",
+                properties);
+
+    Map<String, String> disabledFlag = new HashMap<>();
+    disabledFlag.put(
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "false");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(enabledCtx, disabledFlag);
+    Map<String, String> enabledFlag = new HashMap<>();
+    enabledFlag.put(
+        "databricks.partnerplatform.clientConfigsFeatureFlags.enableNativeMetadataViaSEA", "true");
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(disabledCtx, enabledFlag);
+
+    assertTrue(enabledCtx.isBoundedSeaApiEnabled());
+    assertTrue(enabledCtx.isThriftNativeMetadataEnabled());
+    assertFalse(disabledCtx.isBoundedSeaApiEnabled());
+    assertFalse(disabledCtx.isThriftNativeMetadataEnabled());
+  }
+
   // ---------------------------------------------------------------------------
   // Geospatial flag independence from complex datatype flag
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Sets `UseBoundedSeaApi` and `EnableThriftNativeMetadata` defaults to `1`. When unset, both features require the existing server-side `databricks.partnerplatform.clientConfigsFeatureFlags.enableSqlExecForJdbc` flag on SQL warehouses; explicit JDBC settings continue to take precedence.

## Testing

- `mvn test -pl jdbc-core -Dtest=DatabricksConnectionContextTest#testNativeMetadataViaSea*` (4 passed)
- `mvn spotless:check`
- Full `DatabricksConnectionContextTest` run: 157 passed; one existing Mockito test could not initialize Byte Buddy attachment on the local JDK.

## Telemetry Errors

- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is requested because the author cannot access the classification.

## Additional Notes to the Reviewer

The existing SQL Exec server flag controls the rollout only when the JDBC properties are not explicitly configured.