### PR TITLE
Update Apache Thrift to 0.24.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 - `UseBoundedSeaApi` and `EnableThriftNativeMetadata` now default to `1`; when unset, activation is controlled by the server-side `enableSqlExecForJdbc` rollout flag.
 - `DatabaseMetaData.getColumns(...)` with a `null` catalog now issues a single `SHOW COLUMNS IN ALL CATALOGS` statement (consistent with `getSchemas`/`getTables`) instead of enumerating every catalog and issuing a per-catalog `SHOW COLUMNS`. Older DBR versions that do not support the syntax transparently fall back to the previous enumerate-and-fan-out behavior.
 - Updated bundled Jackson, lz4-java, Netty, and Apache HttpComponents Client and Core dependencies to patched versions to address security findings.
+- Updated bundled Apache Thrift to 0.24.0 to address CVE-2026-43871.
 
 ### Fixed
 - Fixed later logging-enabled connections being unable to produce logs when an earlier connection

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <async-httpclient.version>5.6.3</async-httpclient.version>
     <httpcore5.version>5.4.3</httpcore5.version>
-    <thrift.version>0.23.0</thrift.version>
+    <thrift.version>0.24.0</thrift.version>
     <slf4j.version>2.0.13</slf4j.version>
     <jackson.version>2.18.9</jackson.version>
     <gson.version>2.13.2</gson.version>


### PR DESCRIPTION
## Description

- Upgrade bundled Apache Thrift from 0.23.0 to 0.24.0.
- Address CVE-2026-43871 reported by the repository security scan.
- Document the dependency update in the next release changelog.

## Testing

- mvn package -DskipTests -Ddependency-check.skip=true
- mvn -pl jdbc-core dependency:tree -Dincludes=org.apache.thrift:libthrift -DskipTests -Ddependency-check.skip=true — resolves 0.24.0
- Broad unit-test run: 3,638 tests passed. One JDK no-open-only allocator test was selected under the generic --add-opens JVM configuration; its documented filtered invocation passes and is unrelated to Thrift.
- git diff --check

## Telemetry Errors

- [x] Not applicable — this PR does not add or change a telemetry-visible error.
- [ ] Applicable — the error uses DatabricksDriverErrorCode where appropriate, and any new code is uniquely numbered and tested.
- [ ] Applicable — its driver/server/user classification is linked, or maintainer help is requested because the author cannot access the classification.

## Additional Notes to the Reviewer

No runtime code changes are included.