### PR TITLE
fix(metadata): order getTypeInfo rows by DATA_TYPE

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 - Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions to address security findings.
 
 ### Fixed
+- Fixed `DatabaseMetaData.getTypeInfo()` returning the `INTERVAL` row out of `DATA_TYPE` order.
+
 - Fixed later logging-enabled connections being unable to produce logs when an earlier connection
   used `LogLevel=OFF`. The first enabled connection now establishes the shared JUL handler, while a
   later `OFF` connection does not disable it.

--- a/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
+++ b/src/main/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilder.java
@@ -345,6 +345,26 @@ public class MetadataResultSetBuilder {
           null
         },
         {
+          "INTERVAL",
+          Types.VARCHAR,
+          40,
+          "'",
+          "'",
+          "Qualifier",
+          typeNullable,
+          false,
+          typeSearchable,
+          null,
+          false,
+          null,
+          "INTERVAL",
+          0,
+          6,
+          Types.VARCHAR,
+          null,
+          null
+        },
+        {
           "BOOLEAN",
           Types.BOOLEAN,
           1,
@@ -422,26 +442,6 @@ public class MetadataResultSetBuilder {
           0,
           Types.TIMESTAMP,
           3,
-          null
-        },
-        {
-          "INTERVAL",
-          Types.VARCHAR,
-          40,
-          "'",
-          "'",
-          "Qualifier",
-          typeNullable,
-          false,
-          typeSearchable,
-          null,
-          false,
-          null,
-          "INTERVAL",
-          0,
-          6,
-          Types.VARCHAR,
-          null,
           null
         }
       };

--- a/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
+++ b/src/test/java/com/databricks/jdbc/dbclient/impl/common/MetadataResultSetBuilderTest.java
@@ -45,6 +45,24 @@ public class MetadataResultSetBuilderTest {
   }
 
   @Test
+  void testTypeInfoRowsAreOrderedByDataType() throws SQLException {
+    List<Integer> actualDataTypes = new ArrayList<>();
+    try (DatabricksResultSet resultSet = metadataResultSetBuilder.getTypeInfoResult()) {
+      while (resultSet.next()) {
+        actualDataTypes.add(resultSet.getInt("DATA_TYPE"));
+      }
+    }
+
+    assertFalse(actualDataTypes.isEmpty(), "TYPE_INFO should contain at least one row");
+    List<Integer> sortedDataTypes = new ArrayList<>(actualDataTypes);
+    sortedDataTypes.sort(Integer::compareTo);
+    assertEquals(
+        sortedDataTypes,
+        actualDataTypes,
+        "TYPE_INFO rows should be ordered by DATA_TYPE as required by DatabaseMetaData");
+  }
+
+  @Test
   void testThriftNativeFormattingMatchesRawThriftBuilder() throws SQLException {
     assertNativeFormattingMatchesThrift(
         resultSet -> metadataResultSetBuilder.getFunctionsResult(resultSet, "catalog"),


### PR DESCRIPTION
## Description

- Reorder the static `DatabaseMetaData.getTypeInfo()` catalogue so the `INTERVAL` row is emitted with the other `Types.VARCHAR` rows, before `BOOLEAN`, `DATE`, and `TIMESTAMP`.
- Add regression coverage requiring returned `DATA_TYPE` values to be nondecreasing.
- Document the user-visible metadata fix in `NEXT_CHANGELOG.md`.

The catalogue is shared by the Thrift and SEA metadata clients, so this fixes both backends without changing any row contents or type mappings. This also allows databricks-driver-test#1413 to replace its known-failure tripwire with the strict JDBC ordering assertion.

Fixes #1661.

## Testing

- Focused metadata suites: 391 tests passed, 0 failed (`MetadataResultSetBuilderTest` and `DatabricksDatabaseMetaDataTest`).
- Full `databricks-jdbc-core` suite: 3,640 tests passed, 0 failed, 88 skipped.
- `mvn spotless:check`: passed across the full reactor.
