### PR TITLE
Emit a leaner stack_trace field (emit frames, not the message)

### DIFF
--- a/src/main/java/com/databricks/jdbc/exception/DatabricksBatchUpdateException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksBatchUpdateException.java
@@ -24,7 +24,7 @@ public class DatabricksBatchUpdateException extends BatchUpdateException {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         internalErrorCode.toString(),
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 
@@ -39,7 +39,7 @@ public class DatabricksBatchUpdateException extends BatchUpdateException {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         SQLState,
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksDriverException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksDriverException.java
@@ -22,7 +22,7 @@ public class DatabricksDriverException extends RuntimeException {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         sqlState,
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 
@@ -31,7 +31,7 @@ public class DatabricksDriverException extends RuntimeException {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         sqlState,
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 }

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksSQLException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksSQLException.java
@@ -35,7 +35,7 @@ public class DatabricksSQLException extends SQLException {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         sqlState,
-        reason,
+        this,
         statementId,
         chunkIndex,
         TelemetryLogLevel.ERROR);
@@ -60,7 +60,7 @@ public class DatabricksSQLException extends SQLException {
       DatabricksDriverErrorCode internalError,
       boolean silentExceptions) {
     super(reason, sqlState, internalError.getCode());
-    logTelemetryEvent(sqlState, reason, silentExceptions);
+    logTelemetryEvent(sqlState, silentExceptions);
   }
 
   public DatabricksSQLException(String reason, String sqlState, int vendorCode) {
@@ -70,20 +70,20 @@ public class DatabricksSQLException extends SQLException {
   public DatabricksSQLException(
       String reason, String sqlState, int vendorCode, boolean silentExceptions) {
     super(reason, sqlState, vendorCode);
-    logTelemetryEvent(sqlState, reason, silentExceptions);
+    logTelemetryEvent(sqlState, silentExceptions);
   }
 
   public DatabricksSQLException(String reason, String sqlState, int vendorCode, Throwable cause) {
     super(reason, sqlState, vendorCode, cause);
-    logTelemetryEvent(sqlState, reason, false);
+    logTelemetryEvent(sqlState, false);
   }
 
-  private void logTelemetryEvent(String sqlState, String reason, boolean silentExceptions) {
+  private void logTelemetryEvent(String sqlState, boolean silentExceptions) {
     if (!silentExceptions) {
       exportFailureLog(
           DatabricksThreadContextHolder.getConnectionContext(),
           sqlState,
-          reason,
+          this,
           TelemetryLogLevel.ERROR);
     } else {
       // These are errors that are thrown to call a fallback method (e.g. metadata column not
@@ -92,7 +92,7 @@ public class DatabricksSQLException extends SQLException {
       exportFailureLog(
           DatabricksThreadContextHolder.getConnectionContext(),
           sqlState,
-          reason,
+          this,
           TelemetryLogLevel.TRACE);
     }
   }

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksTimeoutException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksTimeoutException.java
@@ -15,7 +15,7 @@ public class DatabricksTimeoutException extends SQLTimeoutException {
     TelemetryHelper.exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         internalError.name(),
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 
@@ -25,7 +25,7 @@ public class DatabricksTimeoutException extends SQLTimeoutException {
     TelemetryHelper.exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         internalError.name(),
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 }

--- a/src/main/java/com/databricks/jdbc/exception/DatabricksTransactionException.java
+++ b/src/main/java/com/databricks/jdbc/exception/DatabricksTransactionException.java
@@ -36,7 +36,7 @@ public class DatabricksTransactionException extends SQLException {
   public DatabricksTransactionException(
       String reason, String sqlState, int vendorCode, Throwable cause) {
     super(reason, sqlState, vendorCode, cause);
-    logTelemetryEvent(sqlState, reason);
+    logTelemetryEvent(sqlState);
   }
 
   /**
@@ -98,11 +98,11 @@ public class DatabricksTransactionException extends SQLException {
     return DatabricksVendorCode.getVendorCode(cause);
   }
 
-  private void logTelemetryEvent(String sqlState, String reason) {
+  private void logTelemetryEvent(String sqlState) {
     exportFailureLog(
         DatabricksThreadContextHolder.getConnectionContext(),
         sqlState,
-        reason,
+        this,
         TelemetryLogLevel.ERROR);
   }
 }

--- a/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
+++ b/src/main/java/com/databricks/jdbc/telemetry/TelemetryHelper.java
@@ -30,8 +30,10 @@ import com.databricks.sdk.service.sql.Format;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.Charset;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class TelemetryHelper {
   private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(TelemetryHelper.class);
@@ -40,6 +42,9 @@ public class TelemetryHelper {
   private static final ConcurrentHashMap<String, DriverConnectionParameters>
       connectionParameterCache = new ConcurrentHashMap<>();
   private static final String APP_NAME_SYSTEM_PROPERTY = "app.name";
+  // Upper bound on the number of stack frames serialized into the telemetry stack_trace field,
+  // to keep payloads bounded for deep stacks.
+  private static final int MAX_STACK_TRACE_FRAMES = 100;
 
   @VisibleForTesting
   static final String TELEMETRY_FEATURE_FLAG_NAME =
@@ -134,22 +139,22 @@ public class TelemetryHelper {
   public static void exportFailureLog(
       IDatabricksConnectionContext connectionContext,
       String errorName,
-      String errorMessage,
+      Throwable throwable,
       TelemetryLogLevel logLevel) {
     String statementId = DatabricksThreadContextHolder.getStatementId();
     exportFailureLog(
-        connectionContext, errorName, errorMessage, statementId, /* chunkIndex */ null, logLevel);
+        connectionContext, errorName, throwable, statementId, /* chunkIndex */ null, logLevel);
   }
 
   public static void exportFailureLog(
       IDatabricksConnectionContext connectionContext,
       String errorName,
-      String errorMessage,
+      Throwable throwable,
       String statementId,
       Long chunkIndex,
       TelemetryLogLevel logLevel) {
     DriverErrorInfo errorInfo =
-        new DriverErrorInfo().setErrorName(errorName).setStackTrace(errorMessage);
+        new DriverErrorInfo().setErrorName(errorName).setStackTrace(formatStackTrace(throwable));
     StatementTelemetryDetails telemetryDetails;
     if (statementId == null) {
       telemetryDetails = new StatementTelemetryDetails(null);
@@ -159,6 +164,29 @@ public class TelemetryHelper {
       telemetryDetails = collector.getOrCreateTelemetryDetails(statementId);
     }
     exportTelemetryEvent(connectionContext, telemetryDetails, errorInfo, chunkIndex, logLevel);
+  }
+
+  /**
+   * Formats a throwable's stack frames (class, method, file, line) into a newline-separated string
+   * for the telemetry {@code stack_trace} field.
+   *
+   * <p>Only code locations are serialized — never the throwable's message. Exception messages in
+   * the driver routinely embed user data (SQL text, hostnames, literal filter values), so excluding
+   * the message keeps that PII out of telemetry by construction.
+   *
+   * @param throwable the throwable whose frames to format; may be {@code null}
+   * @return the newline-separated frames (capped at {@link #MAX_STACK_TRACE_FRAMES}), or {@code
+   *     null} if {@code throwable} is {@code null}
+   */
+  @VisibleForTesting
+  static String formatStackTrace(Throwable throwable) {
+    if (throwable == null) {
+      return null;
+    }
+    return Arrays.stream(throwable.getStackTrace())
+        .limit(MAX_STACK_TRACE_FRAMES)
+        .map(StackTraceElement::toString)
+        .collect(Collectors.joining("\n"));
   }
 
   public static String getStatementIdString(StatementId statementId) {

--- a/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
+++ b/src/test/java/com/databricks/jdbc/telemetry/TelemetryHelperTest.java
@@ -82,13 +82,46 @@ public class TelemetryHelperTest {
       assertDoesNotThrow(
           () ->
               TelemetryHelper.exportFailureLog(
-                  connectionContext, TEST_STRING, TEST_STRING, TelemetryLogLevel.ERROR));
+                  connectionContext,
+                  TEST_STRING,
+                  new RuntimeException(TEST_STRING),
+                  TelemetryLogLevel.ERROR));
     }
   }
 
   @Test
   void testGetDriverSystemConfigurationDoesNotThrowError() {
     assertDoesNotThrow(TelemetryHelper::getDriverSystemConfiguration);
+  }
+
+  @Test
+  void testFormatStackTraceIncludesFramesButNotMessage() {
+    // Exception messages in the driver can embed user data (SQL text, literal values); the
+    // telemetry stack_trace field must carry code locations only, never the message.
+    String sensitiveMessage = "Failed query: SELECT ssn FROM patients WHERE ssn = '123-45-6789'";
+    Throwable throwable = new RuntimeException(sensitiveMessage);
+
+    String formatted = TelemetryHelper.formatStackTrace(throwable);
+
+    assertNotNull(formatted);
+    // Frames are present: this test method's frame is at the top of the captured trace.
+    assertTrue(
+        formatted.contains("TelemetryHelperTest"),
+        "stack_trace should contain code-location frames");
+    assertTrue(
+        formatted.contains("testFormatStackTraceIncludesFramesButNotMessage"),
+        "stack_trace should include the frame where the throwable was created");
+    // The message (and any PII in it) must never appear.
+    assertFalse(
+        formatted.contains(sensitiveMessage),
+        "stack_trace must not contain the exception message");
+    assertFalse(
+        formatted.contains("123-45-6789"), "stack_trace must not contain PII from the message");
+  }
+
+  @Test
+  void testFormatStackTraceWithNullReturnsNull() {
+    assertNull(TelemetryHelper.formatStackTrace(null));
   }
 
   @ParameterizedTest
@@ -199,7 +232,9 @@ public class TelemetryHelperTest {
     DatabricksThreadContextHolder.clearConnectionContext();
     DatabricksThreadContextHolder.clearStatementInfo();
     assertDoesNotThrow(
-        () -> TelemetryHelper.exportFailureLog(null, "err", "msg", TelemetryLogLevel.ERROR));
+        () ->
+            TelemetryHelper.exportFailureLog(
+                null, "err", new RuntimeException("msg"), TelemetryLogLevel.ERROR));
   }
 
   @Test


### PR DESCRIPTION
## Description

The telemetry `stack_trace` error field was populated with the exception **message** (`reason`), which despite the field name is not a stack trace at all. Exception messages in the driver routinely embed user data — SQL text, hostnames, literal filter values — so error telemetry could leak PII.

This change populates the field with the exception's **actual stack frames** (`class.method(File:line)`) via a new `TelemetryHelper.formatStackTrace(Throwable)`, which are PII-free by construction. `exportFailureLog` now takes the `Throwable`, and each driver exception passes `this` so the captured throw-site frames are recorded. Frames are capped at 100. `error_name`/`sqlState` and all error codes are unchanged.

Affected exceptions: `DatabricksSQLException`, `DatabricksDriverException`, `DatabricksTimeoutException`, `DatabricksTransactionException`, `DatabricksBatchUpdateException`.

## Testing

- Added `TelemetryHelperTest#testFormatStackTraceIncludesFramesButNotMessage`, which asserts the formatted field contains code-location frames and never contains the exception message (including a sample PII string).
- Added `testFormatStackTraceWithNullReturnsNull`.
- Updated existing `exportFailureLog` test call sites to pass a `Throwable`.

> Note: I was unable to run `mvn test` locally (no Maven in the dev environment); please rely on CI to run the suite.

## Telemetry Errors
- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses `DatabricksDriverErrorCode` where appropriate, and any
      new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is
      requested because the author cannot access the classification.

## Additional Notes to the Reviewer

No error names or numeric codes are added or changed — only the **content** of the existing `stack_trace` field changes (real frames instead of the message string). No telemetry taxonomy/dashboard classification update is required. Any downstream consumer that parsed the message text out of `stack_trace` should be aware it now contains stack frames.

Tradeoff: the human-readable exception message is no longer present in telemetry; `error_name` + `sqlState` + the stack frames carry the debugging signal.

NO_CHANGELOG=true
