### PR TITLE
Fix string parameters losing apostrophes when interpolated into SQL

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -24,6 +24,14 @@
 
 - Improved SEA connection-failure error messages.
 
+- Fixed string parameters silently losing apostrophes when `supportManyParameters=1` interpolates them into SQL.
+  `SQLInterpolator` escaped `'` as the SQL-standard `''`, which Databricks does not implement: `'O''Brien'` is read
+  as the adjacent literals `'O'` and `'Brien'` and concatenated, so `O'Brien` was stored as `OBrien`. Quotes are now
+  escaped as `\'`, consistent with the backslash escaping already applied to `\`, `\n`, `\r` and `\t`.
+  Data written through this path before the upgrade still holds the stripped values, so lookups that now send the
+  apostrophe (`WHERE name = ?` bound to `O'Brien`) no longer match those rows. Only values written with
+  `supportManyParameters=1` are affected; correcting them requires a data fix.
+
 - Fixed `NullPointerException` being thrown when materializing an array containing nested object types (other arrays, structs or maps) as `DatabricksArray` when some or all elements are literal `null`. 
 ---
 *Note: When making changes, please add your change under the appropriate section

--- a/src/main/java/com/databricks/jdbc/common/util/SQLInterpolator.java
+++ b/src/main/java/com/databricks/jdbc/common/util/SQLInterpolator.java
@@ -22,8 +22,8 @@ public class SQLInterpolator {
       i += Character.charCount(codePoint);
       switch (codePoint) {
         case '\'':
-          out.append("''");
-          break; // SQL-standard quote escape
+          out.append("\\'");
+          break; // Databricks escapes a quote as \', not as the SQL-standard ''
         case '\\':
           out.append("\\\\");
           break; // escape backslash

--- a/src/test/java/com/databricks/jdbc/common/util/SQLInterpolatorTest.java
+++ b/src/test/java/com/databricks/jdbc/common/util/SQLInterpolatorTest.java
@@ -80,7 +80,7 @@ public class SQLInterpolatorTest {
     Map<Integer, ImmutableSqlParameter> params = new HashMap<>();
     params.put(1, getSqlParam(1, "O'Reilly", DatabricksTypeUtil.STRING));
     params.put(2, getSqlParam(2, 200, DatabricksTypeUtil.INT));
-    String expected = "UPDATE products SET price = 'O''Reilly' WHERE id = 200";
+    String expected = "UPDATE products SET price = 'O\\'Reilly' WHERE id = 200";
     assertEquals(expected, SQLInterpolator.interpolateSQL(sql, params));
   }
 
@@ -108,7 +108,7 @@ public class SQLInterpolatorTest {
     String sql = "SELECT ?";
     Map<Integer, ImmutableSqlParameter> params = new HashMap<>();
     params.put(1, getSqlParam(1, "X'41' OR 1=1 --", DatabricksTypeUtil.BINARY));
-    assertEquals("SELECT 'X''41'' OR 1=1 --'", SQLInterpolator.interpolateSQL(sql, params));
+    assertEquals("SELECT 'X\\'41\\' OR 1=1 --'", SQLInterpolator.interpolateSQL(sql, params));
   }
 
   @Test
@@ -217,8 +217,12 @@ public class SQLInterpolatorTest {
 
   @Test
   public void testEscapeInputs() {
-    // Simple apostrophe doubling
-    assertEquals("'foo''bar'", SQLInterpolator.escapeInputs("foo'bar"));
+    // Apostrophe escaped with a backslash; '' would be read as two adjacent literals
+    assertEquals("'foo\\'bar'", SQLInterpolator.escapeInputs("foo'bar"));
+    // Leading, trailing and consecutive apostrophes
+    assertEquals("'\\'lead'", SQLInterpolator.escapeInputs("'lead"));
+    assertEquals("'trail\\''", SQLInterpolator.escapeInputs("trail'"));
+    assertEquals("'a\\'\\'b'", SQLInterpolator.escapeInputs("a''b"));
     // Escaping newlines
     assertEquals("'line1\\nline2'", SQLInterpolator.escapeInputs("line1\nline2"));
     // Escaping backslashes


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes made and the issue they aim to address.-->
ixed string parameters silently losing apostrophes when `supportManyParameters=1` interpolates them into SQL. `SQLInterpolator` escaped `'` as the SQL-standard `''`, which Databricks does not implement: `'O''Brien'` is read as the adjacent literals `'O'` and `'Brien'` and concatenated, so `O'Brien` was stored as `OBrien`. Quotes are not escaped as `\'`, consistent with the backslash escaping already applied to `\`, `\n`, `\r` and `\t`. Data written through this path before the upgrade still holds the stripped values, so lookups that now send the apostrophe (`WHERE name = ?` bound to `O'Brien`) no longer match those rows. Only values written with `supportManyParameters=1` are affected; correcting them requires a data fix.


Why this does not change behaviour for anything that worked before


- **Inputs without an apostrophe emit byte-identical SQL.** The `case '\''` branch is the only thing that
  changed; every other input takes exactly the path it took before. The `\`, `\n`, `\r`, `\t` and
  supplementary-plane branches, the `BINARY`/hex-literal path guarded by `HEX_LITERAL_PATTERN` (SEC-20590),
  `NULL` handling, `TIMESTAMP`/`DATE` quoting and numeric pass-through are all untouched.
- **Inputs with an apostrophe had no correct behaviour to preserve.** The previous output was never
  interpreted as the caller intended — the value arrived at the server with its quotes removed. So the change
  is a no-op for inputs that worked and a fix for inputs that did not; there is no third category.
- **Both forms keep the literal balanced, so this is a fidelity fix, not a security fix.** `''` contributes an
  even number of quotes; `\'` is a single escaped quote inside one literal. Backslashes in the input are still
  escaped first (`\` -> `\\`), so an input ending in a backslash cannot close the literal early: `a\'b` emits
  `'a\\\'b'`, which the server reads back as `a\'b`. Statement structure is unchanged either way; only the
  value the server stores differs.


## Testing
<!-- Describe how the changes have been tested-->
Running batch inserts with supportManyParameters=1 against real databricks instance
## Telemetry Errors
<!--
If this PR adds or changes an error emitted by the JDBC driver, complete both
"Applicable" items. Otherwise check "Not applicable" only.
-->
- [ ] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any
      new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is
      requested because the author cannot access the classification.

## Additional Notes to the Reviewer
<!-- Share any additional context or insights that may help the reviewer understand the changes better. This could include challenges faced, limitations, or compromises made during the development process.
Also, mention any areas of the code that you would like the reviewer to focus on specifically. -->
