### PR TITLE
Auto-recover Reyden Thrift rejection to SEA (KP001)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added `EnableThriftNativeMetadata` to request and consume supported Thrift-native SEA metadata results.
+- Real-Time (Reyden) SQL warehouses now work over the default Thrift connection with no configuration change: when the gateway rejects a Thrift `OpenSession` with SQLSTATE `KP001`, the driver transparently re-opens the session on SEA and remembers the warehouse (per host, ~6h) so later connections skip Thrift. An explicit `UseThriftClient=1` is always honored and never auto-switched.
 
 ### Updated
 - `UseBoundedSeaApi` and `EnableThriftNativeMetadata` now default to `1`; when unset, activation is controlled by the server-side `enableSqlExecForJdbc` rollout flag.

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
@@ -143,10 +143,11 @@ public class DatabricksSession implements IDatabricksSession {
       String warehouseId = getWarehouseId();
       if (warehouseId != null
           && ReydenWarehouseCache.getInstance()
-              .isReydenWarehouse(connectionContext.getHost().toLowerCase(), warehouseId)) {
+              .isReydenWarehouse(connectionContext.getHost(), warehouseId)) {
         LOGGER.debug(
             "Warehouse {} is known to be Reyden. Switching to SEA to skip Thrift rejection.",
             warehouseId);
+        warnIfOverridingThriftMetadataPreference(warehouseId);
         connectionContext.setClientType(DatabricksClientType.SEA);
       }
     }
@@ -198,7 +199,7 @@ public class DatabricksSession implements IDatabricksSession {
             String warehouseId = getWarehouseId();
             if (warehouseId != null) {
               ReydenWarehouseCache.getInstance()
-                  .markReydenWarehouse(connectionContext.getHost().toLowerCase(), warehouseId);
+                  .markReydenWarehouse(connectionContext.getHost(), warehouseId);
             }
             // Only auto-recover on the default Thrift path; an explicit use_thrift_client=1 is
             // honored. Recovery is a single SEA attempt (no loop).
@@ -207,6 +208,7 @@ public class DatabricksSession implements IDatabricksSession {
                   "Thrift OpenSession rejected with SQLSTATE KP001 (not supported for Thrift protocol). "
                       + "Attempting transparent fallback to SEA. warehouse_id={}",
                   warehouseId);
+              warnIfOverridingThriftMetadataPreference(warehouseId);
               try {
                 this.connectionContext.setClientType(DatabricksClientType.SEA);
                 this.databricksClient =
@@ -508,6 +510,31 @@ public class DatabricksSession implements IDatabricksSession {
     // If the user did NOT explicitly set USE_THRIFT_CLIENT in the URL, then it's the default path.
     // We check this by seeing if the property is present (explicitly set).
     return !connectionContext.isPropertyPresent(DatabricksJdbcUrlParams.USE_THRIFT_CLIENT);
+  }
+
+  /**
+   * Warns when Reyden recovery switches a connection that explicitly requested Thrift-only metadata
+   * behavior over to SEA. Recovering keeps the connection alive (a Reyden warehouse rejects Thrift
+   * entirely), but SEA serves metadata with {@code SHOW} commands rather than the native Thrift
+   * RPCs the user asked for. This makes that otherwise-silent change observable.
+   */
+  private void warnIfOverridingThriftMetadataPreference(String warehouseId) {
+    // These params force the Thrift client for native metadata (see getClientTypeFromContext):
+    // UseQueryForMetadata=0 (native RPCs instead of SHOW) or TreatMetadataCatalogNameAsPattern=1.
+    boolean forcedNativeMetadata =
+        connectionContext.isPropertyPresent(DatabricksJdbcUrlParams.USE_QUERY_FOR_METADATA)
+            && !connectionContext.useQueryForMetadata();
+    boolean forcedCatalogPattern =
+        connectionContext.isPropertyPresent(
+                DatabricksJdbcUrlParams.TREAT_METADATA_CATALOG_NAME_AS_PATTERN)
+            && connectionContext.treatMetadataCatalogNameAsPattern();
+    if (forcedNativeMetadata || forcedCatalogPattern) {
+      LOGGER.warn(
+          "Reyden auto-recovery is switching to SEA, overriding a Thrift-only metadata preference "
+              + "(UseQueryForMetadata=0 / TreatMetadataCatalogNameAsPattern=1). Metadata will use "
+              + "SEA SHOW commands instead of native Thrift RPCs. warehouse_id={}",
+          warehouseId);
+    }
   }
 
   /**

--- a/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
+++ b/src/main/java/com/databricks/jdbc/api/impl/DatabricksSession.java
@@ -8,8 +8,10 @@ import com.databricks.jdbc.common.CompressionCodec;
 import com.databricks.jdbc.common.DatabricksClientType;
 import com.databricks.jdbc.common.DatabricksJdbcUrlParams;
 import com.databricks.jdbc.common.IDatabricksComputeResource;
+import com.databricks.jdbc.common.ReydenWarehouseCache;
 import com.databricks.jdbc.common.SeaCircuitBreakerManager;
 import com.databricks.jdbc.common.StatementType;
+import com.databricks.jdbc.common.Warehouse;
 import com.databricks.jdbc.dbclient.IDatabricksClient;
 import com.databricks.jdbc.dbclient.IDatabricksMetadataClient;
 import com.databricks.jdbc.dbclient.impl.sqlexec.DatabricksEmptyMetadataClient;
@@ -134,6 +136,21 @@ public class DatabricksSession implements IDatabricksSession {
   public void open() throws SQLException {
     LOGGER.debug("public void open()");
 
+    // Reyden pre-check: if warehouse is known to be Reyden and we're about to use Thrift,
+    // switch to SEA to avoid the rejection error. Only for the default Thrift path -- an
+    // explicit use_thrift_client=1 is honored and never auto-switched.
+    if (connectionContext.getClientType() == DatabricksClientType.THRIFT && isDefaultThriftPath()) {
+      String warehouseId = getWarehouseId();
+      if (warehouseId != null
+          && ReydenWarehouseCache.getInstance()
+              .isReydenWarehouse(connectionContext.getHost().toLowerCase(), warehouseId)) {
+        LOGGER.debug(
+            "Warehouse {} is known to be Reyden. Switching to SEA to skip Thrift rejection.",
+            warehouseId);
+        connectionContext.setClientType(DatabricksClientType.SEA);
+      }
+    }
+
     // Skip for tests, it would be already set
     if (databricksClient == null) {
       if (connectionContext.getClientType() == DatabricksClientType.THRIFT) {
@@ -175,45 +192,93 @@ public class DatabricksSession implements IDatabricksSession {
           this.sessionInfo =
               this.databricksClient.createSession(
                   this.computeResource, this.catalog, this.schema, this.sessionConfigs);
-        } catch (DatabricksRateLimitException e) {
-          // Handle 429 rate limit error during SEA session creation
-          // Only handle if using SEA client (not applicable to Thrift)
-          if (connectionContext.getClientType() == DatabricksClientType.SEA) {
-            LOGGER.warn(
-                "SEA session creation failed with HTTP {} (rate limit exceeded) after retries. "
-                    + "Recording failure and falling back to Thrift client for this connection. "
-                    + "Future connections will use Thrift for the next 24 hours.",
-                SeaCircuitBreakerManager.HTTP_TOO_MANY_REQUESTS);
-            // Record the failure to open circuit breaker for future connections
-            SeaCircuitBreakerManager.record429Failure();
-            // Fall back to Thrift for this connection
-            this.connectionContext.setClientType(DatabricksClientType.THRIFT);
-            this.databricksClient =
-                DatabricksMetricsTimedProcessor.createProxy(
-                    new DatabricksThriftServiceClient(connectionContext));
-            if (connectionContext.useQueryForMetadata()) {
-              this.databricksMetadataClient =
-                  DatabricksMetricsTimedProcessor.createProxy(
-                      new DatabricksMetadataQueryClient(databricksClient));
-            } else {
-              this.databricksMetadataClient = null;
+        } catch (DatabricksSQLException e) {
+          // Reyden Thrift auto-recovery: detect KP001 SQLSTATE on Thrift OpenSession rejection
+          if (isReydenThriftRejection(e)) {
+            String warehouseId = getWarehouseId();
+            if (warehouseId != null) {
+              ReydenWarehouseCache.getInstance()
+                  .markReydenWarehouse(connectionContext.getHost().toLowerCase(), warehouseId);
             }
-            try {
-              this.sessionInfo =
-                  this.databricksClient.createSession(
-                      this.computeResource, this.catalog, this.schema, this.sessionConfigs);
-            } catch (DatabricksSQLException fallbackException) {
-              throw new DatabricksSQLException(
-                  String.format(
-                      "SEA session creation failed with HTTP %d rate limit, "
-                          + "and Thrift fallback also failed: %s",
-                      SeaCircuitBreakerManager.HTTP_TOO_MANY_REQUESTS,
-                      fallbackException.getMessage()),
-                  fallbackException,
-                  DatabricksDriverErrorCode.CONNECTION_ERROR);
+            // Only auto-recover on the default Thrift path; an explicit use_thrift_client=1 is
+            // honored. Recovery is a single SEA attempt (no loop).
+            if (isDefaultThriftPath()) {
+              LOGGER.info(
+                  "Thrift OpenSession rejected with SQLSTATE KP001 (not supported for Thrift protocol). "
+                      + "Attempting transparent fallback to SEA. warehouse_id={}",
+                  warehouseId);
+              try {
+                this.connectionContext.setClientType(DatabricksClientType.SEA);
+                this.databricksClient =
+                    DatabricksMetricsTimedProcessor.createProxy(
+                        new DatabricksSdkClient(connectionContext));
+                this.databricksMetadataClient =
+                    DatabricksMetricsTimedProcessor.createProxy(
+                        new DatabricksMetadataQueryClient(databricksClient));
+                this.sessionInfo =
+                    this.databricksClient.createSession(
+                        this.computeResource, this.catalog, this.schema, this.sessionConfigs);
+              } catch (DatabricksSQLException seaException) {
+                // Double-failure: surface the SEA failure as the cause and keep the original
+                // Thrift KP001 as a suppressed exception so neither error chain is lost.
+                DatabricksSQLException combined =
+                    new DatabricksSQLException(
+                        String.format(
+                            "Thrift OpenSession rejected with SQLSTATE KP001, "
+                                + "and SEA fallback also failed: %s",
+                            seaException.getMessage()),
+                        seaException,
+                        DatabricksDriverErrorCode.CONNECTION_ERROR);
+                combined.addSuppressed(e);
+                throw combined;
+              }
+            } else {
+              // User explicitly set use_thrift_client=1, honor it even on KP001
+              throw e;
+            }
+          } else if (e instanceof DatabricksRateLimitException) {
+            // Handle 429 rate limit error during SEA session creation
+            // Only handle if using SEA client (not applicable to Thrift)
+            if (connectionContext.getClientType() == DatabricksClientType.SEA) {
+              LOGGER.warn(
+                  "SEA session creation failed with HTTP {} (rate limit exceeded) after retries. "
+                      + "Recording failure and falling back to Thrift client for this connection. "
+                      + "Future connections will use Thrift for the next 24 hours.",
+                  SeaCircuitBreakerManager.HTTP_TOO_MANY_REQUESTS);
+              // Record the failure to open circuit breaker for future connections
+              SeaCircuitBreakerManager.record429Failure();
+              // Fall back to Thrift for this connection
+              this.connectionContext.setClientType(DatabricksClientType.THRIFT);
+              this.databricksClient =
+                  DatabricksMetricsTimedProcessor.createProxy(
+                      new DatabricksThriftServiceClient(connectionContext));
+              if (connectionContext.useQueryForMetadata()) {
+                this.databricksMetadataClient =
+                    DatabricksMetricsTimedProcessor.createProxy(
+                        new DatabricksMetadataQueryClient(databricksClient));
+              } else {
+                this.databricksMetadataClient = null;
+              }
+              try {
+                this.sessionInfo =
+                    this.databricksClient.createSession(
+                        this.computeResource, this.catalog, this.schema, this.sessionConfigs);
+              } catch (DatabricksSQLException fallbackException) {
+                throw new DatabricksSQLException(
+                    String.format(
+                        "SEA session creation failed with HTTP %d rate limit, "
+                            + "and Thrift fallback also failed: %s",
+                        SeaCircuitBreakerManager.HTTP_TOO_MANY_REQUESTS,
+                        fallbackException.getMessage()),
+                    fallbackException,
+                    DatabricksDriverErrorCode.CONNECTION_ERROR);
+              }
+            } else {
+              // Re-throw if not from SEA client (shouldn't happen, but defensive)
+              throw e;
             }
           } else {
-            // Re-throw if not from SEA client (shouldn't happen, but defensive)
+            // Re-throw other DatabricksSQLException variants
             throw e;
           }
         }
@@ -420,5 +485,40 @@ public class DatabricksSession implements IDatabricksSession {
   public boolean getAutoCommit() {
     LOGGER.debug("public boolean getAutoCommit()");
     return this.autoCommit;
+  }
+
+  /**
+   * Returns true if the exception is a Reyden Thrift rejection (SQLSTATE "KP001").
+   *
+   * @param e the exception to check
+   * @return true if the exception is specifically a KP001 error
+   */
+  private static boolean isReydenThriftRejection(DatabricksSQLException e) {
+    String sqlState = e.getSQLState();
+    return "KP001".equals(sqlState);
+  }
+
+  /**
+   * Returns true if the user did NOT explicitly set use_thrift_client to force Thrift.
+   *
+   * <p>This allows recovery to proceed for the DEFAULT path, while honoring explicit user
+   * configuration.
+   */
+  private boolean isDefaultThriftPath() {
+    // If the user did NOT explicitly set USE_THRIFT_CLIENT in the URL, then it's the default path.
+    // We check this by seeing if the property is present (explicitly set).
+    return !connectionContext.isPropertyPresent(DatabricksJdbcUrlParams.USE_THRIFT_CLIENT);
+  }
+
+  /**
+   * Extracts the warehouse ID from the compute resource, if available.
+   *
+   * @return the warehouse ID, or null if the resource is not a warehouse
+   */
+  private String getWarehouseId() {
+    if (computeResource instanceof Warehouse) {
+      return ((Warehouse) computeResource).getWarehouseId();
+    }
+    return null;
   }
 }

--- a/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
+++ b/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
@@ -12,7 +12,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * SEA directly, avoiding the rejection error.
  *
  * <p>Cache entries expire after ~6 hours to allow warehouses to be de-registered or reconfigured.
- * The cache key is (host_lowercased, warehouse_id) for multi-tenant safety.
+ * The cache key is (host, warehouse_id) for multi-tenant safety; the host is normalized
+ * case-insensitively in {@link #buildKey}, so callers need not lowercase it.
  */
 public final class ReydenWarehouseCache {
 
@@ -47,11 +48,11 @@ public final class ReydenWarehouseCache {
    * Returns true if the warehouse (host, warehouse_id) pair is known to be Reyden. Removes expired
    * entries opportunistically.
    */
-  public boolean isReydenWarehouse(String hostLowercased, String warehouseId) {
-    if (hostLowercased == null || warehouseId == null) {
+  public boolean isReydenWarehouse(String host, String warehouseId) {
+    if (host == null || warehouseId == null) {
       return false;
     }
-    String key = buildKey(hostLowercased, warehouseId);
+    String key = buildKey(host, warehouseId);
     CacheEntry entry = cache.get(key);
     if (entry == null) {
       return false;
@@ -64,17 +65,17 @@ public final class ReydenWarehouseCache {
   }
 
   /** Marks the warehouse (host, warehouse_id) pair as Reyden. */
-  public void markReydenWarehouse(String hostLowercased, String warehouseId) {
-    if (hostLowercased == null || warehouseId == null) {
+  public void markReydenWarehouse(String host, String warehouseId) {
+    if (host == null || warehouseId == null) {
       return;
     }
-    String key = buildKey(hostLowercased, warehouseId);
+    String key = buildKey(host, warehouseId);
     cache.put(key, new CacheEntry());
     evictExpiredEntries(); // opportunistic sweep on write, when the map may grow
     LOGGER.debug(
         "Marked warehouse as Reyden (host={}, warehouse_id={}). "
             + "Future connections will use SEA directly.",
-        hostLowercased,
+        host,
         warehouseId);
   }
 
@@ -94,7 +95,8 @@ public final class ReydenWarehouseCache {
         });
   }
 
-  private static String buildKey(String hostLowercased, String warehouseId) {
-    return hostLowercased.toLowerCase() + "|" + warehouseId;
+  private static String buildKey(String host, String warehouseId) {
+    // Normalize the host here so case-insensitivity holds regardless of what the caller passes.
+    return host.toLowerCase() + "|" + warehouseId;
   }
 }

--- a/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
+++ b/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
@@ -1,0 +1,100 @@
+package com.databricks.jdbc.common;
+
+import com.databricks.jdbc.log.JdbcLogger;
+import com.databricks.jdbc.log.JdbcLoggerFactory;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe, process-wide cache of warehouses known to be Real-Time SQL (Reyden) warehouses.
+ *
+ * <p>When a Thrift OpenSession fails with SQLSTATE "KP001" (not supported for Thrift protocol), the
+ * warehouse is marked as Reyden and future connections to the same warehouse skip Thrift and use
+ * SEA directly, avoiding the rejection error.
+ *
+ * <p>Cache entries expire after ~6 hours to allow warehouses to be de-registered or reconfigured.
+ * The cache key is (host_lowercased, warehouse_id) for multi-tenant safety.
+ */
+public final class ReydenWarehouseCache {
+
+  private static final JdbcLogger LOGGER = JdbcLoggerFactory.getLogger(ReydenWarehouseCache.class);
+
+  /** Approximate TTL in milliseconds: 6 hours */
+  private static final long ENTRY_TTL_MILLIS = 6 * 60 * 60 * 1000L;
+
+  private static final ReydenWarehouseCache INSTANCE = new ReydenWarehouseCache();
+
+  private static class CacheEntry {
+    final long timestamp;
+
+    CacheEntry() {
+      this.timestamp = System.currentTimeMillis();
+    }
+
+    boolean isExpired() {
+      return System.currentTimeMillis() - timestamp > ENTRY_TTL_MILLIS;
+    }
+  }
+
+  private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+  private ReydenWarehouseCache() {}
+
+  public static ReydenWarehouseCache getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Returns true if the warehouse (host, warehouse_id) pair is known to be Reyden. Removes expired
+   * entries opportunistically.
+   */
+  public boolean isReydenWarehouse(String hostLowercased, String warehouseId) {
+    if (hostLowercased == null || warehouseId == null) {
+      return false;
+    }
+    String key = buildKey(hostLowercased, warehouseId);
+    CacheEntry entry = cache.get(key);
+    if (entry == null) {
+      return false;
+    }
+    if (entry.isExpired()) {
+      cache.remove(key, entry); // remove if expired
+      return false;
+    }
+    return true;
+  }
+
+  /** Marks the warehouse (host, warehouse_id) pair as Reyden. */
+  public void markReydenWarehouse(String hostLowercased, String warehouseId) {
+    if (hostLowercased == null || warehouseId == null) {
+      return;
+    }
+    String key = buildKey(hostLowercased, warehouseId);
+    cache.put(key, new CacheEntry());
+    evictExpiredEntries(); // opportunistic sweep on write, when the map may grow
+    LOGGER.debug(
+        "Marked warehouse as Reyden (host={}, warehouse_id={}). "
+            + "Future connections will use SEA directly.",
+        hostLowercased,
+        warehouseId);
+  }
+
+  /** Removes all entries. Intended for test isolation of the process-wide singleton. */
+  public void clearCache() {
+    cache.clear();
+  }
+
+  /** Opportunistically evicts expired entries. Invoked on writes, when the map may grow. */
+  void evictExpiredEntries() {
+    cache.forEachEntry(
+        Long.MAX_VALUE,
+        entry -> {
+          if (entry.getValue().isExpired()) {
+            cache.remove(entry.getKey(), entry.getValue());
+          }
+        });
+  }
+
+  private static String buildKey(String hostLowercased, String warehouseId) {
+    return hostLowercased.toLowerCase() + "|" + warehouseId;
+  }
+}

--- a/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
+++ b/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
@@ -4,6 +4,7 @@ import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 /**
  * Thread-safe, process-wide cache of warehouses known to be Real-Time SQL (Reyden) warehouses.
@@ -25,21 +26,35 @@ public final class ReydenWarehouseCache {
 
   private static final ReydenWarehouseCache INSTANCE = new ReydenWarehouseCache();
 
-  private static class CacheEntry {
+  // Non-static so it reads the enclosing cache's clock/TTL, which the test
+  // constructor can override to exercise the expiry and eviction paths.
+  private class CacheEntry {
     final long timestamp;
 
     CacheEntry() {
-      this.timestamp = System.currentTimeMillis();
+      this.timestamp = clock.getAsLong();
     }
 
     boolean isExpired() {
-      return System.currentTimeMillis() - timestamp > ENTRY_TTL_MILLIS;
+      return clock.getAsLong() - timestamp > ttlMillis;
     }
   }
 
   private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
 
-  private ReydenWarehouseCache() {}
+  // Time source and TTL are injectable so tests can drive expiry deterministically
+  // without sleeping; production uses the wall clock and the 6h TTL.
+  private final LongSupplier clock;
+  private final long ttlMillis;
+
+  private ReydenWarehouseCache() {
+    this(System::currentTimeMillis, ENTRY_TTL_MILLIS);
+  }
+
+  ReydenWarehouseCache(LongSupplier clock, long ttlMillis) {
+    this.clock = clock;
+    this.ttlMillis = ttlMillis;
+  }
 
   public static ReydenWarehouseCache getInstance() {
     return INSTANCE;
@@ -83,6 +98,11 @@ public final class ReydenWarehouseCache {
   /** Removes all entries. Intended for test isolation of the process-wide singleton. */
   public void clearCache() {
     cache.clear();
+  }
+
+  /** Current number of cached entries. Intended for test observability. */
+  int size() {
+    return cache.size();
   }
 
   /** Opportunistically evicts expired entries. Invoked on writes, when the map may grow. */

--- a/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
+++ b/src/main/java/com/databricks/jdbc/common/ReydenWarehouseCache.java
@@ -2,6 +2,7 @@ package com.databricks.jdbc.common;
 
 import com.databricks.jdbc.log.JdbcLogger;
 import com.databricks.jdbc.log.JdbcLoggerFactory;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -97,6 +98,7 @@ public final class ReydenWarehouseCache {
 
   private static String buildKey(String host, String warehouseId) {
     // Normalize the host here so case-insensitivity holds regardless of what the caller passes.
-    return host.toLowerCase() + "|" + warehouseId;
+    // Locale.ROOT avoids locale-sensitive folding (e.g. the Turkish dotless-i).
+    return host.toLowerCase(Locale.ROOT) + "|" + warehouseId;
   }
 }

--- a/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
@@ -207,6 +207,53 @@ public class ReydenThriftAutoRecoveryTest {
   }
 
   /**
+   * Test: a Thrift-forcing metadata param (UseQueryForMetadata=0) still counts as the default path
+   * (UseThriftClient unset), so a KP001 recovers to SEA. Exercises the metadata-override warn.
+   */
+  @Test
+  public void testReydenRecovery_WithThriftMetadataParam_StillRecovers() throws SQLException {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(
+            WAREHOUSE_URL_THRIFT + ";UseQueryForMetadata=0", new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    ImmutableSessionInfo successSessionInfo =
+        ImmutableSessionInfo.builder()
+            .sessionId(SESSION_ID)
+            .computeResource(WAREHOUSE_COMPUTE)
+            .build();
+
+    DatabricksSQLException kp001Error =
+        new DatabricksSQLException(
+            "Lakehouse/RT is not supported for Thrift protocol",
+            "KP001",
+            DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(thriftClient.createSession(any(), any(), any(), any())).thenThrow(kp001Error);
+    when(sdkClient.createSession(eq(WAREHOUSE_COMPUTE), any(), any(), any()))
+        .thenReturn(successSessionInfo);
+
+    try (MockedStatic<DatabricksMetricsTimedProcessor> proxyMock =
+        Mockito.mockStatic(DatabricksMetricsTimedProcessor.class)) {
+      // Swap only the SEA client for the mock; pass other proxied objects through unchanged.
+      proxyMock
+          .when(() -> DatabricksMetricsTimedProcessor.createProxy(any()))
+          .thenAnswer(
+              invocation -> {
+                Object arg = invocation.getArgument(0);
+                return (arg instanceof DatabricksSdkClient) ? sdkClient : arg;
+              });
+
+      DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+      assertDoesNotThrow(session::open);
+
+      // Recovery proceeds despite the metadata-forcing param (it is not a protocol choice).
+      assertTrue(session.isOpen());
+      assertEquals(DatabricksClientType.SEA, connectionContext.getClientType());
+    }
+  }
+
+  /**
    * Test: Explicit UseThriftClient=1 is honored — no fallback on KP001.
    *
    * <p>Real method called: DatabricksSession.open() is called. If UseThriftClient=1 is explicit,

--- a/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
@@ -1,0 +1,358 @@
+package com.databricks.jdbc.api.impl;
+
+import static com.databricks.jdbc.TestConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.databricks.jdbc.api.internal.IDatabricksConnectionContext;
+import com.databricks.jdbc.common.DatabricksClientType;
+import com.databricks.jdbc.common.ReydenWarehouseCache;
+import com.databricks.jdbc.common.safe.DatabricksDriverFeatureFlagsContextFactory;
+import com.databricks.jdbc.dbclient.impl.sqlexec.DatabricksSdkClient;
+import com.databricks.jdbc.dbclient.impl.thrift.DatabricksThriftServiceClient;
+import com.databricks.jdbc.exception.DatabricksSQLException;
+import com.databricks.jdbc.model.telemetry.enums.DatabricksDriverErrorCode;
+import com.databricks.jdbc.telemetry.latency.DatabricksMetricsTimedProcessor;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for Reyden Thrift auto-recovery feature.
+ *
+ * <p>When a driver connects over Thrift to a Reyden (Real-Time SQL) warehouse, the SQL Gateway
+ * proxy rejects the OpenSession with SQLSTATE "KP001". Instead of surfacing that as a fatal error,
+ * the driver should transparently re-open the session on its own SEA (Statement Execution API)
+ * path.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ReydenThriftAutoRecoveryTest {
+  private static final String SESSION_ID = "session_id";
+  private static final String WAREHOUSE_ID = "warehouse_id";
+  private static final String HOST = "sample-host.18.azuredatabricks.net";
+
+  private static final String WAREHOUSE_URL_THRIFT =
+      "jdbc:databricks://"
+          + HOST
+          + ":9999/default;transportMode=http;ssl=1;"
+          + "AuthMech=3;httpPath=/sql/1.0/warehouses/"
+          + WAREHOUSE_ID;
+
+  private static final String WAREHOUSE_URL_THRIFT_FORCED =
+      WAREHOUSE_URL_THRIFT + ";UseThriftClient=1";
+
+  @Mock private DatabricksSdkClient sdkClient;
+  @Mock private DatabricksThriftServiceClient thriftClient;
+
+  @BeforeEach
+  public void setup() {
+    // Clear the process-wide warehouse cache so tests do not leak state into each other.
+    ReydenWarehouseCache.getInstance().clearCache();
+  }
+
+  /**
+   * Test: KP001 detection -> marker -> fallback to SEA succeeds.
+   *
+   * <p>Real method called: DatabricksSession.open() calls databricksClient.createSession() which
+   * throws DatabricksSQLException with SQLSTATE KP001. Stubs: Thrift client throws KP001, SEA
+   * client returns success.
+   */
+  @Test
+  public void testReydenKP001Detection_FallbackSucceeds() throws SQLException {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    ImmutableSessionInfo successSessionInfo =
+        ImmutableSessionInfo.builder()
+            .sessionId(SESSION_ID)
+            .computeResource(WAREHOUSE_COMPUTE)
+            .build();
+
+    // Thrift OpenSession fails with KP001
+    DatabricksSQLException kp001Error =
+        new DatabricksSQLException(
+            "Lakehouse/RT is not supported for Thrift protocol",
+            "KP001",
+            DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(thriftClient.createSession(any(), any(), any(), any())).thenThrow(kp001Error);
+
+    // SEA succeeds
+    when(sdkClient.createSession(eq(WAREHOUSE_COMPUTE), any(), any(), any()))
+        .thenReturn(successSessionInfo);
+
+    try (MockedStatic<DatabricksMetricsTimedProcessor> proxyMock =
+        Mockito.mockStatic(DatabricksMetricsTimedProcessor.class)) {
+      proxyMock
+          .when(() -> DatabricksMetricsTimedProcessor.createProxy(any()))
+          .thenAnswer(
+              invocation -> {
+                Object arg = invocation.getArgument(0);
+                if (arg instanceof DatabricksSdkClient) {
+                  return sdkClient;
+                }
+                return thriftClient;
+              });
+
+      DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+
+      // Should not throw — recovery succeeds
+      assertDoesNotThrow(session::open);
+
+      // Verify session opened successfully on SEA
+      assertTrue(session.isOpen());
+      assertEquals(SESSION_ID, session.getSessionId());
+      assertEquals(DatabricksClientType.SEA, connectionContext.getClientType());
+
+      // Verify warehouse is marked in cache
+      assertTrue(
+          ReydenWarehouseCache.getInstance().isReydenWarehouse(HOST.toLowerCase(), WAREHOUSE_ID));
+    }
+  }
+
+  /**
+   * Test: Pre-check uses cache to skip Thrift for known-Reyden warehouse.
+   *
+   * <p>Real method called: DatabricksSession.open() checks cache and skips Thrift client creation
+   * if warehouse is already in cache. Stubs: Cache says warehouse is Reyden, SEA client returns
+   * success.
+   */
+  @Test
+  public void testReydenPreCheck_SkipsThrift() throws SQLException {
+    // Pre-populate cache
+    ReydenWarehouseCache.getInstance().markReydenWarehouse(HOST.toLowerCase(), WAREHOUSE_ID);
+
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    ImmutableSessionInfo successSessionInfo =
+        ImmutableSessionInfo.builder()
+            .sessionId(SESSION_ID)
+            .computeResource(WAREHOUSE_COMPUTE)
+            .build();
+
+    // SEA succeeds
+    when(sdkClient.createSession(eq(WAREHOUSE_COMPUTE), any(), any(), any()))
+        .thenReturn(successSessionInfo);
+
+    try (MockedStatic<DatabricksMetricsTimedProcessor> proxyMock =
+        Mockito.mockStatic(DatabricksMetricsTimedProcessor.class)) {
+      // Swap only the SEA client for the mock; pass the metadata query client through unchanged
+      // so it keeps its IDatabricksMetadataClient type.
+      proxyMock
+          .when(() -> DatabricksMetricsTimedProcessor.createProxy(any()))
+          .thenAnswer(
+              invocation -> {
+                Object arg = invocation.getArgument(0);
+                return (arg instanceof DatabricksSdkClient) ? sdkClient : arg;
+              });
+
+      DatabricksSession session = new DatabricksSession(connectionContext);
+      // Before open() the client type is still the default THRIFT; the pre-check runs in open().
+      assertEquals(DatabricksClientType.THRIFT, connectionContext.getClientType());
+
+      session.open();
+
+      // The pre-check switched to SEA (Thrift OpenSession was never attempted) and the session
+      // opened directly on SEA.
+      assertEquals(DatabricksClientType.SEA, connectionContext.getClientType());
+      assertTrue(session.isOpen());
+      assertEquals(SESSION_ID, session.getSessionId());
+    }
+  }
+
+  /**
+   * Test: the pre-check honors an explicit UseThriftClient=1 and does NOT switch to SEA, even when
+   * the warehouse is already known to be Reyden in the cache.
+   *
+   * <p>Real method called: DatabricksSession.open() with the warehouse pre-marked Reyden. Stubs:
+   * Thrift client returns success.
+   */
+  @Test
+  public void testReydenPreCheck_ExplicitThriftNotSwitched() throws SQLException {
+    // Warehouse is known Reyden, but the user explicitly forced Thrift.
+    ReydenWarehouseCache.getInstance().markReydenWarehouse(HOST.toLowerCase(), WAREHOUSE_ID);
+
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT_FORCED, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    ImmutableSessionInfo successSessionInfo =
+        ImmutableSessionInfo.builder()
+            .sessionId(SESSION_ID)
+            .computeResource(WAREHOUSE_COMPUTE)
+            .build();
+    when(thriftClient.createSession(eq(WAREHOUSE_COMPUTE), any(), any(), any()))
+        .thenReturn(successSessionInfo);
+
+    DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+    session.open();
+
+    // The pre-check must NOT have switched to SEA -- explicit Thrift is honored.
+    assertEquals(DatabricksClientType.THRIFT, connectionContext.getClientType());
+    assertTrue(session.isOpen());
+  }
+
+  /**
+   * Test: Explicit UseThriftClient=1 is honored — no fallback on KP001.
+   *
+   * <p>Real method called: DatabricksSession.open() is called. If UseThriftClient=1 is explicit,
+   * recovery does NOT happen even on KP001. Stubs: Thrift client throws KP001.
+   */
+  @Test
+  public void testReydenExplicitThriftForced_NoFallback() throws SQLException {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT_FORCED, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    // Thrift OpenSession fails with KP001
+    DatabricksSQLException kp001Error =
+        new DatabricksSQLException(
+            "Lakehouse/RT is not supported for Thrift protocol",
+            "KP001",
+            DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(thriftClient.createSession(any(), any(), any(), any())).thenThrow(kp001Error);
+
+    DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+
+    // Should throw KP001 because user explicitly forced Thrift
+    DatabricksSQLException thrown = assertThrows(DatabricksSQLException.class, session::open);
+    assertEquals("KP001", thrown.getSQLState());
+    assertFalse(session.isOpen());
+  }
+
+  /**
+   * Test: Double-failure preserves both errors in chain.
+   *
+   * <p>Real method called: DatabricksSession.open() fails on Thrift with KP001, attempts SEA
+   * recovery, SEA also fails. Both errors should be chained. Stubs: Both Thrift and SEA throw
+   * errors.
+   */
+  @Test
+  public void testReydenDoubleFailure_PreservesBothErrors() throws SQLException {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    // Thrift fails with KP001
+    DatabricksSQLException kp001Error =
+        new DatabricksSQLException(
+            "Lakehouse/RT is not supported for Thrift protocol",
+            "KP001",
+            DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(thriftClient.createSession(any(), any(), any(), any())).thenThrow(kp001Error);
+
+    // SEA also fails
+    DatabricksSQLException seaError =
+        new DatabricksSQLException(
+            "SEA connection failed", "08001", DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(sdkClient.createSession(eq(WAREHOUSE_COMPUTE), any(), any(), any())).thenThrow(seaError);
+
+    try (MockedStatic<DatabricksMetricsTimedProcessor> proxyMock =
+        Mockito.mockStatic(DatabricksMetricsTimedProcessor.class)) {
+      proxyMock
+          .when(() -> DatabricksMetricsTimedProcessor.createProxy(any()))
+          .thenAnswer(
+              invocation -> {
+                Object arg = invocation.getArgument(0);
+                if (arg instanceof DatabricksSdkClient) {
+                  return sdkClient;
+                }
+                return thriftClient;
+              });
+
+      DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+
+      // Should throw the SEA error but with KP001 in the cause chain
+      DatabricksSQLException thrown = assertThrows(DatabricksSQLException.class, session::open);
+      assertTrue(thrown.getMessage().contains("SEA fallback also failed"));
+
+      // Original KP001 should be in the suppressed or cause chain
+      assertNotNull(thrown.getCause());
+    }
+  }
+
+  /**
+   * Test: Non-KP001 errors are NOT caught by recovery logic.
+   *
+   * <p>Real method called: DatabricksSession.open() with Thrift client. Stubs: Thrift throws a
+   * different SQLSTATE error.
+   */
+  @Test
+  public void testReydenNonKP001Error_PropagatesToCaller() throws SQLException {
+    IDatabricksConnectionContext connectionContext =
+        DatabricksConnectionContext.parse(WAREHOUSE_URL_THRIFT, new Properties());
+    DatabricksDriverFeatureFlagsContextFactory.setFeatureFlagsContext(
+        connectionContext, new HashMap<>());
+
+    // Thrift fails with a different error (not KP001)
+    DatabricksSQLException otherError =
+        new DatabricksSQLException(
+            "Some other error", "42000", DatabricksDriverErrorCode.CONNECTION_ERROR);
+    when(thriftClient.createSession(any(), any(), any(), any())).thenThrow(otherError);
+
+    DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
+
+    // Should throw the original error without attempting recovery
+    DatabricksSQLException thrown = assertThrows(DatabricksSQLException.class, session::open);
+    assertEquals("42000", thrown.getSQLState());
+    assertFalse(session.isOpen());
+  }
+
+  /**
+   * Test: Host case-insensitivity in cache key.
+   *
+   * <p>Real method called: ReydenWarehouseCache.isReydenWarehouse() with different casing. Stubs:
+   * None.
+   */
+  @Test
+  public void testReydenCacheKeyNormalization_HostCaseInsensitive() {
+    ReydenWarehouseCache cache = ReydenWarehouseCache.getInstance();
+
+    // Mark with lowercase
+    cache.markReydenWarehouse(HOST.toLowerCase(), WAREHOUSE_ID);
+
+    // Check with uppercase — should still be found
+    assertTrue(cache.isReydenWarehouse(HOST.toUpperCase(), WAREHOUSE_ID));
+    assertTrue(cache.isReydenWarehouse(HOST.toLowerCase(), WAREHOUSE_ID));
+  }
+
+  /**
+   * Test: Cache key includes both host and warehouse_id.
+   *
+   * <p>Real method called: ReydenWarehouseCache with different hosts/warehouse IDs. Stubs: None.
+   */
+  @Test
+  public void testReydenCacheKey_HostAndWarehouseIsolation() {
+    ReydenWarehouseCache cache = ReydenWarehouseCache.getInstance();
+
+    String host1 = "host1.cloud.databricks.com";
+    String host2 = "host2.cloud.databricks.com";
+    String warehouse1 = "warehouse1";
+    String warehouse2 = "warehouse2";
+
+    // Mark only (host1, warehouse1)
+    cache.markReydenWarehouse(host1, warehouse1);
+
+    // Verify isolation
+    assertTrue(cache.isReydenWarehouse(host1, warehouse1));
+    assertFalse(cache.isReydenWarehouse(host2, warehouse1)); // Different host
+    assertFalse(cache.isReydenWarehouse(host1, warehouse2)); // Different warehouse_id
+    assertFalse(cache.isReydenWarehouse(host2, warehouse2)); // Both different
+  }
+}

--- a/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
+++ b/src/test/java/com/databricks/jdbc/api/impl/ReydenThriftAutoRecoveryTest.java
@@ -325,12 +325,15 @@ public class ReydenThriftAutoRecoveryTest {
 
       DatabricksSession session = new DatabricksSession(connectionContext, thriftClient);
 
-      // Should throw the SEA error but with KP001 in the cause chain
       DatabricksSQLException thrown = assertThrows(DatabricksSQLException.class, session::open);
       assertTrue(thrown.getMessage().contains("SEA fallback also failed"));
 
-      // Original KP001 should be in the suppressed or cause chain
-      assertNotNull(thrown.getCause());
+      // The SEA failure is the cause; the original Thrift KP001 is preserved as a suppressed
+      // exception so neither error chain is lost.
+      assertEquals("08001", ((DatabricksSQLException) thrown.getCause()).getSQLState());
+      Throwable[] suppressed = thrown.getSuppressed();
+      assertEquals(1, suppressed.length, "the original Thrift rejection should be suppressed");
+      assertEquals("KP001", ((DatabricksSQLException) suppressed[0]).getSQLState());
     }
   }
 

--- a/src/test/java/com/databricks/jdbc/common/ReydenWarehouseCacheTest.java
+++ b/src/test/java/com/databricks/jdbc/common/ReydenWarehouseCacheTest.java
@@ -1,0 +1,60 @@
+package com.databricks.jdbc.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the TTL/eviction behavior of {@link ReydenWarehouseCache}, using the package-private
+ * clock/TTL constructor so expiry is driven deterministically rather than by wall-clock sleeps.
+ */
+public class ReydenWarehouseCacheTest {
+  private static final String HOST = "sample-host.azuredatabricks.net";
+  private static final String WAREHOUSE_ID = "warehouse_id";
+  private static final long TTL_MILLIS = 1000L;
+
+  /** Advanceable fake clock. */
+  private static AtomicLong clockAt(long start) {
+    return new AtomicLong(start);
+  }
+
+  @Test
+  public void entryStaysUntilTtlThenIsEvictedOnAccess() {
+    AtomicLong now = clockAt(0L);
+    ReydenWarehouseCache cache = new ReydenWarehouseCache(now::get, TTL_MILLIS);
+
+    cache.markReydenWarehouse(HOST, WAREHOUSE_ID);
+    assertTrue(cache.isReydenWarehouse(HOST, WAREHOUSE_ID));
+
+    // At exactly the TTL boundary the entry is still valid (expiry uses strict >).
+    now.set(TTL_MILLIS);
+    assertTrue(cache.isReydenWarehouse(HOST, WAREHOUSE_ID));
+
+    // One tick past the TTL: expired, and evicted on access.
+    now.set(TTL_MILLIS + 1);
+    assertFalse(cache.isReydenWarehouse(HOST, WAREHOUSE_ID));
+    assertEquals(0, cache.size());
+  }
+
+  @Test
+  public void markSweepsExpiredEntries() {
+    AtomicLong now = clockAt(0L);
+    ReydenWarehouseCache cache = new ReydenWarehouseCache(now::get, TTL_MILLIS);
+
+    cache.markReydenWarehouse(HOST, "warehouse-a");
+    assertEquals(1, cache.size());
+
+    // Advance past the TTL so the first entry is expired, then mark a second warehouse.
+    // markReydenWarehouse sweeps the expired entry rather than only adding — proven by the
+    // size dropping back to 1 without warehouse-a ever being looked up (which would otherwise
+    // trigger the lazy per-entry eviction in isReydenWarehouse).
+    now.set(TTL_MILLIS + 1);
+    cache.markReydenWarehouse(HOST, "warehouse-b");
+
+    assertEquals(1, cache.size());
+    assertTrue(cache.isReydenWarehouse(HOST, "warehouse-b"));
+  }
+}


### PR DESCRIPTION
## What

Transparently auto-recover the Reyden onboarding case for JDBC: when a **default-Thrift**
connection to a Real-Time (Reyden) SQL warehouse is rejected by the gateway with SQLSTATE
`KP001` ("Lakehouse/RT is not supported for Thrift protocol"), the driver re-opens the session
on its SEA path (`DatabricksSdkClient`) and remembers the warehouse so later connections skip
Thrift — no customer configuration change. This mirrors the same feature already in the Python
(#948), Go (#479), and Node (#523) drivers; design follows ADBC databricks#670.

## Changes

- **`ReydenWarehouseCache`** (new): process-wide, thread-safe cache keyed by
  `host_lowercased|warehouse_id`, ~6h TTL, lazy eviction on read plus an opportunistic sweep on
  write.
- **`DatabricksSession.open`**:
  - **Pre-check** — on the default Thrift path, if the warehouse is already known-Reyden, open
    SEA directly and skip the Thrift round-trip.
  - **Reactive catch** — a `KP001` on the Thrift `OpenSession` marks the cache and (default path
    only) retries once on SEA. On a double failure both error chains are preserved (SEA error as
    cause, original Thrift `KP001` as a suppressed exception).
- Detection (`getSQLState() == "KP001"`) is scoped to the `OpenSession` `createSession` call
  only — there is no shared status checker that maps `KP001` elsewhere.

## Guardrail

Recovery engages only on the **default** Thrift path (`isDefaultThriftPath()` = `UseThriftClient`
unset). An explicit `UseThriftClient=1` is honored: `KP001` is surfaced to the caller, never
auto-switched to SEA.

### Known edge case (documented, not fixed here)

`isDefaultThriftPath()` gates on `UseThriftClient` alone. A user who sets a Thrift-forcing
metadata param (`UseQueryForMetadata=0` or `TreatMetadataCatalogNameAsPattern=1`) on a Reyden
warehouse will therefore be auto-recovered to SEA, silently dropping the native-Thrift-metadata
behavior. This is judged acceptable — the connection would otherwise hard-fail with `KP001`, and
a Reyden warehouse cannot serve Thrift metadata at all — but flagging it for reviewer input.

## Testing

- **Unit** (`ReydenThriftAutoRecoveryTest`, 8 tests): reactive fallback success, cache pre-check,
  explicit-Thrift guardrail (2 cases incl. cached-Reyden), double-failure error chaining,
  non-`KP001` propagation, and cache host/warehouse isolation. `DatabricksSessionTest` (21)
  passes unchanged.
- **End-to-end** against a prod Reyden warehouse:
  - Forced Thrift (`UseThriftClient=1`) returns the real `TStatus(ERROR_STATUS, sqlState:KP001)`
    and the guardrail surfaces it (no fallback).
  - Reactive path: connect #1 recovers `KP001` → SEA (10 rows, cache marked); connect #2
    pre-checks (skips Thrift), opens SEA directly (10 rows).

## Notes

- No new `DatabricksDriverErrorCode` is introduced; the double-failure exception reuses the
  existing `CONNECTION_ERROR` code, so no telemetry-taxonomy change is required.
- `NEXT_CHANGELOG.md` updated under `### Added`.

This pull request and its description were written by Isaac.
